### PR TITLE
Disable tinting of SVG strokes for compatibility

### DIFF
--- a/lib/middleware/tint-svg.js
+++ b/lib/middleware/tint-svg.js
@@ -18,7 +18,10 @@ function tintSvg() {
 		// validation here
 		let tintStream;
 		try {
-			tintStream = new SvgTintStream({color});
+			tintStream = new SvgTintStream({
+				color,
+				stroke: false
+			});
 		} catch (error) {
 			error.status = 400;
 			return next(error);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "request": "^2",
     "require-all": "^2",
     "statuses": "^1",
-    "svg-tint-stream": "^0.2"
+    "svg-tint-stream": "^0.3"
   },
   "devDependencies": {
     "chai": "^3",

--- a/test/unit/lib/middleware/tint-svg.js
+++ b/test/unit/lib/middleware/tint-svg.js
@@ -53,7 +53,8 @@ describe('lib/middleware/tint-svg', () => {
 				assert.calledOnce(SvgTintStream);
 				assert.calledWithNew(SvgTintStream);
 				assert.calledWith(SvgTintStream, {
-					color: express.mockRequest.query.color
+					color: express.mockRequest.query.color,
+					stroke: false
 				});
 			});
 
@@ -172,7 +173,8 @@ describe('lib/middleware/tint-svg', () => {
 
 				it('creates an SVG tint stream with "#000"', () => {
 					assert.calledWith(SvgTintStream, {
-						color: '#000'
+						color: '#000',
+						stroke: false
 					});
 				});
 


### PR DESCRIPTION
This is for backwards compatibility with v1 of the image service. Some SVGs break slightly if we tint the stroke colour too.