### PR TITLE
Make transforms more consistent with v1 of the Image Service

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -466,10 +466,10 @@ module.exports = class ImageTransform {
 	 */
 	static get qualityValueMap() {
 		return {
-			lowest: 30,
-			low: 50,
-			medium: 70,
-			high: 80,
+			lowest: 35,
+			low: 55,
+			medium: 72,
+			high: 81,
 			highest: 90,
 			lossless: 100
 		};

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -134,11 +134,13 @@ module.exports = class ImageTransform {
 		const errorMessage = `Image format must be one of ${ImageTransform.validFormats.join(', ')}`;
 		this.format = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validFormats, errorMessage);
 		if (value === 'auto') {
-			if (/\.svg/i.test(this.uri)) {
-				return this.format = 'svg';
-			}
+			const pathname = url.parse(this.uri).pathname || '';
+			const extensionMatch = pathname.match(/\.(svg|png|jpg)$/i);
 			if (this.quality === 100) {
 				return this.format = 'png';
+			}
+			if (extensionMatch) {
+				return this.format = extensionMatch[1].toLowerCase();
 			}
 			this.format = 'jpg';
 		}

--- a/test/integration/v2/images-debug.js
+++ b/test/integration/v2/images-debug.js
@@ -20,11 +20,11 @@ describe('GET /v2/images/debug…', function() {
 				fit: 'cover',
 				format: 'jpg',
 				height: 456,
-				quality: 70,
+				quality: 72,
 				uri: testImageUris.http,
 				width: 123
 			},
-			appliedTransform: 'http://res.cloudinary.com/financial-times/image/fetch/c_fill,f_jpg,h_456,q_70,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
+			appliedTransform: 'http://res.cloudinary.com/financial-times/image/fetch/c_fill,f_jpg,h_456,q_72,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
 		}).end(done);
 	});
 

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -211,6 +211,28 @@ describe('lib/image-transform', () => {
 
 			});
 
+			describe('when `value` is "auto" and the `uri` property ends in ".png"', () => {
+
+				it('[get] returns "png"', () => {
+					ImageTransform.sanitizeEnumerableValue.restore();
+					instance.setUri('http://example.com/foo.png?a=b');
+					instance.setFormat();
+					assert.strictEqual(instance.getFormat(), 'png');
+				});
+
+			});
+
+			describe('when `value` is "auto" and the `uri` property ends in an unknown extension', () => {
+
+				it('[get] returns "jpg"', () => {
+					ImageTransform.sanitizeEnumerableValue.restore();
+					instance.setUri('http://example.com/foo.img?a=b');
+					instance.setFormat();
+					assert.strictEqual(instance.getFormat(), 'jpg');
+				});
+
+			});
+
 		});
 
 		describe('.setQuality() / .getQuality()', () => {

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -894,10 +894,10 @@ describe('lib/image-transform', () => {
 
 	it('has a `qualityValueMap` static property', () => {
 		assert.deepEqual(ImageTransform.qualityValueMap, {
-			lowest: 30,
-			low: 50,
-			medium: 70,
-			high: 80,
+			lowest: 35,
+			low: 55,
+			medium: 72,
+			high: 81,
 			highest: 90,
 			lossless: 100
 		});

--- a/test/unit/lib/transformers/cloudinary.js
+++ b/test/unit/lib/transformers/cloudinary.js
@@ -31,7 +31,7 @@ describe('lib/transformers/cloudinary', () => {
 		});
 
 		it('returns a Cloudinary fetch URL', () => {
-			assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_70/http://example.com/');
+			assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_72/http://example.com/');
 		});
 
 		describe('when `transform` has a `width` property', () => {
@@ -42,7 +42,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_70,w_123/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_72,w_123/http://example.com/');
 			});
 
 		});
@@ -55,7 +55,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,h_123,q_70/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,h_123,q_72/http://example.com/');
 			});
 
 		});
@@ -68,7 +68,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,dpr_2,f_jpg,q_70/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,dpr_2,f_jpg,q_72/http://example.com/');
 			});
 
 		});
@@ -81,7 +81,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fit,f_jpg,q_70/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fit,f_jpg,q_72/http://example.com/');
 			});
 
 		});
@@ -94,7 +94,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_70/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_72/http://example.com/');
 			});
 
 		});
@@ -107,7 +107,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_limit,f_jpg,q_70/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_limit,f_jpg,q_72/http://example.com/');
 			});
 
 		});
@@ -120,7 +120,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_png,q_70/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_png,q_72/http://example.com/');
 			});
 
 		});
@@ -133,7 +133,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_30/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_jpg,q_35/http://example.com/');
 			});
 
 		});
@@ -146,7 +146,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/b_rgb:ff0000,c_fill,f_jpg,q_70/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/b_rgb:ff0000,c_fill,f_jpg,q_72/http://example.com/');
 			});
 
 		});

--- a/test/unit/lib/transformers/imgix.js
+++ b/test/unit/lib/transformers/imgix.js
@@ -31,7 +31,7 @@ describe('lib/transformers/imgix', () => {
 		});
 
 		it('returns an Imgix fetch URL', () => {
-			assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=crop');
+			assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=crop');
 		});
 
 		describe('when `transform` has a `width` property', () => {
@@ -42,7 +42,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=crop&w=123');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=crop&w=123');
 			});
 
 		});
@@ -55,7 +55,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=crop&h=123');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=crop&h=123');
 			});
 
 		});
@@ -68,7 +68,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=crop&dpr=2');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=crop&dpr=2');
 			});
 
 		});
@@ -81,7 +81,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=clip');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=clip');
 			});
 
 		});
@@ -94,7 +94,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=crop');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=crop');
 			});
 
 		});
@@ -107,7 +107,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=max');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=max');
 			});
 
 		});
@@ -120,7 +120,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=png&quality=70&fit=crop');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=png&quality=72&fit=crop');
 			});
 
 		});
@@ -133,7 +133,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=30&fit=crop');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=35&fit=crop');
 			});
 
 		});
@@ -146,7 +146,7 @@ describe('lib/transformers/imgix', () => {
 			});
 
 			it('returns the expected Imgix fetch URL', () => {
-				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=70&fit=crop&bg=ff0000');
+				assert.strictEqual(imgixUrl, 'https://foo-source.imgix.net/http%3A%2F%2Fexample.com%2F?fm=jpg&quality=72&fit=crop&bg=ff0000');
 			});
 
 		});


### PR DESCRIPTION
- Use the same quality numbers as v1
- Default the image format correctly based on file extension