### PR TITLE
Move SVG tinting into middleware and write tests

### DIFF
--- a/lib/middleware/tint-svg.js
+++ b/lib/middleware/tint-svg.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const httpError = require('http-errors');
+const httpRequest = require('request');
+const SvgTintStream = require('svg-tint-stream');
+
+module.exports = tintSvg;
+
+function tintSvg() {
+	return (request, response, next) => {
+
+		// Grab the params we need for tinting
+		const color = request.query.color || '#000';
+		const uri = request.params[0];
+
+		// Create a tint stream with the colour found in
+		// the querystring. SvgTintStream deals with colour
+		// validation here
+		let tintStream;
+		try {
+			tintStream = new SvgTintStream({color});
+		} catch (error) {
+			error.status = 400;
+			return next(error);
+		}
+
+		// Request the original SVG image
+		const imageRequest = httpRequest(uri);
+		imageRequest
+			// We listen for the response event so that we
+			// can error properly and *early* if the URI
+			// does not point to an SVG or it errors
+			.on('response', imageResponse => {
+				if (imageResponse.statusCode >= 400) {
+					return imageRequest.emit('error', httpError(imageResponse.statusCode));
+				}
+				if (imageResponse.headers['content-type'].indexOf('image/svg+xml') === -1) {
+					return imageRequest.emit('error', httpError(400, 'URI must point to an SVG image'));
+				}
+				response.set('Content-Type', 'image/svg+xml; charset=utf-8');
+			})
+			// If the request errors, report this using
+			// the standard error middleware
+			.on('error', error => {
+				return next(error);
+			})
+			// Pipe the image request through the tint
+			// stream and into the response
+			.pipe(tintStream)
+			.pipe(response);
+	};
+}

--- a/lib/routes/v2/images-svgtint.js
+++ b/lib/routes/v2/images-svgtint.js
@@ -1,59 +1,15 @@
 'use strict';
 
-const httpError = require('http-errors');
-const httpRequest = require('request');
-const SvgTintStream = require('svg-tint-stream');
+const tintSvg = require('../../middleware/tint-svg');
 
 module.exports = app => {
-
-	// SVG tinting middleware
-	function tintSvg(request, response, next) {
-		const color = request.query.color || '#000';
-		const uri = request.params[0];
-
-		// Create a tint stream with the colour found in
-		// the querystring. SvgTintStream deals with colour
-		// validation here
-		let tintStream;
-		try {
-			tintStream = new SvgTintStream({color});
-		} catch (error) {
-			error.status = 400;
-			return next(error);
-		}
-
-		// Request the original SVG image
-		const imageRequest = httpRequest(uri);
-		imageRequest
-			// We listen for the response event so that we
-			// can error properly and *early* if the URI
-			// does not point to an SVG or it errors
-			.on('response', imageResponse => {
-				if (imageResponse.statusCode >= 400) {
-					return imageRequest.emit('error', httpError(imageResponse.statusCode));
-				}
-				if (imageResponse.headers['content-type'].indexOf('image/svg+xml') === -1) {
-					return imageRequest.emit('error', httpError(400, 'URI must point to an SVG image'));
-				}
-				response.set('Content-Type', 'image/svg+xml; charset=utf-8');
-			})
-			// If the request errors, report this using
-			// the standard error middleware
-			.on('error', error => {
-				return next(error);
-			})
-			// Pipe the image request through the tint
-			// stream and into the response
-			.pipe(tintStream)
-			.pipe(response);
-	}
 
 	// Image with an HTTP or HTTPS scheme, matches:
 	// /v2/images/svgtint/https://...
 	// /v2/images/svgtint/http://...
 	app.get(
 		/\/v2\/images\/svgtint\/(https?(:|%3A).*)$/,
-		tintSvg
+		tintSvg()
 	);
 
 };

