### PR TITLE
Fix SVG header sending and write tests

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ module.exports = {
 	cloudinaryAccountName: process.env.CLOUDINARY_ACCOUNT_NAME,
 	customSchemeStore: process.env.CUSTOM_SCHEME_STORE,
 	environment: process.env.NODE_ENV || 'development',
+	hostname: process.env.HOSTNAME,
 	imgixSecureUrlToken: process.env.IMGIX_SECURE_URL_TOKEN,
 	imgixSourceName: process.env.IMGIX_SOURCE_NAME,
 	log: console,

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -55,7 +55,6 @@ function createProxy(errorHandler) {
 		proxyResponse.headers = {
 			'Access-Control-Allow-Origin': '*',
 			'Cache-Control': `public, max-age=${oneWeek}, stale-while-revalidate=${oneWeek}, stale-if-error=${oneWeek}`,
-			'Content-Disposition': originalHeaders['content-disposition'],
 			'Content-Encoding': originalHeaders['content-encoding'],
 			'Content-Type': originalHeaders['content-type'],
 			'Content-Length': originalHeaders['content-length'],

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -133,6 +133,9 @@ module.exports = class ImageTransform {
 		const errorMessage = `Image format must be one of ${ImageTransform.validFormats.join(', ')}`;
 		this.format = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validFormats, errorMessage);
 		if (value === 'auto') {
+			if (/\.svg/i.test(this.uri)) {
+				return this.format = 'svg';
+			}
 			if (this.quality === 100) {
 				return this.format = 'png';
 			}

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -35,7 +35,8 @@ function processImage(config) {
 			// We only use the first comma-delimited tint colour
 			// that we find, additional colours are obsolete
 			const tint = request.query.tint.split(',')[0];
-			transform.setUri(`${request.protocol}://${request.hostname}/v2/images/svgtint/${encodedUri}?color=${tint}`);
+			const hostname = (config.hostname || request.hostname);
+			transform.setUri(`${request.protocol}://${hostname}/v2/images/svgtint/${encodedUri}?color=${tint}`);
 		}
 
 		// Switch on the `transformer` query parameter, and

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -123,7 +123,8 @@ describe('lib/image-service', () => {
 					'foo': 'bar',
 					'cache-control': 'public, max-age=123',
 					'content-type': 'image/jpeg',
-					'content-length': '1234'
+					'content-length': '1234',
+					'content-disposition': 'foo'
 				};
 				handler(proxyResponse);
 			});
@@ -132,7 +133,6 @@ describe('lib/image-service', () => {
 				assert.deepEqual(httpProxy.mockProxyResponse.headers, {
 					'Access-Control-Allow-Origin': '*',
 					'Cache-Control': 'public, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800',
-					'Content-Disposition': undefined,
 					'Content-Encoding': undefined,
 					'Content-Type': 'image/jpeg',
 					'Content-Length': '1234',

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -198,6 +198,17 @@ describe('lib/image-transform', () => {
 
 			});
 
+			describe('when `value` is "auto" and the `uri` property ends in ".svg"', () => {
+
+				it('[get] returns "svg"', () => {
+					ImageTransform.sanitizeEnumerableValue.restore();
+					instance.setUri('http://example.com/foo.svg');
+					instance.setFormat();
+					assert.strictEqual(instance.getFormat(), 'svg');
+				});
+
+			});
+
 		});
 
 		describe('.setQuality() / .getQuality()', () => {

--- a/test/unit/lib/middleware/process-image-request.js
+++ b/test/unit/lib/middleware/process-image-request.js
@@ -103,6 +103,40 @@ describe('lib/middleware/process-image-request', () => {
 				assert.calledWithExactly(next);
 			});
 
+			describe('when the image transform format is "svg" and `request.query.tint` is set', () => {
+
+				beforeEach(() => {
+					mockImageTransform.format = 'svg';
+					mockImageTransform.uri = 'transform-uri?foo';
+					mockImageTransform.setUri = sinon.spy();
+					express.mockRequest.protocol = 'proto';
+					express.mockRequest.hostname = 'hostname';
+					express.mockRequest.query.tint = 'f00';
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sets the image transform `uri` property to route through the SVG tinter', () => {
+					assert.calledOnce(mockImageTransform.setUri);
+					assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://hostname/v2/images/svgtint/transform-uri%3Ffoo?color=f00');
+				});
+
+				describe('when `config.hostname` is set', () => {
+
+					beforeEach(() => {
+						mockImageTransform.setUri.reset();
+						config.hostname = 'config-hostname';
+						middleware(express.mockRequest, express.mockResponse, next);
+					});
+
+					it('sets the image transform `uri` property to route through the SVG tinter', () => {
+						assert.calledOnce(mockImageTransform.setUri);
+						assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://config-hostname/v2/images/svgtint/transform-uri%3Ffoo?color=f00');
+					});
+
+				});
+
+			});
+
 			describe('when `request.query.transformer` is "imgix"', () => {
 
 				beforeEach(() => {


### PR DESCRIPTION
SVG headers weren't being set properly, and a format of "auto" would never result in SVGs being sent. This fixes it and adds some tests to prevent it from happening again.