### PR TITLE
Handle the ftcms custom scheme

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
 		"before": true,
 		"beforeEach": true,
 		"describe": true,
+		"fetch": true,
 		"it": true,
 		"xdescribe": true,
 		"xit": true

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -29,7 +29,7 @@ function getCmsUrl() {
 				return fetch(v2Uri, fetchOptions);
 			})
 			.then(secondResponse => {
-				// Cool, we've got an image from v2
+				// Cool, we've got an image from v2 (or v1 if that is OK)
 				if (secondResponse.ok) {
 					return secondResponse;
 				}

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const httpError = require('http-errors');
+
+module.exports = getCmsUrl;
+
+function getCmsUrl() {
+	return (request, response, next) => {
+
+		// Grab the CMS ID and construct the v1 and v2 API URLs
+		const cmsId = request.params[0].split(':').pop();
+		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img`;
+		const v2Uri = `http://com.ft.imagepublish.prod.s3.amazonaws.com/${cmsId}`;
+
+		// Use HEAD requests so we don't have to wait for
+		// the full image to load
+		const fetchOptions = {
+			method: 'HEAD'
+		};
+
+		// First try fetching the v1 image
+		fetch(v1Uri, fetchOptions)
+			.then(firstResponse => {
+				// Cool, we've got an image from v1
+				if (firstResponse.ok) {
+					return firstResponse;
+				}
+				// If the v1 image can't be found, try v2
+				return fetch(v2Uri, fetchOptions);
+			})
+			.then(secondResponse => {
+				// Cool, we've got an image from v2
+				if (secondResponse.ok) {
+					return secondResponse;
+				}
+				// If the v2 image can't be found, we error
+				throw httpError(404, `Unable to get image ${cmsId} from FT CMS v1 or v2`);
+			})
+			.then(finalResponse => {
+				request.params[0] = finalResponse.url;
+				next();
+			})
+			.catch(next);
+	};
+}

--- a/lib/routes/v2/images-debug.js
+++ b/lib/routes/v2/images-debug.js
@@ -1,10 +1,18 @@
 'use strict';
 
-const httpError = require('http-errors');
+const getCmsUrl = require('../../middleware/get-cms-url');
 const mapCustomScheme = require('../../middleware/map-custom-scheme');
 const processImageRequest = require('../../middleware/process-image-request');
 
 module.exports = app => {
+
+	// Debug middleware to log transform information
+	function debug(request, response) {
+		response.send({
+			transform: request.transform,
+			appliedTransform: request.appliedTransform
+		});
+	}
 
 	// Debug image with an HTTP or HTTPS scheme, matches:
 	// /v2/images/debug/https://...
@@ -12,12 +20,7 @@ module.exports = app => {
 	app.get(
 		/\/v2\/images\/debug\/(https?(:|%3A).*)$/,
 		processImageRequest(app.imageServiceConfig),
-		(request, response) => {
-			response.send({
-				transform: request.transform,
-				appliedTransform: request.appliedTransform
-			});
-		}
+		debug
 	);
 
 	// Debug image with a custom scheme, matches:
@@ -31,19 +34,16 @@ module.exports = app => {
 		/^\/v2\/images\/debug\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/,
 		mapCustomScheme(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
-		(request, response) => {
-			response.send({
-				transform: request.transform,
-				appliedTransform: request.appliedTransform
-			});
-		}
+		debug
 	);
 
 	// Image with a custom scheme, matches:
 	// /v2/images/debug/ftcms:...
-	app.get(/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/, (request, response, next) => {
-		// Not implemented yet
-		next(httpError(501));
-	});
+	app.get(
+		/^\/v2\/images\/debug\/((ftcms)(:|%3A).*)$/,
+		getCmsUrl(app.imageServiceConfig),
+		processImageRequest(app.imageServiceConfig),
+		debug
+	);
 
 };

--- a/lib/routes/v2/images-raw.js
+++ b/lib/routes/v2/images-raw.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const getCmsUrl = require('../../middleware/get-cms-url');
 const httpError = require('http-errors');
 const mapCustomScheme = require('../../middleware/map-custom-scheme');
 const processImageRequest = require('../../middleware/process-image-request');
@@ -39,10 +40,16 @@ module.exports = app => {
 
 	// Image with a custom scheme, matches:
 	// /v2/images/raw/ftcms:...
-	app.get(/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/, (request, response, next) => {
-		// Not implemented yet
-		next(httpError(501));
-	});
+	app.get(
+		/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/,
+		getCmsUrl(app.imageServiceConfig),
+		processImageRequest(app.imageServiceConfig),
+		(request, response) => {
+			app.proxy.web(request, response, {
+				target: request.appliedTransform
+			});
+		}
+	);
 
 	// Image with an imageset, matches:
 	// all other /v2/images/raw/...

--- a/lib/routes/v2/images-raw.js
+++ b/lib/routes/v2/images-raw.js
@@ -7,17 +7,20 @@ const processImageRequest = require('../../middleware/process-image-request');
 
 module.exports = app => {
 
+	// Proxy image middleware
+	function proxyImage(request, response) {
+		app.proxy.web(request, response, {
+			target: request.appliedTransform
+		});
+	}
+
 	// Image with an HTTP or HTTPS scheme, matches:
 	// /v2/images/raw/https://...
 	// /v2/images/raw/http://...
 	app.get(
 		/\/v2\/images\/raw\/(https?(:|%3A).*)$/,
 		processImageRequest(app.imageServiceConfig),
-		(request, response) => {
-			app.proxy.web(request, response, {
-				target: request.appliedTransform
-			});
-		}
+		proxyImage
 	);
 
 	// Image with a custom scheme, matches:
@@ -31,11 +34,7 @@ module.exports = app => {
 		/^\/v2\/images\/raw\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/,
 		mapCustomScheme(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
-		(request, response) => {
-			app.proxy.web(request, response, {
-				target: request.appliedTransform
-			});
-		}
+		proxyImage
 	);
 
 	// Image with a custom scheme, matches:
@@ -44,11 +43,7 @@ module.exports = app => {
 		/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/,
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
-		(request, response) => {
-			app.proxy.web(request, response, {
-				target: request.appliedTransform
-			});
-		}
+		proxyImage
 	);
 
 	// Image with an imageset, matches:

--- a/test/integration/v2/images-raw.js
+++ b/test/integration/v2/images-raw.js
@@ -39,7 +39,7 @@ describe('GET /v2/images/raw…', function() {
 
 	describe('/ftcms:… (ftcms scheme)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.ftcms}?source=test`);
-		itRespondsWithStatus(501);
+		itRespondsWithStatus(200);
 	});
 
 	xdescribe('/fticon:… (fticon scheme)', function() {

--- a/test/unit/lib/middleware/get-cms-url.js
+++ b/test/unit/lib/middleware/get-cms-url.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+describe('lib/middleware/get-cms-url', () => {
+
+	let express;
+	let getCmsUrl;
+
+	beforeEach(() => {
+
+		express = require('../../mock/n-express.mock');
+		mockery.registerMock('express', express);
+
+		getCmsUrl = require('../../../../lib/middleware/get-cms-url');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(getCmsUrl);
+	});
+
+	describe('getCmsUrl(config)', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = getCmsUrl();
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let mockFetchResponseV1;
+			let mockFetchResponseV2;
+
+			beforeEach(done => {
+				express.mockRequest.params[0] = 'ftcms:mock-id';
+				mockFetchResponseV1 = {
+					url: 'response-url-v1',
+					ok: true
+				};
+				mockFetchResponseV2 = {
+					url: 'response-url-v2',
+					ok: true
+				};
+				global.fetch = sinon.stub();
+				global.fetch.withArgs('http://im.ft-static.com/content/images/mock-id.img').resolves(mockFetchResponseV1);
+				global.fetch.withArgs('http://com.ft.imagepublish.prod.s3.amazonaws.com/mock-id').resolves(mockFetchResponseV2);
+				middleware(express.mockRequest, express.mockResponse, done);
+			});
+
+			it('attempts to fetch the v1 API URL corresponding to the CMS ID', () => {
+				assert.calledOnce(global.fetch);
+				assert.calledWith(global.fetch, 'http://im.ft-static.com/content/images/mock-id.img');
+				assert.deepEqual(global.fetch.firstCall.args[1], {
+					method: 'HEAD'
+				});
+			});
+
+			it('sets the request param (0) to the v1 API URL corresponding to the CMS ID', () => {
+				assert.strictEqual(express.mockRequest.params[0], mockFetchResponseV1.url);
+			});
+
+			describe('when the v1 API cannot find the image', () => {
+
+				beforeEach(done => {
+					global.fetch.reset();
+					express.mockRequest.params[0] = 'ftcms:mock-id';
+					mockFetchResponseV1.ok = false;
+					middleware(express.mockRequest, express.mockResponse, done);
+				});
+
+				it('attempts to fetch the v2 API URL corresponding to the CMS ID', () => {
+					assert.calledTwice(global.fetch);
+					assert.calledWith(global.fetch, 'http://com.ft.imagepublish.prod.s3.amazonaws.com/mock-id');
+					assert.deepEqual(global.fetch.secondCall.args[1], {
+						method: 'HEAD'
+					});
+				});
+
+				it('sets the request param (0) to the v2 API URL corresponding to the CMS ID', () => {
+					assert.strictEqual(express.mockRequest.params[0], mockFetchResponseV2.url);
+				});
+
+			});
+
+			describe('when neither the v1 or v2 API can find the image', () => {
+				let responseError;
+
+				beforeEach(done => {
+					global.fetch.reset();
+					express.mockRequest.params[0] = 'ftcms:mock-id';
+					mockFetchResponseV1.ok = false;
+					mockFetchResponseV2.ok = false;
+					middleware(express.mockRequest, express.mockResponse, error => {
+						responseError = error;
+						done();
+					});
+				});
+
+				it('calls `next` with a 404 error', () => {
+					assert.instanceOf(responseError, Error);
+					assert.strictEqual(responseError.message, 'Unable to get image mock-id from FT CMS v1 or v2');
+					assert.strictEqual(responseError.status, 404);
+				});
+
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This mirrors the behaviour of the original image service, first
attempting to load an image from the V1 API and then trying V2.

In order to utilise the proxying behaviour of this service we
don't load the image, we make a HEAD request to verify that an
image is available.

If neither can be found then we error.