### PR TITLE
Comparison sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,7 @@ run:
 
 run-dev:
 	@nodemon --ext html,js,json index.js
+
+
+fetch-comparison-data:
+	@./scripts/fetch-comparison-data.js

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ make verify
 
 We run the tests and linter on CI, you can view [results on CircleCI][ci]. `make test` and `make lint` must pass before we merge a pull request.
 
+### Comparison page
+
+The comparison page in the documentation (`/origami/service/image/v2/docs/compare`) is used to manually check images against their version 1 equivalent. This page is powered by [a JSON file](data/comparison-images.json) which is updated manually.
+
+Once you've added a new comparison image to this file, you should run the following Make task to update the file sizes and formats:
+
+```sh
+make fetch-comparison-data
+```
+
+Then you should commit your changes.
+
 
 Deployment
 ----------

--- a/data/comparison-images.json
+++ b/data/comparison-images.json
@@ -4,7 +4,9 @@
 		"description": "An image with no transforms applied.",
 		"shouldMatch": true,
 		"uri": "ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2",
-		"transform": ""
+		"transform": "",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "82674"
 	},
 	{
 		"name": "Sizing",
@@ -15,21 +17,27 @@
 		"description": "An image with just a width transform applied.",
 		"shouldMatch": true,
 		"uri": "ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2",
-		"transform": "width=200"
+		"transform": "width=200",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "10042"
 	},
 	{
 		"name": "Height",
 		"description": "An image with just a height transform applied.",
 		"shouldMatch": true,
 		"uri": "ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2",
-		"transform": "height=150"
+		"transform": "height=150",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "15783"
 	},
 	{
 		"name": "Width and height",
 		"description": "An image with width and height transforms applied.",
 		"shouldMatch": true,
 		"uri": "ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2",
-		"transform": "width=200&height=200"
+		"transform": "width=200&height=200",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "15571"
 	},
 	{
 		"name": "Cropping strategies",
@@ -40,21 +48,27 @@
 		"description": "An image with width and height transforms applied, and a fit transform set to 'cover'.",
 		"shouldMatch": true,
 		"uri": "ftcms:b35b7a62-8fce-11e6-8df8-d3778b55a923",
-		"transform": "width=200&height=200&fit=cover"
+		"transform": "width=200&height=200&fit=cover",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "11544"
 	},
 	{
 		"name": "Width, height, and contain",
 		"description": "An image with width and height transforms applied, and a fit transform set to 'contain'.",
 		"shouldMatch": true,
 		"uri": "ftcms:b35b7a62-8fce-11e6-8df8-d3778b55a923",
-		"transform": "width=200&height=200&fit=contain"
+		"transform": "width=200&height=200&fit=contain",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "7118"
 	},
 	{
 		"name": "Width, height, and scale-down",
 		"description": "An image with width and height transforms applied, and a fit transform set to 'scale-down'.",
 		"shouldMatch": true,
 		"uri": "ftcms:b35b7a62-8fce-11e6-8df8-d3778b55a923",
-		"transform": "width=200&height=200&fit=scale-down"
+		"transform": "width=200&height=200&fit=scale-down",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "7118"
 	},
 	{
 		"name": "Device pixel ratio",
@@ -65,14 +79,18 @@
 		"description": "An image with a width transform applied, and dpr transform set to 1.",
 		"shouldMatch": true,
 		"uri": "ftcms:2dac88f0-b273-4e48-9c7d-9078db39db55",
-		"transform": "width=200&dpr=1"
+		"transform": "width=200&dpr=1",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "10488"
 	},
 	{
 		"name": "Width and DPR 2",
 		"description": "An image with a width transform applied, and dpr transform set to 2.",
 		"shouldMatch": true,
 		"uri": "ftcms:2dac88f0-b273-4e48-9c7d-9078db39db55",
-		"transform": "width=200&dpr=2"
+		"transform": "width=200&dpr=2",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "15808"
 	},
 	{
 		"name": "Quality",
@@ -83,42 +101,54 @@
 		"description": "An image with the quality transform set to 'lowest'.",
 		"shouldMatch": true,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "width=250&quality=lowest"
+		"transform": "width=250&quality=lowest",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "1956"
 	},
 	{
 		"name": "Low",
 		"description": "An image with the quality transform set to 'low'.",
 		"shouldMatch": true,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "width=250&quality=low"
+		"transform": "width=250&quality=low",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "2968"
 	},
 	{
 		"name": "Medium",
 		"description": "An image with the quality transform set to 'medium'.",
 		"shouldMatch": true,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "width=250&quality=medium"
+		"transform": "width=250&quality=medium",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "8572"
 	},
 	{
 		"name": "High",
 		"description": "An image with the quality transform set to 'high'.",
 		"shouldMatch": true,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "width=250&quality=high"
+		"transform": "width=250&quality=high",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "10183"
 	},
 	{
 		"name": "Highest",
 		"description": "An image with the quality transform set to 'highest'.",
 		"shouldMatch": true,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "width=250&quality=highest"
+		"transform": "width=250&quality=highest",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "20011"
 	},
 	{
 		"name": "Lossless",
 		"description": "An image with the quality transform set to 'lossless'.",
 		"shouldMatch": true,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "width=250&quality=lossless"
+		"transform": "width=250&quality=lossless",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "87296"
 	},
 	{
 		"name": "Format",
@@ -129,42 +159,54 @@
 		"description": "An image converted to a JPEG.",
 		"shouldMatch": true,
 		"uri": "ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2",
-		"transform": "format=jpg"
+		"transform": "format=jpg",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "82674"
 	},
 	{
 		"name": "PNG",
 		"description": "An image converted to a PNG.",
 		"shouldMatch": true,
 		"uri": "ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2",
-		"transform": "format=png"
+		"transform": "format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "1238752"
 	},
 	{
 		"name": "GIF",
 		"description": "An image converted to a GIF. Will not match because v1 does not support conversion to GIF.",
 		"shouldMatch": false,
 		"uri": "ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2",
-		"transform": "format=gif"
+		"transform": "format=gif",
+		"v1ImageFormat": "text/html;charset=UTF-8",
+		"v1ImageSize": "1712"
 	},
 	{
 		"name": "SVG",
 		"description": "An SVG image served as SVG.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg",
-		"transform": "format=svg"
+		"transform": "format=svg",
+		"v1ImageFormat": "image/svg+xml",
+		"v1ImageSize": "68630"
 	},
 	{
 		"name": "SVG to PNG",
 		"description": "A simple SVG converted to a PNG image.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg",
-		"transform": "format=png"
+		"transform": "format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "2355"
 	},
 	{
 		"name": "SVG to PNG",
 		"description": "A complex SVG converted to a PNG image. Will not match because v1 does not deal with compound paths in SVGs.",
 		"shouldMatch": false,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg",
-		"transform": "format=png"
+		"transform": "format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "61946"
 	},
 	{
 		"name": "Custom schemes",
@@ -175,42 +217,54 @@
 		"description": "A headshot image using the 'fthead' scheme.",
 		"shouldMatch": true,
 		"uri": "fthead:lionel-barber",
-		"transform": "width=200&format=png"
+		"transform": "width=200&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "14553"
 	},
 	{
 		"name": "FTICON",
 		"description": "An icon using the 'fticon' scheme.",
 		"shouldMatch": true,
 		"uri": "fticon:cross",
-		"transform": "width=100&format=png"
+		"transform": "width=100&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "2041"
 	},
 	{
 		"name": "FTICON-V1",
 		"description": "An icon using the 'fticon-v1' scheme.",
 		"shouldMatch": true,
 		"uri": "fticon-v1:cross",
-		"transform": "width=100&format=png"
+		"transform": "width=100&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "719"
 	},
 	{
 		"name": "FTLOGO",
 		"description": "An icon using the 'ftlogo' scheme.",
 		"shouldMatch": true,
 		"uri": "ftlogo:brand-ft-logo-square",
-		"transform": "width=100&format=png"
+		"transform": "width=100&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "1514"
 	},
 	{
 		"name": "FTPODCAST",
 		"description": "An icon using the 'ftpodcast' scheme.",
 		"shouldMatch": true,
 		"uri": "ftpodcast:arts",
-		"transform": "width=100&format=png"
+		"transform": "width=100&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "8834"
 	},
 	{
 		"name": "FTSOCIAL",
 		"description": "An icon using the 'ftsocial' scheme.",
 		"shouldMatch": true,
 		"uri": "ftsocial:twitter",
-		"transform": "format=svg"
+		"transform": "format=svg",
+		"v1ImageFormat": "image/svg+xml",
+		"v1ImageSize": "890"
 	},
 	{
 		"name": "Background colour",
@@ -221,28 +275,36 @@
 		"description": "A transparent PNG with a background set to '#ffff00'. The background should not appear as the image supports transparency.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png",
-		"transform": "bgcolor=ffff00&format=png"
+		"transform": "bgcolor=ffff00&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "218144"
 	},
 	{
 		"name": "PNG with background converted to JPEG",
 		"description": "A transparent PNG converted to a JPEG with a background set to '#ffff00'.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png",
-		"transform": "bgcolor=ffff00&format=jpg"
+		"transform": "bgcolor=ffff00&format=jpg",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "20419"
 	},
 	{
 		"name": "PNG with background converted to JPEG",
 		"description": "A transparent PNG converted to a JPEG with a background set to 'hotpink'.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png",
-		"transform": "bgcolor=hotpink&format=jpg"
+		"transform": "bgcolor=hotpink&format=jpg",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "19414"
 	},
 	{
 		"name": "SVG with background converted to JPEG",
 		"description": "An SVG with transparency converted to a JPEG with a background set to 'hotpink'.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg",
-		"transform": "bgcolor=hotpink&format=jpg&width=100"
+		"transform": "bgcolor=hotpink&format=jpg&width=100",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "2047"
 	},
 	{
 		"name": "Tinting",
@@ -253,34 +315,44 @@
 		"description": "A simple SVG image with the tint transform set.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg",
-		"transform": "tint=ff0000,ff0000&format=svg"
+		"transform": "tint=ff0000,ff0000&format=svg",
+		"v1ImageFormat": "image/svg+xml",
+		"v1ImageSize": "1270"
 	},
 	{
 		"name": "SVG with tint",
 		"description": "A complex SVG image with the tint transform set.",
 		"shouldMatch": true,
 		"uri": "https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg",
-		"transform": "tint=ff0000,ff0000&format=svg"
+		"transform": "tint=ff0000,ff0000&format=svg",
+		"v1ImageFormat": "image/svg+xml",
+		"v1ImageSize": "68671"
 	},
 	{
 		"name": "JPEG with tint",
 		"description": "A JPEG image with the tint transform set to the default value. Will not match because v2 does not support tinting of non-SVG images.",
 		"shouldMatch": false,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "tint"
+		"transform": "tint",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "331374"
 	},
 	{
 		"name": "JPEG with tint",
 		"description": "A JPEG image with the tint transform set to red. Will not match because v2 does not support tinting of non-SVG images.",
 		"shouldMatch": false,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "tint=ff0000"
+		"transform": "tint=ff0000",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "424110"
 	},
 	{
 		"name": "JPEG with tint",
 		"description": "A JPEG image with the tint transform set to red and green. Will not match because v2 does not support tinting of non-SVG images.",
 		"shouldMatch": false,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
-		"transform": "tint=ff0000,00ff00"
+		"transform": "tint=ff0000,00ff00",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "171304"
 	}
 ]

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -124,6 +124,7 @@ function mountRoutes(app) {
 	app.get('/__gtg', (request, response) => {
 		response.status(200).send('OK');
 	});
+	app.use(app.imageServiceConfig.basePath, express.static('public'));
 	app.use(app.imageServiceConfig.basePath, router);
 	requireAll({
 		dirname: `${__dirname}/routes`,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "http-errors": "^1",
     "http-proxy": "^1",
     "imgix-core-js": "^1",
+    "isomorphic-fetch": "^2.2.1",
     "morgan": "^1",
     "request": "^2",
     "require-all": "^2",

--- a/public/.eslintrc.js
+++ b/public/.eslintrc.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+	"env": {
+		"browser": true,
+		"es6": false,
+		"node": false
+	},
+	"rules": {
+		"strict": [2, "function"],
+		"no-var": 0
+	}
+}

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,83 @@
+(function() {
+	'use strict';
+
+	// Selectors used in the comparison component
+	var selectors = {
+		component: '[data-component=comparison]',
+		roles: {
+			v1Image: '[data-component-role=v1-image]',
+			v1ImageFormat: '[data-component-role=v1-image-format]',
+			v1ImageSize: '[data-component-role=v1-image-size]',
+			v2Image: '[data-component-role=v2-image]',
+			v2ImageFormat: '[data-component-role=v2-image-format]',
+			v2ImageSize: '[data-component-role=v2-image-size]'
+		},
+		classes: {
+			match: 'comparison-image-match--yes',
+			noMatch: 'comparison-image-match--no',
+		}
+	};
+
+	// Create comparisons
+	document.addEventListener('o.DOMContentLoaded', function() {
+		Array.from(document.querySelectorAll(selectors.component)).forEach(createComparison);
+	});
+
+	// Create a comparison component
+	function createComparison(element) {
+
+		// Get all the component elements
+		var elements = {
+			main: element
+		};
+		Object.keys(selectors.roles).map(function(key) {
+			elements[key] = elements.main.querySelector(selectors.roles[key]);
+		});
+
+		// Data store
+		var imageData = {
+			v1Format: elements.v1ImageFormat.innerText,
+			v1Size: parseInt(elements.v1ImageSize.innerText, 10),
+			v2Format: null,
+			v2Size: null
+		};
+
+		// Fetch the v2 image and fill out details
+		fetch(elements.v2Image.src, {
+			headers: {
+				Accept: (supportsWebP() ? 'image/webp,*/*' : '*/*')
+			}
+		}).then(function(response) {
+			elements.v2ImageFormat.innerHTML = imageData.v2Format = response.headers.get('Content-Type');
+			elements.v2ImageSize.innerHTML = imageData.v2Size = parseInt(response.headers.get('Content-Length'), 10);
+			addComparisonColors();
+		});
+
+		function addComparisonColors() {
+			if (imageData.v1Format === imageData.v2Format || imageData.v2Format === 'image/webp') {
+				elements.v1ImageFormat.classList.add(selectors.classes.match);
+				elements.v2ImageFormat.classList.add(selectors.classes.match);
+			} else {
+				elements.v1ImageFormat.classList.add(selectors.classes.noMatch);
+				elements.v2ImageFormat.classList.add(selectors.classes.noMatch);
+			}
+			if (imageData.v1Size >= imageData.v2Size) {
+				elements.v1ImageSize.classList.add(selectors.classes.noMatch);
+				elements.v2ImageSize.classList.add(selectors.classes.match);
+			} else {
+				elements.v1ImageSize.classList.add(selectors.classes.match);
+				elements.v2ImageSize.classList.add(selectors.classes.noMatch);
+			}
+		}
+
+		function supportsWebP() {
+			var canvas = document.createElement('canvas');
+			if (!!(canvas.getContext && canvas.getContext('2d'))) {
+				return (canvas.toDataURL('image/webp').indexOf('data:image/webp') == 0);
+			}
+			return false;
+		}
+
+	}
+
+}());

--- a/public/main.js
+++ b/public/main.js
@@ -44,6 +44,7 @@
 
 		// Fetch the v2 image and fill out details
 		fetch(elements.v2Image.src, {
+			method: 'HEAD',
 			headers: {
 				Accept: (supportsWebP() ? 'image/webp,*/*' : '*/*')
 			}

--- a/public/main.js
+++ b/public/main.js
@@ -69,16 +69,16 @@
 				elements.v1ImageSize.classList.add(selectors.classes.match);
 				elements.v2ImageSize.classList.add(selectors.classes.noMatch);
 			}
-			const percentageDifference = ((imageData.v2Size - imageData.v1Size) / imageData.v1Size) * 100;
-			const percentageDifferenceAbs = Math.abs(Math.round(percentageDifference));
-			const label = (percentageDifference < 0 ? 'smaller' : 'larger');
-			elements.v2ImageSize.innerHTML += ` (${percentageDifferenceAbs}% ${label})`
+			var percentageDifference = ((imageData.v2Size - imageData.v1Size) / imageData.v1Size) * 100;
+			var percentageDifferenceAbs = Math.abs(Math.round(percentageDifference));
+			var label = (percentageDifference < 0 ? 'smaller' : 'larger');
+			elements.v2ImageSize.innerHTML += ' (' + percentageDifferenceAbs + '% ' +label + ')';
 		}
 
 		function supportsWebP() {
 			var canvas = document.createElement('canvas');
 			if (!!(canvas.getContext && canvas.getContext('2d'))) {
-				return (canvas.toDataURL('image/webp').indexOf('data:image/webp') == 0);
+				return (canvas.toDataURL('image/webp').indexOf('data:image/webp') === 0);
 			}
 			return false;
 		}

--- a/public/main.js
+++ b/public/main.js
@@ -68,6 +68,10 @@
 				elements.v1ImageSize.classList.add(selectors.classes.match);
 				elements.v2ImageSize.classList.add(selectors.classes.noMatch);
 			}
+			const percentageDifference = ((imageData.v2Size - imageData.v1Size) / imageData.v1Size) * 100;
+			const percentageDifferenceAbs = Math.abs(Math.round(percentageDifference));
+			const label = (percentageDifference < 0 ? 'smaller' : 'larger');
+			elements.v2ImageSize.innerHTML += ` (${percentageDifferenceAbs}% ${label})`
 		}
 
 		function supportsWebP() {

--- a/public/main.js
+++ b/public/main.js
@@ -30,7 +30,7 @@
 		var elements = {
 			main: element
 		};
-		Object.keys(selectors.roles).map(function(key) {
+		Object.keys(selectors.roles).forEach(function(key) {
 			elements[key] = elements.main.querySelector(selectors.roles[key]);
 		});
 

--- a/scripts/fetch-comparison-data.js
+++ b/scripts/fetch-comparison-data.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict';
+
+const comparisonImagesPath = `${__dirname}/../data/comparison-images.json`;
+const comparisonImages = require(comparisonImagesPath);
+const fs = require('fs');
+require('isomorphic-fetch');
+
+fetchImages(comparisonImages).then(results => {
+	console.log(`Saving image info to "${comparisonImagesPath}"`);
+	fs.writeFileSync(comparisonImagesPath, JSON.stringify(results, null, '\t'));
+});
+
+function fetchImages(images) {
+	return Promise.all(images.map(fetchImage));
+}
+
+function fetchImage(image) {
+	if (image.isSection) {
+		return image;
+	}
+	return fetch(getImageUrl(image)).then(response => {
+		console.log(`Loaded image "${response.url}"`);
+		image.v1ImageFormat = response.headers.get('Content-Type');
+		image.v1ImageSize = response.headers.get('Content-Length');
+		return image;
+	});
+}
+
+function getImageUrl(image) {
+	const uri = encodeURIComponent(image.uri);
+	return `https://image.webservices.ft.com/v1/images/raw/${uri}?source=comparison&${image.transform}`;
+}

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -318,6 +318,12 @@ describe('lib/image-service', () => {
 			assert.isFunction(requireAll.firstCall.args[0].resolve);
 		});
 
+		it('mounts a static middleware at `config.basePath`', () => {
+			assert.calledOnce(express.static);
+			assert.calledWithExactly(express.static, 'public');
+			assert.calledWithExactly(express.mockApp.use, config.basePath, express.mockStaticMiddleware);
+		});
+
 		it('mounts an express router at `config.basePath`', () => {
 			assert.calledWithExactly(express.mockApp.use, config.basePath, express.mockRouter);
 		});

--- a/test/unit/mock/n-express.mock.js
+++ b/test/unit/mock/n-express.mock.js
@@ -19,6 +19,8 @@ const mockServer = module.exports.mockServer = {};
 
 const mockRouter = module.exports.mockRouter = {};
 
+const mockStaticMiddleware = module.exports.mockStaticMiddleware = {};
+
 module.exports.mockRequest = {
 	query: {},
 	params: {}
@@ -35,3 +37,4 @@ module.exports.mockResponse = {
 mockApp.listen.resolves(mockServer);
 express.returns(mockApp);
 express.Router = sinon.stub().returns(mockRouter);
+express.static = sinon.stub().returns(mockStaticMiddleware);

--- a/views/compare.html
+++ b/views/compare.html
@@ -35,7 +35,7 @@
 									</th>
 								</tr>
 							{{else}}
-								<tr>
+								<tr data-component="comparison">
 									<td class="comparison-result-column">
 										<p>
 											<b>{{name}}{{#description}}:{{/description}}</b>
@@ -51,13 +51,25 @@
 											{{/shouldMatch}}
 										</p>
 									</td>
-									<td class="comparison-result-column" data-component="comparison-image">
-										<img src="{{v1Url}}" alt="{{name}}" /><br/>
+									<td class="comparison-result-column">
+										<img src="{{v1Url}}" alt="{{name}}" data-component-role="v1-image"/><br/>
 										<a href="{{v1Url}}">Image served through v1</a>
+										<dl>
+											<dt>Image format</dt>
+											<dd data-component-role="v1-image-format">{{v1ImageFormat}}</dd>
+											<dt>Image size</dt>
+											<dd data-component-role="v1-image-size">{{v1ImageSize}}</dd>
+										</dl>
 									</td>
-									<td class="comparison-result-column" data-component="comparison-image">
-										<img src="{{v2Url}}" alt="{{name}}" /><br/>
+									<td class="comparison-result-column">
+										<img src="{{v2Url}}" alt="{{name}}" data-component-role="v2-image"/><br/>
 										<a href="{{v2Url}}">Image served through v2</a>
+										<dl>
+											<dt>Image format</dt>
+											<dd data-component-role="v2-image-format">-</dd>
+											<dt>Image size</dt>
+											<dd data-component-role="v2-image-size">-</dd>
+										</dl>
 									</td>
 								</tr>
 							{{/if}}

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -77,7 +77,7 @@
 	</style>
 
 	<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-icons@^4.2.0" />
-	<script src="//polyfill.webservices.ft.com/v2/polyfill.min.js"></script>
+	<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 	<script>
 		(function(src) {
 			if (cutsTheMustard) {
@@ -89,6 +89,7 @@
 			}
 		}('https://origami-build.ft.com/v2/bundles/js?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-icons@^4.2.0'));
 	</script>
+	<script src="main.js"></script>
 
 </head>
 <body class="o-techdocs">


### PR DESCRIPTION
Add image formats and sizes to the comparison page. The v1 URLs are static and set in the comparison JSON; the v2 URLs are fetched on page load so that we can inspect the response information.

This allows us to manually (for now) ensure that changes we make do not result in a size gain for common images.