### PR TITLE
Move tinting validation logic into ImageTransform

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -30,6 +30,7 @@ module.exports = class ImageTransform {
 		this.setQuality(properties.quality);
 		this.setFormat(properties.format);
 		this.setBgcolor(properties.bgcolor);
+		this.setTint(properties.tint);
 	}
 
 	/**
@@ -179,6 +180,23 @@ module.exports = class ImageTransform {
 	}
 
 	/**
+	 * Get the tint color of the transformed image.
+	 * @return {String}
+	 */
+	getTint() {
+		return this.tint;
+	}
+
+	/**
+	 * Set the tint color of the transformed image.
+	 * @param {String} [value] - The background color. A comma-delimited list of hex codes and named colors.
+	 */
+	setTint(value) {
+		const errorMessage = 'Image tint must be a comma-delimited list of valid hex codes and color names';
+		this.tint = ImageTransform.sanitizeColorListValue(value, errorMessage);
+	}
+
+	/**
 	 * Sanitize an image transform URI value.
 	 * @param {String} value - The URI to sanitize.
 	 * @param {String} [errorMessage] - The error message to use when the URI is invalid.
@@ -251,6 +269,7 @@ module.exports = class ImageTransform {
 		if (value === undefined) {
 			return value;
 		}
+		value = value.trim();
 		if (value === 'transparent') {
 			return ImageTransform.colors.white;
 		}
@@ -267,6 +286,22 @@ module.exports = class ImageTransform {
 			value = value.split('').map(character => character + character).join('');
 		}
 		return value;
+	}
+
+	/**
+	 * Sanitize an image transform color list value.
+	 * @param {String} value - The color list to sanitize. A comma-delimited list of hex codes and named colors.
+	 * @param {String} [errorMessage] - The error message to use when a color in the list is invalid.
+	 * @throws Will throw an error if a color in the list is invalid.
+	 * @static
+	 */
+	static sanitizeColorListValue(value, errorMessage = 'Expected a list of valid colors') {
+		if (value === undefined) {
+			return value;
+		}
+		return value.split(',').map(color => {
+			return ImageTransform.sanitizeColorValue(color, errorMessage);
+		});
 	}
 
 	/**

--- a/lib/middleware/handle-errors.js
+++ b/lib/middleware/handle-errors.js
@@ -10,7 +10,7 @@ function createErrorHandler(config) {
 		/* eslint no-unused-vars:0 */
 		error = sanitizeError(error);
 		const explanation = explanations[error.status] || '';
-		let stack;
+		let stack = '';
 
 		if (config.environment !== 'production') {
 			stack = `

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -30,11 +30,11 @@ function processImage(config) {
 		// If the image is an SVG with a tint parameter then
 		// we need to route it through the /images/svgtint
 		// endpoint. This involves modifying the URI.
-		if ((transform.format === 'svg' || /\.svg/i.test(transform.uri)) && request.query.tint) {
+		if ((transform.format === 'svg' || /\.svg/i.test(transform.uri)) && transform.tint) {
 			const encodedUri = encodeURIComponent(transform.uri);
 			// We only use the first comma-delimited tint colour
 			// that we find, additional colours are obsolete
-			const tint = request.query.tint.split(',')[0];
+			const tint = transform.tint[0];
 			const hostname = (config.hostname || request.hostname);
 			transform.setUri(`${request.protocol}://${hostname}/v2/images/svgtint/${encodedUri}?color=${tint}`);
 		}

--- a/test/unit/lib/middleware/process-image-request.js
+++ b/test/unit/lib/middleware/process-image-request.js
@@ -102,21 +102,21 @@ describe('lib/middleware/process-image-request', () => {
 				assert.calledWithExactly(next);
 			});
 
-			describe('when the image transform format is "svg" and `request.query.tint` is set', () => {
+			describe('when the image transform format is "svg" and tint is set', () => {
 
 				beforeEach(() => {
 					mockImageTransform.format = 'svg';
+					mockImageTransform.tint = ['ff0000'];
 					mockImageTransform.uri = 'transform-uri?foo';
 					mockImageTransform.setUri = sinon.spy();
 					express.mockRequest.protocol = 'proto';
 					express.mockRequest.hostname = 'hostname';
-					express.mockRequest.query.tint = 'f00';
 					middleware(express.mockRequest, express.mockResponse, next);
 				});
 
 				it('sets the image transform `uri` property to route through the SVG tinter', () => {
 					assert.calledOnce(mockImageTransform.setUri);
-					assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://hostname/v2/images/svgtint/transform-uri%3Ffoo?color=f00');
+					assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://hostname/v2/images/svgtint/transform-uri%3Ffoo?color=ff0000');
 				});
 
 				describe('when `config.hostname` is set', () => {
@@ -129,7 +129,7 @@ describe('lib/middleware/process-image-request', () => {
 
 					it('sets the image transform `uri` property to route through the SVG tinter', () => {
 						assert.calledOnce(mockImageTransform.setUri);
-						assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://config-hostname/v2/images/svgtint/transform-uri%3Ffoo?color=f00');
+						assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://config-hostname/v2/images/svgtint/transform-uri%3Ffoo?color=ff0000');
 					});
 
 				});


### PR DESCRIPTION
It's more testable here and allows us to use `ImageTransform`'s colour name conversion stuff. E.g. `red` to `#ff0000`.