### PR TITLE
Redirect v2

### DIFF
--- a/lib/middleware/handle-errors.js
+++ b/lib/middleware/handle-errors.js
@@ -9,7 +9,7 @@ function createErrorHandler(config) {
 	return function handleErrors(error, request, response, next) {
 		/* eslint no-unused-vars:0 */
 		error = sanitizeError(error);
-		const explanation = explanations[error.status] || '';
+		const explanation = error.explanation || explanations[error.status] || '';
 
 		response.status(error.status).render('error', {
 			layout: 'layout',

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -4,7 +4,7 @@ module.exports = app => {
 
 	// Service home page
 	app.get('/', (request, response) => {
-		response.redirect(301, '/v1/');
+		response.redirect(301, '/v2/');
 	});
 
 };

--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -6,7 +6,10 @@ module.exports = app => {
 
 	// v1 documentation page (gone)
 	app.use('/v1', (request, response, next) => {
-		next(httpError(410));
+		const error = httpError(501);
+		const url = `http://image.webservices.ft.com/v1${request.url}`;
+		error.explanation = `Version 1 of the image service can be found at <a href="${url}">${url}</a>.`;
+		next(error);
 	});
 
 };

--- a/test/integration/home.js
+++ b/test/integration/home.js
@@ -8,8 +8,8 @@ describe('GET /', function() {
 	setupRequest('GET', '/');
 	itRespondsWithStatus(301);
 
-	it('redirects the request to the v1 documentation page', function(done) {
-		this.request.expect('Location', '/v1/').end(done);
+	it('redirects the request to the v2 documentation page', function(done) {
+		this.request.expect('Location', '/v2/').end(done);
 	});
 
 });

--- a/test/integration/v1/docs.js
+++ b/test/integration/v1/docs.js
@@ -6,6 +6,6 @@ const setupRequest = require('../helpers/setup-request');
 
 describe('GET /v1/', function() {
 	setupRequest('GET', '/v1/');
-	itRespondsWithStatus(410);
+	itRespondsWithStatus(501);
 	itRespondsWithContentType('text/html');
 });

--- a/views/error.html
+++ b/views/error.html
@@ -10,7 +10,7 @@
 							{{title}}: {{message}}
 						</h1>
 						{{#if explanation}}
-							<p>{{explanation}}</p>
+							<p>{{{explanation}}}</p>
 						{{/if}}
 					</div>
 				</div>


### PR DESCRIPTION
- **Switch to `501 Not Implemented` for `/v1` URLs:**  
   I think this makes more sense than `410 Gone`, as the resource will never have existed
- **Redirect the application index page to /v2:**  
   This makes more sense than redirecting to a `501` :)