### PR TITLE
Route tinted SVGs through the svgtint endpoint

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -27,6 +27,17 @@ function processImage(config) {
 			return next(httpError(400, 'The source parameter is required'));
 		}
 
+		// If the image is an SVG with a tint parameter then
+		// we need to route it through the /images/svgtint
+		// endpoint. This involves modifying the URI.
+		if ((transform.format === 'svg' || /\.svg/i.test(transform.uri)) && request.query.tint) {
+			const encodedUri = encodeURIComponent(transform.uri);
+			// We only use the first comma-delimited tint colour
+			// that we find, additional colours are obsolete
+			const tint = request.query.tint.split(',')[0];
+			transform.setUri(`${request.protocol}://${request.hostname}/v2/images/svgtint/${encodedUri}?color=${tint}`);
+		}
+
 		// Switch on the `transformer` query parameter, and
 		// build an applied transform based on the specified
 		// third-party image service


### PR DESCRIPTION
This doesn't have tests yet because I want to see how it works on qa – third party services don't have access to my local server and so the routing doesn't work properly. I'll be opening a second PR with automated tests once I know this works.