### PR TITLE
Ignore the bgcolor parameter for PNGs and SVGs

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -178,6 +178,9 @@ module.exports = class ImageTransform {
 	 */
 	setBgcolor(value) {
 		const errorMessage = 'Image bgcolor must be a valid hex code or color name';
+		if (this.format === 'png' || this.format === 'svg') {
+			return this.bgcolor = undefined;
+		}
 		this.bgcolor = ImageTransform.sanitizeColorValue(value, errorMessage);
 	}
 

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -36,7 +36,7 @@ describe('lib/image-transform', () => {
 				dpr: 2,
 				fit: 'scale-down',
 				quality: 'lossless',
-				format: 'png',
+				format: 'jpg',
 				bgcolor: '00ff00',
 				tint: 'f00,00f'
 			};
@@ -281,6 +281,26 @@ describe('lib/image-transform', () => {
 
 			it('[get] returns the sanitized `value`', () => {
 				assert.strictEqual(instance.getBgcolor(), 'sanitized');
+			});
+
+			describe('when `value` is valid and the `format` property is "png"', () => {
+
+				it('[get] returns `undefined`', () => {
+					instance.setFormat('png');
+					instance.setBgcolor('foo');
+					assert.isUndefined(instance.getBgcolor());
+				});
+
+			});
+
+			describe('when `value` is valid and the `format` property is "svg"', () => {
+
+				it('[get] returns `undefined`', () => {
+					instance.setFormat('svg');
+					instance.setBgcolor('foo');
+					assert.isUndefined(instance.getBgcolor());
+				});
+
 			});
 
 		});


### PR DESCRIPTION
This now matches the behaviour of Image Service v1.