### PR TITLE
Refactor the ImageTransform class

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -3,107 +3,96 @@
 const colornames = require('colornames');
 const url = require('url');
 
-const props = Symbol('props');
-
 module.exports = class ImageTransform {
 
 	constructor(properties) {
-		this[props] = {};
-		this.uri = properties.uri;
-		this.width = properties.width;
-		this.height = properties.height;
-		this.dpr = properties.dpr;
-		this.fit = properties.fit;
-		this.quality = properties.quality;
-		this.format = properties.format;
-		this.bgcolor = properties.bgcolor;
+		this.setUri(properties.uri);
+		this.setWidth(properties.width);
+		this.setHeight(properties.height);
+		this.setDpr(properties.dpr);
+		this.setFit(properties.fit);
+		this.setQuality(properties.quality);
+		this.setFormat(properties.format);
+		this.setBgcolor(properties.bgcolor);
 	}
 
-	get uri() {
-		return this[props].uri;
+	getUri() {
+		return this.uri;
 	}
 
-	set uri(value) {
+	setUri(value) {
 		const errorMessage = 'Image URI must be a string with a valid scheme';
-		this[props].uri = ImageTransform.sanitizeUriValue(value, errorMessage);
+		this.uri = ImageTransform.sanitizeUriValue(value, errorMessage);
 	}
 
-	get width() {
-		return this[props].width;
+	getWidth() {
+		return this.width;
 	}
 
-	set width(value) {
+	setWidth(value) {
 		const errorMessage = 'Image width must be a positive whole number';
-		this[props].width = ImageTransform.sanitizeNumericValue(value, errorMessage);
+		this.width = ImageTransform.sanitizeNumericValue(value, errorMessage);
 	}
 
-	get height() {
-		return this[props].height;
+	getHeight() {
+		return this.height;
 	}
 
-	set height(value) {
+	setHeight(value) {
 		const errorMessage = 'Image height must be a positive whole number';
-		this[props].height = ImageTransform.sanitizeNumericValue(value, errorMessage);
+		this.height = ImageTransform.sanitizeNumericValue(value, errorMessage);
 	}
 
-	get dpr() {
-		return this[props].dpr;
+	getDpr() {
+		return this.dpr;
 	}
 
-	set dpr(value) {
+	setDpr(value) {
 		const errorMessage = 'Image DPR must be a positive whole number';
-		this[props].dpr = ImageTransform.sanitizeNumericValue(value, errorMessage);
+		this.dpr = ImageTransform.sanitizeNumericValue(value, errorMessage);
 	}
 
-	get fit() {
-		return this[props].fit;
+	getFit() {
+		return this.fit;
 	}
 
-	set fit(value = 'cover') {
+	setFit(value = 'cover') {
 		const errorMessage = `Image fit must be one of ${ImageTransform.validFits.join(', ')}`;
-		this[props].fit = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validFits, errorMessage);
+		this.fit = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validFits, errorMessage);
 	}
 
-	get format() {
-		return this[props].format;
+	getFormat() {
+		return this.format;
 	}
 
-	set format(value = 'auto') {
+	setFormat(value = 'auto') {
 		const errorMessage = `Image format must be one of ${ImageTransform.validFormats.join(', ')}`;
-		this[props].format = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validFormats, errorMessage);
+		this.format = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validFormats, errorMessage);
 		if (value === 'auto') {
 			if (this.quality === 100) {
-				return this[props].format = 'png';
+				return this.format = 'png';
 			}
-			this[props].format = 'jpg';
+			this.format = 'jpg';
 		}
 	}
 
-	get quality() {
-		return this[props].quality;
+	getQuality() {
+		return this.quality;
 	}
 
-	set quality(value = 'medium') {
+	setQuality(value = 'medium') {
 		const errorMessage = `Image quality must be one of ${ImageTransform.validQualities.join(', ')}`;
 		const quality = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validQualities, errorMessage);
-		this[props].quality = ImageTransform.qualityValueMap[quality];
+		this.quality = ImageTransform.qualityValueMap[quality];
 	}
 
-	get bgcolor() {
-		return this[props].bgcolor;
+	getBgcolor() {
+		return this.bgcolor;
 	}
 
-	set bgcolor(value) {
+	setBgcolor(value) {
 		const errorMessage = 'Image bgcolor must be a valid hex code or color name';
-		this[props].bgcolor = ImageTransform.sanitizeColorValue(value, errorMessage);
-	}
-
-	toJSON() {
-		return Object.assign({}, this[props]);
-	}
-
-	inspect() {
-		return this.toJSON();
+		this.bgcolor = ImageTransform.sanitizeColorValue(value, errorMessage);
 	}
 
 	static sanitizeUriValue(value, errorMessage = 'Expected a URI string with a valid scheme') {

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -12,19 +12,19 @@ function cloudinaryTransform(transform, options = {}) {
 	cloudinary.config({
 		cloud_name: options.cloudinaryAccountName
 	});
-	return cloudinary.url(encodeURI(transform.uri), buildCloudinaryTransforms(transform));
+	return cloudinary.url(encodeURI(transform.getUri()), buildCloudinaryTransforms(transform));
 }
 
 function buildCloudinaryTransforms(transform) {
 	const cloudinaryTransforms = {
 		type: 'fetch',
-		width: transform.width,
-		height: transform.height,
-		dpr: transform.dpr,
-		format: transform.format,
-		quality: transform.quality,
-		background: (transform.bgcolor ? `#${transform.bgcolor}` : undefined),
-		crop: getCloudinaryCropStrategy(transform.fit)
+		width: transform.getWidth(),
+		height: transform.getHeight(),
+		dpr: transform.getDpr(),
+		format: transform.getFormat(),
+		quality: transform.getQuality(),
+		background: (transform.getBgcolor() ? `#${transform.getBgcolor()}` : undefined),
+		crop: getCloudinaryCropStrategy(transform.getFit())
 	};
 	return cloudinaryTransforms;
 }

--- a/lib/transformers/imgix.js
+++ b/lib/transformers/imgix.js
@@ -14,26 +14,26 @@ function imgixTransform(transform, options = {}) {
 		includeLibraryParam: false,
 		secureURLToken: options.imgixSecureUrlToken
 	});
-	return client.buildURL(transform.uri, buildImgixTransforms(transform));
+	return client.buildURL(transform.getUri(), buildImgixTransforms(transform));
 }
 
 function buildImgixTransforms(transform) {
 	const imgixTransforms = {
-		fm: transform.format,
-		quality: transform.quality,
-		fit: getImgixFitStrategy(transform.fit)
+		fm: transform.getFormat(),
+		quality: transform.getQuality(),
+		fit: getImgixFitStrategy(transform.getFit())
 	};
-	if (transform.width !== undefined) {
-		imgixTransforms.w = transform.width;
+	if (transform.getWidth() !== undefined) {
+		imgixTransforms.w = transform.getWidth();
 	}
-	if (transform.height !== undefined) {
-		imgixTransforms.h = transform.height;
+	if (transform.getHeight() !== undefined) {
+		imgixTransforms.h = transform.getHeight();
 	}
-	if (transform.dpr !== undefined) {
-		imgixTransforms.dpr = transform.dpr;
+	if (transform.getDpr() !== undefined) {
+		imgixTransforms.dpr = transform.getDpr();
 	}
-	if (transform.bgcolor !== undefined) {
-		imgixTransforms.bg = transform.bgcolor;
+	if (transform.getBgcolor() !== undefined) {
+		imgixTransforms.bg = transform.getBgcolor();
 	}
 	return imgixTransforms;
 }

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -40,21 +40,21 @@ describe('lib/image-transform', () => {
 				bgcolor: '00ff00'
 			};
 			instance = new ImageTransform(properties);
-			assert.strictEqual(instance.uri, properties.uri);
-			assert.strictEqual(instance.width, properties.width);
-			assert.strictEqual(instance.height, properties.height);
-			assert.strictEqual(instance.dpr, properties.dpr);
-			assert.strictEqual(instance.fit, properties.fit);
-			assert.strictEqual(instance.quality, ImageTransform.qualityValueMap[properties.quality]);
-			assert.strictEqual(instance.format, properties.format);
-			assert.strictEqual(instance.bgcolor, properties.bgcolor);
+			assert.strictEqual(instance.getUri(), properties.uri);
+			assert.strictEqual(instance.getWidth(), properties.width);
+			assert.strictEqual(instance.getHeight(), properties.height);
+			assert.strictEqual(instance.getDpr(), properties.dpr);
+			assert.strictEqual(instance.getFit(), properties.fit);
+			assert.strictEqual(instance.getQuality(), ImageTransform.qualityValueMap[properties.quality]);
+			assert.strictEqual(instance.getFormat(), properties.format);
+			assert.strictEqual(instance.getBgcolor(), properties.bgcolor);
 		});
 
-		describe('.uri', () => {
+		describe('.setUri() / .getUri()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeUriValue').returns('sanitized');
-				instance.uri = 'http://foo/';
+				instance.setUri('http://foo/');
 			});
 
 			it('[set] calls the `sanitizeUriValue` static method with `value`', () => {
@@ -63,16 +63,16 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[get] returns the sanitized `value`', () => {
-				assert.strictEqual(instance.uri, 'sanitized');
+				assert.strictEqual(instance.getUri(), 'sanitized');
 			});
 
 		});
 
-		describe('.width', () => {
+		describe('.setWidth() / .getWidth()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeNumericValue').returns('sanitized');
-				instance.width = 123;
+				instance.setWidth(123);
 			});
 
 			it('[set] calls the `sanitizeNumericValue` static method with `value`', () => {
@@ -81,16 +81,16 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[get] returns the sanitized `value`', () => {
-				assert.strictEqual(instance.width, 'sanitized');
+				assert.strictEqual(instance.getWidth(), 'sanitized');
 			});
 
 		});
 
-		describe('.height', () => {
+		describe('.setHeight() / .getHeight()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeNumericValue').returns('sanitized');
-				instance.height = 123;
+				instance.setHeight(123);
 			});
 
 			it('[set] calls the `sanitizeNumericValue` static method with `value`', () => {
@@ -99,16 +99,16 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[get] returns the sanitized `value`', () => {
-				assert.strictEqual(instance.height, 'sanitized');
+				assert.strictEqual(instance.getHeight(), 'sanitized');
 			});
 
 		});
 
-		describe('.dpr', () => {
+		describe('.setDpr() / .getDpr()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeNumericValue').returns('sanitized');
-				instance.dpr = 2;
+				instance.setDpr(2);
 			});
 
 			it('[set] calls the `sanitizeNumericValue` static method with `value`', () => {
@@ -117,16 +117,16 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[get] returns the sanitized `value`', () => {
-				assert.strictEqual(instance.dpr, 'sanitized');
+				assert.strictEqual(instance.getDpr(), 'sanitized');
 			});
 
 		});
 
-		describe('.fit', () => {
+		describe('.setFit() / .getFit()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeEnumerableValue').returns('sanitized');
-				instance.fit = 'foo';
+				instance.setFit('foo');
 			});
 
 			it('[set] calls the `sanitizeEnumerableValue` static method with `value`', () => {
@@ -140,21 +140,21 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[set] defaults `value` to "cover"', () => {
-				instance.fit = undefined;
+				instance.setFit();
 				assert.calledWith(ImageTransform.sanitizeEnumerableValue, 'cover');
 			});
 
 			it('[get] returns the sanitized `value`', () => {
-				assert.strictEqual(instance.fit, 'sanitized');
+				assert.strictEqual(instance.getFit(), 'sanitized');
 			});
 
 		});
 
-		describe('.format', () => {
+		describe('.setFormat() / .getFormat()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeEnumerableValue').returns('sanitized');
-				instance.format = 'foo';
+				instance.setFormat('foo');
 			});
 
 			it('[set] calls the `sanitizeEnumerableValue` static method with `value`', () => {
@@ -168,21 +168,21 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[set] defaults `value` to "auto"', () => {
-				instance.format = undefined;
+				instance.setFormat();
 				assert.calledWith(ImageTransform.sanitizeEnumerableValue, 'auto');
 			});
 
 			it('[get] returns the sanitized `value`', () => {
-				assert.strictEqual(instance.format, 'sanitized');
+				assert.strictEqual(instance.getFormat(), 'sanitized');
 			});
 
 			describe('when `value` is "auto"', () => {
 
 				it('[get] returns "jpg"', () => {
 					ImageTransform.sanitizeEnumerableValue.restore();
-					instance.quality = undefined;
-					instance.format = undefined;
-					assert.strictEqual(instance.format, 'jpg');
+					instance.setQuality();
+					instance.setFormat();
+					assert.strictEqual(instance.getFormat(), 'jpg');
 				});
 
 			});
@@ -191,20 +191,20 @@ describe('lib/image-transform', () => {
 
 				it('[get] returns "png"', () => {
 					ImageTransform.sanitizeEnumerableValue.restore();
-					instance.quality = 'lossless';
-					instance.format = undefined;
-					assert.strictEqual(instance.format, 'png');
+					instance.setQuality('lossless');
+					instance.setFormat();
+					assert.strictEqual(instance.getFormat(), 'png');
 				});
 
 			});
 
 		});
 
-		describe('.quality', () => {
+		describe('.setQuality() / .getQuality()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeEnumerableValue').returns('lossless');
-				instance.quality = 'lossless';
+				instance.setQuality('lossless');
 			});
 
 			it('[set] calls the `sanitizeEnumerableValue` static method with `value`', () => {
@@ -218,21 +218,21 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[set] defaults `value` to "medium"', () => {
-				instance.quality = undefined;
+				instance.setQuality();
 				assert.calledWith(ImageTransform.sanitizeEnumerableValue, 'medium');
 			});
 
 			it('[get] returns a numeric representation of the sanitized `value`', () => {
-				assert.strictEqual(instance.quality, 100);
+				assert.strictEqual(instance.getQuality(), 100);
 			});
 
 		});
 
