### PR TITLE
Rewrite CMS URLs

### DIFF
--- a/lib/middleware/convert-to-cms-scheme.js
+++ b/lib/middleware/convert-to-cms-scheme.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = convertToCmsScheme;
+
+function convertToCmsScheme() {
+	const cmsRegExp = /^https?:\/\/(?:com\.ft\.imagepublish\.prod\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.img)?$/i;
+	return (request, response, next) => {
+		const match = request.params[0].match(cmsRegExp);
+		if (match && match[1]) {
+			request.params[0] = `ftcms:${match[1]}`;
+		}
+		next();
+	};
+}

--- a/lib/routes/v2/images-debug.js
+++ b/lib/routes/v2/images-debug.js
@@ -18,7 +18,7 @@ module.exports = (app, router) => {
 	// /v2/images/debug/https://...
 	// /v2/images/debug/http://...
 	router.get(
-		/\/v2\/images\/debug\/(https?(:|%3A).*)$/,
+		/\/v2\/images\/debug\/(https?(:|%3A).*)$/i,
 		processImageRequest(app.imageServiceConfig),
 		debug
 	);
@@ -31,7 +31,7 @@ module.exports = (app, router) => {
 	// /v2/images/debug/ftlogo:...
 	// TODO make sure these default to the original exension! E.g. SVG for fticon
 	router.get(
-		/^\/v2\/images\/debug\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/,
+		/^\/v2\/images\/debug\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/i,
 		mapCustomScheme(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
 		debug
@@ -40,7 +40,7 @@ module.exports = (app, router) => {
 	// Image with a custom scheme, matches:
 	// /v2/images/debug/ftcms:...
 	router.get(
-		/^\/v2\/images\/debug\/((ftcms)(:|%3A).*)$/,
+		/^\/v2\/images\/debug\/((ftcms)(:|%3A).*)$/i,
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
 		debug

--- a/lib/routes/v2/images-raw.js
+++ b/lib/routes/v2/images-raw.js
@@ -14,22 +14,12 @@ module.exports = (app, router) => {
 		});
 	}
 
-	// Image with an HTTP or HTTPS scheme, matches:
-	// /v2/images/raw/https://...
-	// /v2/images/raw/http://...
-	router.get(
-		/\/v2\/images\/raw\/(https?(:|%3A).*)$/,
-		processImageRequest(app.imageServiceConfig),
-		proxyImage
-	);
-
 	// Image with a custom scheme, matches:
 	// /v2/images/raw/fticon:...
 	// /v2/images/raw/fthead:...
 	// /v2/images/raw/ftsocial:...
 	// /v2/images/raw/ftpodcast:...
 	// /v2/images/raw/ftlogo:...
-	// TODO make sure these default to the original exension! E.g. SVG for fticon
 	router.get(
 		/^\/v2\/images\/raw\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/,
 		mapCustomScheme(app.imageServiceConfig),
@@ -42,6 +32,15 @@ module.exports = (app, router) => {
 	router.get(
 		/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/,
 		getCmsUrl(app.imageServiceConfig),
+		processImageRequest(app.imageServiceConfig),
+		proxyImage
+	);
+
+	// Image with an HTTP or HTTPS scheme, matches:
+	// /v2/images/raw/https://...
+	// /v2/images/raw/http://...
+	router.get(
+		/\/v2\/images\/raw\/(https?(:|%3A).*)$/,
 		processImageRequest(app.imageServiceConfig),
 		proxyImage
 	);

--- a/lib/routes/v2/images-raw.js
+++ b/lib/routes/v2/images-raw.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const convertToCmsScheme = require('../../middleware/convert-to-cms-scheme');
 const getCmsUrl = require('../../middleware/get-cms-url');
 const httpError = require('http-errors');
 const mapCustomScheme = require('../../middleware/map-custom-scheme');
@@ -23,6 +24,19 @@ module.exports = (app, router) => {
 	router.get(
 		/^\/v2\/images\/raw\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/i,
 		mapCustomScheme(app.imageServiceConfig),
+		processImageRequest(app.imageServiceConfig),
+		proxyImage
+	);
+
+	// Image with an HTTP or HTTPS scheme that should be an ftcms URL, matches:
+	// /v2/images/raw/https://com.ft.imagepublish.prod.s3.amazonaws.com/...
+	// /v2/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/...
+	// /v2/images/raw/https://im.ft-static.com/...
+	// /v2/images/raw/http://im.ft-static.com/...
+	router.get(
+		/^\/v2\/images\/raw\/(https?(:|%3A)(\/|%2F){2}(com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
+		convertToCmsScheme(),
+		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
 		proxyImage
 	);

--- a/lib/routes/v2/images-raw.js
+++ b/lib/routes/v2/images-raw.js
@@ -21,7 +21,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/ftpodcast:...
 	// /v2/images/raw/ftlogo:...
 	router.get(
-		/^\/v2\/images\/raw\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/,
+		/^\/v2\/images\/raw\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/i,
 		mapCustomScheme(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
 		proxyImage
@@ -30,7 +30,7 @@ module.exports = (app, router) => {
 	// Image with a custom scheme, matches:
 	// /v2/images/raw/ftcms:...
 	router.get(
-		/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/,
+		/^\/v2\/images\/raw\/((ftcms)(:|%3A).*)$/i,
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
 		proxyImage
@@ -40,14 +40,14 @@ module.exports = (app, router) => {
 	// /v2/images/raw/https://...
 	// /v2/images/raw/http://...
 	router.get(
-		/\/v2\/images\/raw\/(https?(:|%3A).*)$/,
+		/\/v2\/images\/raw\/(https?(:|%3A).*)$/i,
 		processImageRequest(app.imageServiceConfig),
 		proxyImage
 	);
 
 	// Image with an imageset, matches:
 	// all other /v2/images/raw/...
-	router.get(/\/v2\/images\/raw\/?$/, (request, response, next) => {
+	router.get(/\/v2\/images\/raw\/?$/i, (request, response, next) => {
 		// Not implemented, maybe we don't need to based on logs?
 		next(httpError(501));
 	});

--- a/test/unit/lib/middleware/convert-to-cms-scheme.js
+++ b/test/unit/lib/middleware/convert-to-cms-scheme.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+
+describe('lib/middleware/convert-to-cms-scheme', () => {
+	let convertToCmsScheme;
+	let express;
+
+	beforeEach(() => {
+
+		express = require('../../mock/n-express.mock');
+		mockery.registerMock('express', express);
+
+		convertToCmsScheme = require('../../../../lib/middleware/convert-to-cms-scheme');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(convertToCmsScheme);
+	});
+
+	describe('convertToCmsScheme()', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = convertToCmsScheme();
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+
+			describe('when the request param (0) does not point to a known CMS image store', () => {
+
+				beforeEach(done => {
+					express.mockRequest.params[0] = 'http://foo.bar/image.jpg';
+					middleware(express.mockRequest, express.mockResponse, done);
+				});
+
+				it('does nothing to the request param (0)', () => {
+					assert.strictEqual(express.mockRequest.params[0], 'http://foo.bar/image.jpg');
+				});
+
+			});
+
+			describe('when the request param (0) points to an image in the imagepublish S3 bucket', () => {
+
+				beforeEach(done => {
+					express.mockRequest.params[0] = 'https://com.ft.imagepublish.prod.s3.amazonaws.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
+					middleware(express.mockRequest, express.mockResponse, done);
+				});
+
+				it('sets the request param (0) to an `ftcms` URL with the image ID', () => {
+					assert.strictEqual(express.mockRequest.params[0], 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
+				});
+
+			});
+
+			describe('when the request param (0) points to an image on im.ft-static.com', () => {
+
+				beforeEach(done => {
+					express.mockRequest.params[0] = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img';
+					middleware(express.mockRequest, express.mockResponse, done);
+				});
+
+				it('sets the request param (0) to an `ftcms` URL with the image ID', () => {
+					assert.strictEqual(express.mockRequest.params[0], 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
+				});
+
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR addresses #63, and brings v2 closer to the behaviour of v1. If a user requests a CMS image by using the full URL rather than the `ftcms` scheme, then behind the scenes we will rewrite it to make sure we take advantage of the CMS v1/v2 fallback behaviour.

This will also make it easier to correct URLs that point to region-specific S3 buckets in future.