### PR TITLE
Implement an SVG tinting endpoint

### DIFF
--- a/lib/routes/v2/images-svgtint.js
+++ b/lib/routes/v2/images-svgtint.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const httpError = require('http-errors');
+const httpRequest = require('request');
+const SvgTintStream = require('svg-tint-stream');
+
+module.exports = app => {
+
+	// SVG tinting middleware
+	function tintSvg(request, response, next) {
+		const color = request.query.color || '#000';
+		const uri = request.params[0];
+
+		let tintStream;
+		try {
+			tintStream = new SvgTintStream({color});
+		} catch (error) {
+			error.status = 400;
+			return next(error);
+		}
+
+		const imageRequest = httpRequest(uri);
+		imageRequest
+			.on('response', imageResponse => {
+				if (imageResponse.statusCode >= 400) {
+					return imageRequest.emit('error', httpError(imageResponse.statusCode));
+				}
+				if (imageResponse.headers['content-type'].indexOf('image/svg+xml') === -1) {
+					return imageRequest.emit('error', httpError(400, 'URI must point to an SVG image'));
+				}
+				response.set('Content-Type', 'image/svg+xml; charset=utf-8');
+			})
+			.on('error', error => {
+				return next(error);
+			})
+			.pipe(tintStream)
+			.pipe(response);
+	}
+
+	// Image with an HTTP or HTTPS scheme, matches:
+	// /v2/images/svgtint/https://...
+	// /v2/images/svgtint/http://...
+	app.get(
+		/\/v2\/images\/svgtint\/(https?(:|%3A).*)$/,
+		tintSvg
+	);
+
+};

--- a/lib/routes/v2/images-svgtint.js
+++ b/lib/routes/v2/images-svgtint.js
@@ -11,6 +11,9 @@ module.exports = app => {
 		const color = request.query.color || '#000';
 		const uri = request.params[0];
 
+		// Create a tint stream with the colour found in
+		// the querystring. SvgTintStream deals with colour
+		// validation here
 		let tintStream;
 		try {
 			tintStream = new SvgTintStream({color});
@@ -19,8 +22,12 @@ module.exports = app => {
 			return next(error);
 		}
 
+		// Request the original SVG image
 		const imageRequest = httpRequest(uri);
 		imageRequest
+			// We listen for the response event so that we
+			// can error properly and *early* if the URI
+			// does not point to an SVG or it errors
 			.on('response', imageResponse => {
 				if (imageResponse.statusCode >= 400) {
 					return imageRequest.emit('error', httpError(imageResponse.statusCode));
@@ -30,9 +37,13 @@ module.exports = app => {
 				}
 				response.set('Content-Type', 'image/svg+xml; charset=utf-8');
 			})
+			// If the request errors, report this using
+			// the standard error middleware
 			.on('error', error => {
 				return next(error);
 			})
+			// Pipe the image request through the tint
+			// stream and into the response
 			.pipe(tintStream)
 			.pipe(response);
 	}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "http-proxy": "^1",
     "imgix-core-js": "^1",
     "morgan": "^1",
+    "request": "^2",
     "require-all": "^2",
-    "statuses": "^1"
+    "statuses": "^1",
+    "svg-tint-stream": "^0.2"
   },
   "devDependencies": {
     "chai": "^3",

--- a/test/integration/v2/images-svgtint.js
+++ b/test/integration/v2/images-svgtint.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const itRespondsWithContentType = require('../helpers/it-responds-with-content-type');
+const itRespondsWithStatus = require('../helpers/it-responds-with-status');
+const setupRequest = require('../helpers/setup-request');
+
+const testImageUris = {
+	valid: 'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',
+	notFound: 'http://google.com/404',
+	nonSvg: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
+};
+
+describe('GET /v2/images/svgtint…', function() {
+
+	describe('with a valid URI', function() {
+		setupRequest('GET', `/v2/images/svgtint/${testImageUris.valid}`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+	});
+
+	describe('with a URI that 404s', function() {
+		setupRequest('GET', `/v2/images/svgtint/${testImageUris.notFound}`);
+		itRespondsWithStatus(404);
+		itRespondsWithContentType('text/html');
+	});
+
+	describe('with a URI that does not point to an SVG', function() {
+		setupRequest('GET', `/v2/images/svgtint/${testImageUris.nonSvg}`);
+		itRespondsWithStatus(400);
+		it('responds with a descriptive error message', function(done) {
+			this.request.expect(/uri must point to an svg image/i).end(done);
+		});
+	});
+
+	describe('with a valid `color` query parameter', function() {
+		setupRequest('GET', `/v2/images/svgtint/${testImageUris.valid}?color=f00`);
+		itRespondsWithStatus(200);
+	});
+
+	describe('with an invalid `color` query parameter', function() {
+		setupRequest('GET', `/v2/images/svgtint/${testImageUris.valid}?color=nope`);
+		itRespondsWithStatus(400);
+		it('responds with a descriptive error message', function(done) {
+			this.request.expect(/tint color must be a valid hex code/i).end(done);
+		});
+	});
+
+});


### PR DESCRIPTION
This adds partial support for #12. The next part of this work is routing any SVG image requests through this additional layer if they have a tint parameter.