### PR TITLE
Add health-checks for Cloudinary and S3

### DIFF
--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const cloudinary = require('cloudinary');
+const pingInterval = 60 * 1000;
+
+let customSchemeCheckUrl;
+let cloudinaryCheckUrl;
+
+// Health checks
+const healthChecks = module.exports = {
+
+	// Service status store
+	statuses: {},
+
+	// Initialise the health-checks
+	init(config) {
+
+		cloudinary.config({
+			cloud_name: config.cloudinaryAccountName
+		});
+		customSchemeCheckUrl = (config.customSchemeStore || '').replace(/\/+$/, '') + '/fticon/v1/cross.svg';
+		cloudinaryCheckUrl = cloudinary.url('http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img', {
+			type: 'fetch'
+		});
+
+		// Ping services that the image service relies on
+		function pingServices() {
+			healthChecks.pingService('cloudinary', cloudinaryCheckUrl);
+			healthChecks.pingService('customSchemeStore', customSchemeCheckUrl);
+		}
+
+		pingServices();
+		setInterval(pingServices, pingInterval);
+	},
+
+	// Ping a service and record its status
+	pingService(name, url) {
+		return fetch(url)
+			.then(response => {
+				healthChecks.statuses[name] = response.ok;
+			})
+			.catch(() => {
+				healthChecks.statuses[name] = false;
+			});
+	},
+
+	// Check that the Cloudinary is available
+	cloudinary: {
+		getStatus: () => ({
+			name: 'Images can be transformed with Cloudinary',
+			ok: healthChecks.statuses.cloudinary,
+			severity: 2,
+			businessImpact: 'Users may not be able to view images if they\'re not pre-cached',
+			technicalSummary: 'Transforms an image with Cloudinary and checks that it responds successfully',
+			panicGuide: 'Check the cloudinary status page http://status.cloudinary.com/'
+		})
+	},
+
+	// Check that the custom scheme store (S3 bucket) is available
+	customSchemeStore: {
+		getStatus: () => ({
+			name: 'Image sets can be retrieved from the custom scheme store',
+			ok: healthChecks.statuses.customSchemeStore,
+			severity: 2,
+			businessImpact: 'Users may not be able to use custom schemes (e.g. fticon) if they\'re not pre-cached',
+			technicalSummary: 'Hits the given url and checks that it responds successfully',
+			panicGuide: 'Check that the bucket still exists and that the AWS Region is up',
+			url: customSchemeCheckUrl
+		})
+	}
+};

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -2,6 +2,7 @@
 
 const express = require('@financial-times/n-express');
 const handleErrors = require('./middleware/handle-errors');
+const healthChecks = require('./health-checks');
 const httpProxy = require('http-proxy');
 const morgan = require('morgan');
 const notFound = require('./middleware/not-found');
