### PR TITLE
Add a proxy response handler to tidy up headers

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -4,6 +4,7 @@ const express = require('express');
 const handleErrors = require('./middleware/handle-errors');
 const httpProxy = require('http-proxy');
 const notFound = require('./middleware/not-found');
+const oneWeek = 60 * 60 * 24 * 7;
 const requireAll = require('require-all');
 const url = require('url');
 
@@ -46,10 +47,28 @@ function createProxy(errorHandler) {
 		secure: false
 	});
 	proxy.on('proxyReq', proxyRequestHandler);
+	proxy.on('proxyRes', proxyResponseHandler);
 	proxy.on('error', errorHandler);
 
 	function proxyRequestHandler(proxyRequest, request, response, proxyOptions) {
 		proxyRequest.setHeader('Host', url.parse(proxyOptions.target).host);
+	}
+
+	function proxyResponseHandler(proxyResponse) {
+		const originalHeaders = proxyResponse.headers;
+
+		// Define our own headers for proxy responses
+		proxyResponse.headers = {
+			'Access-Control-Allow-Origin': '*',
+			'Cache-Control': `public, max-age=${oneWeek}, stale-while-revalidate=${oneWeek}, stale-if-error=${oneWeek}`,
+			'Content-Disposition': originalHeaders['content-disposition'],
+			'Content-Encoding': originalHeaders['content-encoding'],
+			'Content-Type': originalHeaders['content-type'],
+			'Content-Length': originalHeaders['content-length'],
+			'Connection': 'keep-alive',
+			'Vary': originalHeaders['vary']
+		};
+
 	}
 
 	return proxy;

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -121,6 +121,40 @@ describe('lib/image-service', () => {
 
 		});
 
+		it('adds a listener on the HTTP proxy\'s `proxyRes` event', () => {
+			assert.calledWith(httpProxy.mockProxyServer.on, 'proxyRes');
+		});
+
+		describe('HTTP Proxy `proxyRes` handler', () => {
+			let proxyResponse;
+
+			beforeEach(() => {
+				const handler = httpProxy.mockProxyServer.on.withArgs('proxyRes').firstCall.args[1];
+				proxyResponse = httpProxy.mockProxyResponse;
+				proxyResponse.headers = {
+					'foo': 'bar',
+					'cache-control': 'public, max-age=123',
+					'content-type': 'image/jpeg',
+					'content-length': '1234'
+				};
+				handler(proxyResponse);
+			});
+
+			it('should set the headers of the proxy response to a subset of the original headers', () => {
+				assert.deepEqual(httpProxy.mockProxyResponse.headers, {
+					'Access-Control-Allow-Origin': '*',
+					'Cache-Control': 'public, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800',
+					'Content-Disposition': undefined,
+					'Content-Encoding': undefined,
+					'Content-Type': 'image/jpeg',
+					'Content-Length': '1234',
+					'Connection': 'keep-alive',
+					'Vary': undefined
+				});
+			});
+
+		});
+
 		it('adds a listener on the HTTP proxy\'s `error` event', () => {
 			assert.calledWith(httpProxy.mockProxyServer.on, 'error');
 		});

--- a/test/unit/mock/http-proxy.mock.js
+++ b/test/unit/mock/http-proxy.mock.js
@@ -15,4 +15,8 @@ module.exports.mockProxyRequest = {
 	setHeader: sinon.spy()
 };
 
+module.exports.mockProxyResponse = {
+	headers: {}
+};
+
 httpProxy.createProxyServer.returns(mockProxyServer);


### PR DESCRIPTION
The headers that come back from Cloudinary and Imgix are a bit
inconsitent, and they include a lot of stuff we don't really want to
send as part of the response.

This removes them and sets consistent headers no matter where the image
comes from.