### PR TITLE
Add ability to mount router at different locations

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-	baseUrl: process.env.BASE_URL || '',
+	baseUrl: process.env.BASE_URL || '/origami/service/image',
 	cloudinaryAccountName: process.env.CLOUDINARY_ACCOUNT_NAME,
 	customSchemeStore: process.env.CUSTOM_SCHEME_STORE,
 	environment: process.env.NODE_ENV || 'development',

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -107,9 +107,12 @@ function createProxy(errorHandler) {
 }
 
 function mountRoutes(app) {
+  const router = express.Router();
+  app.use(router);
+  app.use('/origami/service/image/', router);
 	requireAll({
 		dirname: `${__dirname}/routes`,
-		resolve: initRoute => initRoute(app)
+		resolve: initRoute => initRoute(app, router)
 	});
 }
 

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -107,7 +107,7 @@ function createProxy(errorHandler) {
 }
 
 function mountRoutes(app) {
-  const router = express.Router();
+  const router = express.Router(); // eslint-disable-line new-cap
   app.use(router);
   app.use('/origami/service/image/', router);
 	requireAll({

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -107,9 +107,9 @@ function createProxy(errorHandler) {
 }
 
 function mountRoutes(app) {
-  const router = express.Router(); // eslint-disable-line new-cap
-  app.use(router);
-  app.use('/origami/service/image/', router);
+	const router = express.Router(); // eslint-disable-line new-cap
+	app.use(router);
+	app.use('/origami/service/image/', router);
 	requireAll({
 		dirname: `${__dirname}/routes`,
 		resolve: initRoute => initRoute(app, router)

--- a/lib/routes/__gtg.js
+++ b/lib/routes/__gtg.js
@@ -1,8 +1,8 @@
 'use strict';
 
-module.exports = app => {
+module.exports = (app, router) => {
 
-	app.get('/__gtg', (request, response) => {
+	router.get('/__gtg', (request, response) => {
 		response.status(200).send('OK');
 	});
 

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -1,9 +1,8 @@
 'use strict';
-
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// Service home page
-	app.get('/', (request, response) => {
+	router.get('/', (request, response) => {
 		response.redirect(301, `${app.locals.baseUrl}v2/`);
 	});
 

--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -2,10 +2,10 @@
 
 const httpError = require('http-errors');
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// v1 documentation page (gone)
-	app.use('/v1', (request, response, next) => {
+	router.use('/v1', (request, response, next) => {
 		const error = httpError(501);
 		const url = `http://image.webservices.ft.com/v1${request.url}`;
 		error.explanation = `Version 1 of the image service can be found at <a href="${url}">${url}</a>.`;

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -2,10 +2,10 @@
 
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// v2 api documentation page
-	app.get('/v2/docs/api', (request, response) => {
+	router.get('/v2/docs/api', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/lib/routes/v2/docs/compare.js
+++ b/lib/routes/v2/docs/compare.js
@@ -3,10 +3,10 @@
 const images = require('../../../../data/comparison-images.json');
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// v2 image comparison page
-	app.get('/v2/docs/compare', (request, response) => {
+	router.get('/v2/docs/compare', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -2,10 +2,10 @@
 
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// v2 migration page
-	app.get('/v2/docs/migration', (request, response) => {
+	router.get('/v2/docs/migration', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/lib/routes/v2/images-debug.js
+++ b/lib/routes/v2/images-debug.js
@@ -4,7 +4,7 @@ const getCmsUrl = require('../../middleware/get-cms-url');
 const mapCustomScheme = require('../../middleware/map-custom-scheme');
 const processImageRequest = require('../../middleware/process-image-request');
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// Debug middleware to log transform information
 	function debug(request, response) {
@@ -17,7 +17,7 @@ module.exports = app => {
 	// Debug image with an HTTP or HTTPS scheme, matches:
 	// /v2/images/debug/https://...
 	// /v2/images/debug/http://...
-	app.get(
+	router.get(
 		/\/v2\/images\/debug\/(https?(:|%3A).*)$/,
 		processImageRequest(app.imageServiceConfig),
 		debug
@@ -30,7 +30,7 @@ module.exports = app => {
 	// /v2/images/debug/ftpodcast:...
 	// /v2/images/debug/ftlogo:...
 	// TODO make sure these default to the original exension! E.g. SVG for fticon
-	app.get(
+	router.get(
 		/^\/v2\/images\/debug\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/,
 		mapCustomScheme(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
@@ -39,7 +39,7 @@ module.exports = app => {
 
 	// Image with a custom scheme, matches:
 	// /v2/images/debug/ftcms:...
-	app.get(
+	router.get(
 		/^\/v2\/images\/debug\/((ftcms)(:|%3A).*)$/,
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),

--- a/lib/routes/v2/images-raw.js
+++ b/lib/routes/v2/images-raw.js
@@ -5,7 +5,7 @@ const httpError = require('http-errors');
 const mapCustomScheme = require('../../middleware/map-custom-scheme');
 const processImageRequest = require('../../middleware/process-image-request');
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// Proxy image middleware
 	function proxyImage(request, response) {
@@ -17,7 +17,7 @@ module.exports = app => {
 	// Image with an HTTP or HTTPS scheme, matches:
 	// /v2/images/raw/https://...
 	// /v2/images/raw/http://...
-	app.get(
+	router.get(
 		/\/v2\/images\/raw\/(https?(:|%3A).*)$/,
 		processImageRequest(app.imageServiceConfig),
 		proxyImage
@@ -30,7 +30,7 @@ module.exports = app => {
 	// /v2/images/raw/ftpodcast:...
 	// /v2/images/raw/ftlogo:...
 	// TODO make sure these default to the original exension! E.g. SVG for fticon
-	app.get(
+	router.get(
 		/^\/v2\/images\/raw\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/,
 		mapCustomScheme(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
@@ -39,7 +39,7 @@ module.exports = app => {
 
 	// Image with a custom scheme, matches:
 	// /v2/images/raw/ftcms:...
-	app.get(
+	router.get(
 		/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/,
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
@@ -48,7 +48,7 @@ module.exports = app => {
 
 	// Image with an imageset, matches:
 	// all other /v2/images/raw/...
-	app.get(/\/v2\/images\/raw\/?$/, (request, response, next) => {
+	router.get(/\/v2\/images\/raw\/?$/, (request, response, next) => {
 		// Not implemented, maybe we don't need to based on logs?
 		next(httpError(501));
 	});

--- a/lib/routes/v2/images-svgtint.js
+++ b/lib/routes/v2/images-svgtint.js
@@ -2,12 +2,12 @@
 
 const tintSvg = require('../../middleware/tint-svg');
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// Image with an HTTP or HTTPS scheme, matches:
 	// /v2/images/svgtint/https://...
 	// /v2/images/svgtint/http://...
-	app.get(
+	router.get(
 		/\/v2\/images\/svgtint\/(https?(:|%3A).*)$/,
 		tintSvg()
 	);

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -2,10 +2,10 @@
 
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = app => {
+module.exports = (app, router) => {
 
 	// v2 home page
-	app.get('/v2', (request, response) => {
+	router.get('/v2', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -18,7 +18,7 @@ before(function() {
 		log: mockLog,
 		logLevel: process.env.LOG_LEVEL || 'trace',
 		port: process.env.PORT || null,
-    baseUrl: ''
+		baseUrl: ''
 	})
 	.then(service => {
 		this.agent = supertest.agent(service);

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -17,7 +17,8 @@ before(function() {
 		environment: 'test',
 		log: mockLog,
 		logLevel: process.env.LOG_LEVEL || 'trace',
-		port: process.env.PORT || null
+		port: process.env.PORT || null,
+    baseUrl: ''
 	})
 	.then(service => {
 		this.agent = supertest.agent(service);

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -262,10 +262,10 @@ describe('lib/image-service', () => {
 			assert.isFunction(requireAll.firstCall.args[0].resolve);
 		});
 
-    it('mounts an express router at root and as `/origami/service/image/`', () => {
-      assert.calledWithExactly(express.mockApp.use, express.mockRouter);
-      assert.calledWithExactly(express.mockApp.use, '/origami/service/image/', express.mockRouter);
-    });
+		it('mounts an express router at root and as `/origami/service/image/`', () => {
+			assert.calledWithExactly(express.mockApp.use, express.mockRouter);
+			assert.calledWithExactly(express.mockApp.use, '/origami/service/image/', express.mockRouter);
+		});
 
 		it('calls each route with the Express application and Router', () => {
 			const route = sinon.spy();

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -262,11 +262,16 @@ describe('lib/image-service', () => {
 			assert.isFunction(requireAll.firstCall.args[0].resolve);
 		});
 
-		it('calls each route with the Express application', () => {
+    it('mounts an express router at root and as `/origami/service/image/`', () => {
+      assert.calledWithExactly(express.mockApp.use, express.mockRouter);
+      assert.calledWithExactly(express.mockApp.use, '/origami/service/image/', express.mockRouter);
+    });
+
+		it('calls each route with the Express application and Router', () => {
 			const route = sinon.spy();
 			requireAll.firstCall.args[0].resolve(route);
 			assert.calledOnce(route);
-			assert.calledWithExactly(route, express.mockApp);
+			assert.calledWithExactly(route, express.mockApp, express.mockRouter);
 		});
 
 		it('mounts middleware to handle routes that are not found', () => {

--- a/test/unit/mock/n-express.mock.js
+++ b/test/unit/mock/n-express.mock.js
@@ -17,6 +17,8 @@ const mockApp = module.exports.mockApp = {
 
 const mockServer = module.exports.mockServer = {};
 
+const mockRouter = module.exports.mockRouter = {};
+
 module.exports.mockRequest = {
 	query: {},
 	params: {}
@@ -32,3 +34,4 @@ module.exports.mockResponse = {
 
 mockApp.listen.resolves(mockServer);
 express.returns(mockApp);
+express.Router = sinon.stub().returns(mockRouter);


### PR DESCRIPTION
This adds the routehandlers to both the root path and to `origami/service/image` for use with next-router.