-		describe('.bgcolor', () => {
+		describe('.setBgcolor() / .getBgcolor()', () => {
 
 			beforeEach(() => {
 				sinon.stub(ImageTransform, 'sanitizeColorValue').returns('sanitized');
-				instance.bgcolor = 'foo';
+				instance.setBgcolor('foo');
 			});
 
 			it('[set] calls the `sanitizeColorValue` static method with `value`', () => {
@@ -245,50 +245,7 @@ describe('lib/image-transform', () => {
 			});
 
 			it('[get] returns the sanitized `value`', () => {
-				assert.strictEqual(instance.bgcolor, 'sanitized');
-			});
-
-		});
-
-		it('has a `toJSON` method', () => {
-			assert.isFunction(instance.toJSON);
-		});
-
-		describe('.toJSON()', () => {
-
-			it('returns a JSON representation of the object properties', () => {
-				const properties = {
-					uri: 'http://example.com/',
-					width: 123,
-					height: 456,
-					dpr: 2,
-					fit: 'scale-down',
-					quality: 'lossless',
-					format: 'png',
-					bgcolor: '00ff00'
-				};
-				instance = new ImageTransform(properties);
-				properties.quality = 100;
-				assert.deepEqual(instance.toJSON(), properties);
-			});
-
-		});
-
-		it('has an `inspect` method', () => {
-			assert.isFunction(instance.inspect);
-		});
-
-		describe('.inspect()', () => {
-
-			it('returns the result of `.toJSON()`', () => {
-				const json = {};
-				instance = new ImageTransform({
-					uri: 'http://example.com/'
-				});
-				sinon.stub(instance, 'toJSON').returns(json);
-				const returnValue = instance.inspect();
-				assert.calledOnce(instance.toJSON);
-				assert.strictEqual(returnValue, json);
+				assert.strictEqual(instance.getBgcolor(), 'sanitized');
 			});
 
 		});

--- a/test/unit/lib/transformers/cloudinary.js
+++ b/test/unit/lib/transformers/cloudinary.js
@@ -37,7 +37,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `width` property', () => {
 
 			beforeEach(() => {
-				transform.width = 123;
+				transform.setWidth(123);
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -50,7 +50,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `height` property', () => {
 
 			beforeEach(() => {
-				transform.height = 123;
+				transform.setHeight(123);
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -63,7 +63,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `dpr` property', () => {
 
 			beforeEach(() => {
-				transform.dpr = 2;
+				transform.setDpr(2);
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -76,7 +76,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `fit` property set to `contain`', () => {
 
 			beforeEach(() => {
-				transform.fit = 'contain';
+				transform.setFit('contain');
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -89,7 +89,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `fit` property set to `cover`', () => {
 
 			beforeEach(() => {
-				transform.fit = 'cover';
+				transform.setFit('cover');
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -102,7 +102,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `fit` property set to `scale-down`', () => {
 
 			beforeEach(() => {
-				transform.fit = 'scale-down';
+				transform.setFit('scale-down');
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -115,7 +115,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `format` property', () => {
 
 			beforeEach(() => {
-				transform.format = 'png';
+				transform.setFormat('png');
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -128,7 +128,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `quality` property', () => {
 
 			beforeEach(() => {
-				transform.quality = 'lowest';
+				transform.setQuality('lowest');
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 
@@ -141,7 +141,7 @@ describe('lib/transformers/cloudinary', () => {
 		describe('when `transform` has a `bgcolor` property', () => {
 
 			beforeEach(() => {
-				transform.bgcolor = 'ff0000';
+				transform.setBgcolor('ff0000');
 				cloudinaryUrl = cloudinaryTransform(transform, options);
 			});
 

--- a/test/unit/lib/transformers/imgix.js
+++ b/test/unit/lib/transformers/imgix.js
@@ -37,7 +37,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `width` property', () => {
 
 			beforeEach(() => {
-				transform.width = 123;
+				transform.setWidth(123);
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -50,7 +50,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `height` property', () => {
 
 			beforeEach(() => {
-				transform.height = 123;
+				transform.setHeight(123);
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -63,7 +63,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `dpr` property', () => {
 
 			beforeEach(() => {
-				transform.dpr = 2;
+				transform.setDpr(2);
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -76,7 +76,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `fit` property set to `contain`', () => {
 
 			beforeEach(() => {
-				transform.fit = 'contain';
+				transform.setFit('contain');
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -89,7 +89,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `fit` property set to `cover`', () => {
 
 			beforeEach(() => {
-				transform.fit = 'cover';
+				transform.setFit('cover');
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -102,7 +102,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `fit` property set to `scale-down`', () => {
 
 			beforeEach(() => {
-				transform.fit = 'scale-down';
+				transform.setFit('scale-down');
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -115,7 +115,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `format` property', () => {
 
 			beforeEach(() => {
-				transform.format = 'png';
+				transform.setFormat('png');
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -128,7 +128,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `quality` property', () => {
 
 			beforeEach(() => {
-				transform.quality = 'lowest';
+				transform.setQuality('lowest');
 				imgixUrl = imgixTransform(transform, options);
 			});
 
@@ -141,7 +141,7 @@ describe('lib/transformers/imgix', () => {
 		describe('when `transform` has a `bgcolor` property', () => {
 
 			beforeEach(() => {
-				transform.bgcolor = 'ff0000';
+				transform.setBgcolor('ff0000');
 				imgixUrl = imgixTransform(transform, options);
 			});
 


### PR DESCRIPTION
Refactoring the `ImageTransform` class to stop using getters/setters. This should be a bit clearer/easier to understand now.