### PR TITLE
Anonymise user requests before proxying to a third party

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -6,6 +6,7 @@ const httpProxy = require('http-proxy');
 const morgan = require('morgan');
 const notFound = require('./middleware/not-found');
 const oneWeek = 60 * 60 * 24 * 7;
+const pkg = require('../package.json');
 const requireAll = require('require-all');
 const url = require('url');
 
@@ -46,6 +47,9 @@ function createProxy(errorHandler) {
 
 	function proxyRequestHandler(proxyRequest, request, response, proxyOptions) {
 		proxyRequest.setHeader('Host', url.parse(proxyOptions.target).host);
+		proxyRequest.setHeader('User-Agent', `${pkg.name}/${pkg.version}`);
+		proxyRequest.removeHeader('Cookie');
+		console.log(proxyRequest._headers);
 	}
 
 	function proxyResponseHandler(proxyResponse) {

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -45,13 +45,28 @@ function createProxy(errorHandler) {
 	proxy.on('proxyRes', proxyResponseHandler);
 	proxy.on('error', errorHandler);
 
+	const requestHeaderWhitelist = [
+		'accept',
+		'accept-encoding',
+		'accept-language'
+	];
+
+	// Handle proxy requests, allowing modification of a request
+	// before it is proxied
 	function proxyRequestHandler(proxyRequest, request, response, proxyOptions) {
+
+		// Remove non-whitelisted headers from the proxy request
+		Object.keys(request.headers)
+			.filter(header => !requestHeaderWhitelist.includes(header))
+			.forEach(header => proxyRequest.removeHeader(header));
+
+		// Set our own headers to send to the third party
 		proxyRequest.setHeader('Host', url.parse(proxyOptions.target).host);
 		proxyRequest.setHeader('User-Agent', `${pkg.name}/${pkg.version}`);
-		proxyRequest.removeHeader('Cookie');
-		console.log(proxyRequest._headers);
 	}
 
+	// Handle proxy responses, allowing modification of a response
+	// before sending it to the user
 	function proxyResponseHandler(proxyResponse) {
 		const originalHeaders = proxyResponse.headers;
 

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const path = require('path');
+const pkg = require('../../../package.json');
 const sinon = require('sinon');
 
 describe('lib/image-service', () => {
@@ -105,6 +106,14 @@ describe('lib/image-service', () => {
 
 			it('should set the `Host` header of the proxy request to the host in `proxyOptions.target`', () => {
 				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'Host', 'foo.bar');
+			});
+
+			it('should set the `User-Agent` header of the proxy request to the image service name/version', () => {
+				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'User-Agent', `${pkg.name}/${pkg.version}`);
+			});
+
+			it('should remove the `Cookie` header of the proxy request', () => {
+				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'Cookie');
 			});
 
 		});

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -99,9 +99,32 @@ describe('lib/image-service', () => {
 					target: 'http://foo.bar/baz/qux'
 				};
 				proxyRequest = httpProxy.mockProxyRequest;
-				request = {};
+				request = {
+					headers: {
+						'accept-encoding': 'bar',
+						'accept-language': 'baz',
+						'accept': 'foo',
+						'cookie': 'qux',
+						'host': 'www.example.com',
+						'user-agent': 'test',
+						'x-identifying-information': 'oops'
+					}
+				};
 				response = {};
 				handler(proxyRequest, request, response, proxyOptions);
+			});
+
+			it('should remove all non-whitelisted headers from the proxy request', () => {
+				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'cookie');
+				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'host');
+				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'user-agent');
+				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'x-identifying-information');
+			});
+
+			it('should leave all whitelisted headers from the proxy request intact', () => {
+				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept-encoding');
+				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept-language');
+				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept');
 			});
 
 			it('should set the `Host` header of the proxy request to the host in `proxyOptions.target`', () => {
@@ -110,10 +133,6 @@ describe('lib/image-service', () => {
 
 			it('should set the `User-Agent` header of the proxy request to the image service name/version', () => {
 				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'User-Agent', `${pkg.name}/${pkg.version}`);
-			});
-
-			it('should remove the `Cookie` header of the proxy request', () => {
-				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'Cookie');
 			});
 
 		});

--- a/test/unit/mock/http-proxy.mock.js
+++ b/test/unit/mock/http-proxy.mock.js
@@ -12,6 +12,7 @@ const mockProxyServer = module.exports.mockProxyServer = {
 };
 
 module.exports.mockProxyRequest = {
+	removeHeader: sinon.spy(),
 	setHeader: sinon.spy()
 };
 


### PR DESCRIPTION
This attempts to address #27 by removing potential personal data from the request before proxying it to a third party. Currently we're setting the `User-Agent` header to the image service, and then removing cookies.

Are there any other common headers which might contain information that could identify the end user? I feel like I've probably missed a lot.