@@ -19,6 +20,8 @@ function imageService(config) {
 	app.proxy = createProxy(errorHandler);
 	app.imageServiceConfig = config;
 
+	healthChecks.init(config);
+
 	app.use(morgan('combined'));
 	mountRoutes(app);
 	app.use(notFound);
@@ -31,7 +34,13 @@ function imageService(config) {
 }
 
 function createExpressApp() {
-	const app = express();
+	const app = express({
+		healthChecks: [
+			healthChecks.cloudinary,
+			healthChecks.customSchemeStore
+		],
+		healthChecksAppName: `Origami Image Service in ${process.env.REGION || 'unknown region'}`
+	});
 	app.enable('case sensitive routing');
 	return app;
 }

--- a/lib/routes/__gtg.js
+++ b/lib/routes/__gtg.js
@@ -3,7 +3,7 @@
 module.exports = app => {
 
 	app.get('/__gtg', (request, response) => {
-		response.status(200).end();
+		response.status(200).send('OK');
 	});
 
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "origami-image-service",
   "version": "0.0.0",
   "private": true,
-  "description": "Origami image service",
+  "description": "Optimises and resize images.",
   "keywords": [
     "origami"
   ],
@@ -23,7 +23,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@financial-times/n-express": "^16",
+    "@financial-times/n-express": "^17",
     "cloudinary": "^1",
     "colornames": "^1",
     "dotenv": "^2",

--- a/test/unit/lib/health-checks.js
+++ b/test/unit/lib/health-checks.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+describe('lib/health-checks', () => {
+	let healthChecks;
+
+	beforeEach(() => {
+		global.fetch = sinon.stub();
+		healthChecks = require('../../../lib/health-checks');
+	});
+
+	it('exports an object', () => {
+		assert.isObject(healthChecks);
+	});
+
+	it('has an `init` method', () => {
+		assert.isFunction(healthChecks.init);
+	});
+
+	describe('.init(config)', () => {
+
+		beforeEach(() => {
+			healthChecks.pingService = sinon.stub();
+			sinon.stub(global, 'setInterval');
+			healthChecks.init({
+				cloudinaryAccountName: 'testaccount',
+				customSchemeStore: 'http://foo/'
+			});
+		});
+
+		afterEach(() => {
+			global.setInterval.restore();
+		});
+
+		it('calls `pingService` with a Cloudinary URL', () => {
+			assert.calledWithExactly(healthChecks.pingService, 'cloudinary', 'http://res.cloudinary.com/testaccount/image/fetch/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img');
+		});
+
+		it('calls `pingService` with a custom scheme URL', () => {
+			assert.calledWithExactly(healthChecks.pingService, 'customSchemeStore', 'http://foo/fticon/v1/cross.svg');
+		});
+
+		it('sets an interval to ping the services again', () => {
+			assert.calledOnce(global.setInterval);
+			assert.isFunction(global.setInterval.firstCall.args[0]);
+			assert.strictEqual(global.setInterval.firstCall.args[1], 60 * 1000);
+		});
+
+		describe('when no custom scheme store is specified in the config', () => {
+
+			beforeEach(() => {
+				healthChecks.pingService.reset();
+				healthChecks.init({
+					cloudinaryAccountName: 'testaccount'
+				});
+			});
+
+			it('calls `pingService` with the expected default store', () => {
+				assert.calledWithExactly(healthChecks.pingService, 'customSchemeStore', '/fticon/v1/cross.svg');
+			});
+
+		});
+
+	});
+
+	it('has a `pingService` method', () => {
+		assert.isFunction(healthChecks.pingService);
+	});
+
+	describe('.pingService(name, url)', () => {
+
+		beforeEach(() => {
+			global.fetch.resolves({
+				ok: true
+			});
+			return healthChecks.pingService('foo', 'bar');
+		});
+
+		it('fetches the given URL', () => {
+			assert.calledOnce(global.fetch);
+			assert.calledWithExactly(global.fetch, 'bar');
+		});
+
+		it('sets the status of the check to `true`', () => {
+			assert.isTrue(healthChecks.statuses.foo);
+		});
+
+		describe('when the response from the URL is not OK', () => {
+
+			beforeEach(() => {
+				global.fetch.resolves({
+					ok: false
+				});
+				return healthChecks.pingService('foo', 'bar');
+			});
+
+			it('sets the status of the check to `false`', () => {
+				assert.isFalse(healthChecks.statuses.foo);
+			});
+
+		});
+
+		describe('when the fetch errors', () => {
+
+			beforeEach(() => {
+				global.fetch.rejects('error');
+				return healthChecks.pingService('foo', 'bar');
+			});
+
+			it('sets the status of the check to `false`', () => {
+				assert.isFalse(healthChecks.statuses.foo);
+			});
+
+		});
+
+	});
+
+	it('has a `statuses` property', () => {
+		assert.isObject(healthChecks.statuses);
+		assert.deepEqual(healthChecks.statuses, {});
+	});
+
+	it('has a `cloudinary` property', () => {
+		assert.isObject(healthChecks.cloudinary);
+	});
+
+	describe('.cloudinary', () => {
+
+		it('has a `getStatus` method', () => {
+			assert.isFunction(healthChecks.cloudinary.getStatus);
+		});
+
+		describe('.getStatus()', () => {
+
+			it('returns an object', () => {
+				assert.isObject(healthChecks.cloudinary.getStatus());
+			});
+
+		});
+
+	});
+
+	it('has a `customSchemeStore` property', () => {
+		assert.isObject(healthChecks.customSchemeStore);
+	});
+
+	describe('.customSchemeStore', () => {
+
+		it('has a `getStatus` method', () => {
+			assert.isFunction(healthChecks.customSchemeStore.getStatus);
+		});
+
+		describe('.getStatus()', () => {
+
+			it('returns an object', () => {
+				assert.isObject(healthChecks.customSchemeStore.getStatus());
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/health-checks.mock.js
+++ b/test/unit/mock/health-checks.mock.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	init: sinon.stub(),
+	cloudinary: sinon.stub(),
+	customSchemeStore: sinon.stub()
+};


### PR DESCRIPTION
This gets us some of the way towards completing #33, adding in health-checks for Cloudinary and the S3 bucket we use to store image sets.