--- a/test/unit/lib/middleware/handle-errors.js
+++ b/test/unit/lib/middleware/handle-errors.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('chai').assert;
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 describe('lib/middleware/handle-errors', () => {
@@ -11,7 +10,6 @@ describe('lib/middleware/handle-errors', () => {
 	beforeEach(() => {
 
 		express = require('../../mock/n-express.mock');
-		mockery.registerMock('express', express);
 
 		handleErrors = require('../../../../lib/middleware/handle-errors');
 	});

--- a/test/unit/lib/middleware/process-image-request.js
+++ b/test/unit/lib/middleware/process-image-request.js
@@ -14,7 +14,6 @@ describe('lib/middleware/process-image-request', () => {
 	beforeEach(() => {
 
 		express = require('../../mock/n-express.mock');
-		mockery.registerMock('express', express);
 
 		ImageTransform = sinon.stub();
 		mockery.registerMock('../image-transform', ImageTransform);

--- a/test/unit/lib/middleware/tint-svg.js
+++ b/test/unit/lib/middleware/tint-svg.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+describe('lib/middleware/tint-svg', () => {
+	let express;
+	let request;
+	let svgTint;
+	let SvgTintStream;
+
+	beforeEach(() => {
+
+		express = require('../../mock/n-express.mock');
+
+		request = require('../../mock/request.mock');
+		mockery.registerMock('request', request);
+
+		SvgTintStream = require('../../mock/svg-tint-stream.mock');
+		mockery.registerMock('svg-tint-stream', SvgTintStream);
+
+		svgTint = require('../../../../lib/middleware/tint-svg');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(svgTint);
+	});
+
+	describe('svgTint()', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = svgTint();
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+
+			beforeEach(() => {
+				next = sinon.spy();
+				express.mockRequest.params[0] = 'mock-uri';
+				express.mockRequest.query.color = 'f00';
+				middleware(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('creates an SVG tint stream with `request.query.color`', () => {
+				assert.calledOnce(SvgTintStream);
+				assert.calledWithNew(SvgTintStream);
+				assert.calledWith(SvgTintStream, {
+					color: express.mockRequest.query.color
+				});
+			});
+
+			it('creates an HTTP request stream with `request.params[0]`', () => {
+				assert.calledOnce(request);
+				assert.calledWith(request, express.mockRequest.params[0]);
+			});
+
+			it('binds a handler to the HTTP request stream "response" event', () => {
+				assert.calledWith(request.mockStream.on, 'response');
+			});
+
+			describe('HTTP request stream "response" handler', () => {
+				let handler;
+				let mockImageResponse;
+
+				beforeEach(() => {
+					mockImageResponse = {
+						statusCode: 200,
+						headers: {
+							'content-type': 'image/svg+xml'
+						}
+					};
+					handler = request.mockStream.on.withArgs('response').firstCall.args[1];
+					handler(mockImageResponse);
+				});
+
+				it('sets the Content-Type header to the SVG content type', () => {
+					assert.calledOnce(express.mockResponse.set);
+					assert.calledWithExactly(express.mockResponse.set, 'Content-Type', 'image/svg+xml; charset=utf-8');
+				});
+
+				describe('when the image response status is an error code', () => {
+
+					beforeEach(() => {
+						express.mockResponse.set.reset();
+						mockImageResponse.statusCode = 400;
+						handler(mockImageResponse);
+					});
+
+					it('does not set the Content-Type header', () => {
+						assert.notCalled(express.mockResponse.set);
+					});
+
+					it('emits an error on the HTTP request stream', () => {
+						assert.calledOnce(request.mockStream.emit);
+						assert.calledWith(request.mockStream.emit, 'error');
+						assert.instanceOf(request.mockStream.emit.firstCall.args[1], Error);
+						assert.strictEqual(request.mockStream.emit.firstCall.args[1].status, 400);
+						assert.strictEqual(request.mockStream.emit.firstCall.args[1].message, 'Bad Request');
+					});
+
+				});
+
+				describe('when the image response is not an SVG', () => {
+
+					beforeEach(() => {
+						express.mockResponse.set.reset();
+						mockImageResponse.headers['content-type'] = 'text/html';
+						handler(mockImageResponse);
+					});
+
+					it('does not set the Content-Type header', () => {
+						assert.notCalled(express.mockResponse.set);
+					});
+
+					it('emits an error on the HTTP request stream', () => {
+						assert.calledOnce(request.mockStream.emit);
+						assert.calledWith(request.mockStream.emit, 'error');
+						assert.instanceOf(request.mockStream.emit.firstCall.args[1], Error);
+						assert.strictEqual(request.mockStream.emit.firstCall.args[1].status, 400);
+						assert.strictEqual(request.mockStream.emit.firstCall.args[1].message, 'URI must point to an SVG image');
+					});
+
+				});
+
+			});
+
+			it('binds a handler to the HTTP request stream "error" event', () => {
+				assert.calledWith(request.mockStream.on, 'error');
+			});
+
+			describe('HTTP request stream "error" handler', () => {
+				let handler;
+				let streamError;
+
+				beforeEach(() => {
+					streamError = new Error('stream error');
+					handler = request.mockStream.on.withArgs('error').firstCall.args[1];
+					handler(streamError);
+				});
+
+				it('calls `next` with the error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next, streamError);
+				});
+
+			});
+
+			it('pipes the HTTP request stream through the tint stream and into the response', () => {
+				assert.calledWithExactly(request.mockStream.pipe, SvgTintStream.mockStream);
+				assert.calledWithExactly(request.mockStream.pipe, express.mockResponse);
+				assert.callOrder(
+					request.mockStream.pipe.withArgs(SvgTintStream.mockStream),
+					request.mockStream.pipe.withArgs(express.mockResponse)
+				);
+			});
+
+			describe('when `request.query.color` is not set', () => {
+
+				beforeEach(() => {
+					SvgTintStream.reset();
+					delete express.mockRequest.query.color;
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('creates an SVG tint stream with "#000"', () => {
+					assert.calledWith(SvgTintStream, {
+						color: '#000'
+					});
+				});
+
+			});
+
+			describe('when the SvgTintStream errors', () => {
+				let tintError;
+
+				beforeEach(() => {
+					next.reset();
+					tintError = new Error('stream error');
+					SvgTintStream.throws(tintError);
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sets the error `status` property to 400', () => {
+					assert.strictEqual(tintError.status, 400);
+				});
+
+				it('calls `next` with the error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next, tintError);
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/n-express.mock.js
+++ b/test/unit/mock/n-express.mock.js
@@ -23,6 +23,7 @@ module.exports.mockRequest = {
 
 module.exports.mockResponse = {
 	send: sinon.stub().returnsThis(),
+	set: sinon.stub().returnsThis(),
 	status: sinon.stub().returnsThis()
 };
 

--- a/test/unit/mock/request.mock.js
+++ b/test/unit/mock/request.mock.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const request = module.exports = sinon.stub();
+
+const mockStream = module.exports.mockStream = {
+	emit: sinon.stub().returnsThis(),
+	on: sinon.stub().returnsThis(),
+	pipe: sinon.stub().returnsThis()
+};
+
+request.returns(mockStream);

--- a/test/unit/mock/svg-tint-stream.mock.js
+++ b/test/unit/mock/svg-tint-stream.mock.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const SvgTintStream = module.exports = sinon.stub();
+
+const mockStream = module.exports.mockStream = {};
+
+SvgTintStream.returns(mockStream);


### PR DESCRIPTION
This introduces unit tests for the SVG tinting that was added in #20. It also moves all of that code into reusable (and more testable) middleware.