### PR TITLE
Add default image-format as a catch-all

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -103,7 +103,8 @@ function createProxy(errorHandler) {
 
 		const validImageFormatHeaders = [
 			'webp',
-			'jpegxr'
+			'jpegxr',
+			'default'
 		];
 		if (validImageFormatHeaders.includes(request.headers['ft-image-format'])) {
 			proxyResponse.headers['FT-Image-Format'] = request.headers['ft-image-format'];


### PR DESCRIPTION
If the user's browser does not support `webp` or `jpegxr`, we should set a the ft-image-format key with a default value to ensure that our cdn can vary with it.