### PR TITLE
Tweak the quality values when image DPR is set

### DIFF
--- a/data/comparison-images.json
+++ b/data/comparison-images.json
@@ -148,7 +148,61 @@
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
 		"transform": "width=250&quality=lossless",
 		"v1ImageFormat": "image/png",
-		"v1ImageSize": "87296"
+		"v1ImageSize": "79304"
+	},
+	{
+		"name": "Lowest and DPR 2",
+		"description": "An image with the quality transform set to 'lowest' and a DPR of 2.",
+		"shouldMatch": true,
+		"uri": "ftcms:03b32b22-91a0-11e6-a72e-b428cb934b78",
+		"transform": "width=250&quality=lowest&dpr=2",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "6011"
+	},
+	{
+		"name": "Low and DPR 2",
+		"description": "An image with the quality transform set to 'low' and a DPR of 2.",
+		"shouldMatch": true,
+		"uri": "ftcms:03b32b22-91a0-11e6-a72e-b428cb934b78",
+		"transform": "width=250&quality=low&dpr=2",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "11487"
+	},
+	{
+		"name": "Medium and DPR 2",
+		"description": "An image with the quality transform set to 'medium' and a DPR of 2.",
+		"shouldMatch": true,
+		"uri": "ftcms:03b32b22-91a0-11e6-a72e-b428cb934b78",
+		"transform": "width=250&quality=medium&dpr=2",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "14435"
+	},
+	{
+		"name": "High and DPR 2",
+		"description": "An image with the quality transform set to 'high' and a DPR of 2.",
+		"shouldMatch": true,
+		"uri": "ftcms:03b32b22-91a0-11e6-a72e-b428cb934b78",
+		"transform": "width=250&quality=high&dpr=2",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "10498"
+	},
+	{
+		"name": "Highest and DPR 2",
+		"description": "An image with the quality transform set to 'highest' and a DPR of 2.",
+		"shouldMatch": true,
+		"uri": "ftcms:03b32b22-91a0-11e6-a72e-b428cb934b78",
+		"transform": "width=250&quality=highest&dpr=2",
+		"v1ImageFormat": "image/jpeg",
+		"v1ImageSize": "14153"
+	},
+	{
+		"name": "Lossless and DPR 2",
+		"description": "An image with the quality transform set to 'lossless' and a DPR of 2.",
+		"shouldMatch": true,
+		"uri": "ftcms:03b32b22-91a0-11e6-a72e-b428cb934b78",
+		"transform": "width=250&quality=lossless&dpr=2",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "302592"
 	},
 	{
 		"name": "Format",
@@ -237,7 +291,7 @@
 		"uri": "fticon-v1:cross",
 		"transform": "width=100&format=png",
 		"v1ImageFormat": "image/png",
-		"v1ImageSize": "719"
+		"v1ImageSize": "650"
 	},
 	{
 		"name": "FTLOGO",

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -150,7 +150,11 @@ module.exports = class ImageTransform {
 	setQuality(value = 'medium') {
 		const errorMessage = `Image quality must be one of ${ImageTransform.validQualities.join(', ')}`;
 		const quality = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validQualities, errorMessage);
-		this.quality = ImageTransform.qualityValueMap[quality];
+		if (this.dpr && this.dpr > 1) {
+			this.quality = ImageTransform.qualityValueMapDpr[quality];
+		} else {
+			this.quality = ImageTransform.qualityValueMap[quality];
+		}
 	}
 
 	/**
@@ -461,11 +465,25 @@ module.exports = class ImageTransform {
 	 */
 	static get qualityValueMap() {
 		return {
-			lowest: 35,
-			low: 55,
+			lowest: 30,
+			low: 50,
 			medium: 72,
 			high: 81,
 			highest: 90,
+			lossless: 100
+		};
+	}
+
+	/**
+	 * @private
+	 */
+	static get qualityValueMapDpr() {
+		return {
+			lowest: 18,
+			low: 25,
+			medium: 35,
+			high: 45,
+			highest: 55,
 			lossless: 100
 		};
 	}

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -916,4 +916,14 @@ describe('lib/image-transform', () => {
 		});
 	});
 
+	describe('.qualityValueMapDpr', () => {
+
+		it('has values that are lower than or equal to their equivalent in `qualityValueMap`', () => {
+			ImageTransform.validQualities.forEach((quality) => {
+				assert.isAtMost(ImageTransform.qualityValueMapDpr[quality], ImageTransform.qualityValueMap[quality]);
+			});
+		});
+
+	});
+
 });

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -206,6 +206,20 @@ describe('lib/image-transform', () => {
 				assert.strictEqual(instance.getQuality(), 100);
 			});
 
+			describe('when `value` is valid and the `dpr` property is set', () => {
+
+				beforeEach(() => {
+					ImageTransform.sanitizeEnumerableValue.returns('medium');
+					instance.setDpr(2);
+					instance.setQuality('medium');
+				});
+
+				it('[get] returns a numeric representation of the sanitized `value` for images with higher DPRs', () => {
+					assert.strictEqual(instance.getQuality(), 35);
+				});
+
+			});
+
 		});
 
 		describe('.setBgcolor() / .getBgcolor()', () => {
@@ -882,11 +896,22 @@ describe('lib/image-transform', () => {
 
 	it('has a `qualityValueMap` static property', () => {
 		assert.deepEqual(ImageTransform.qualityValueMap, {
-			lowest: 35,
-			low: 55,
+			lowest: 30,
+			low: 50,
 			medium: 72,
 			high: 81,
 			highest: 90,
+			lossless: 100
+		});
+	});
+
+	it('has a `qualityValueMapDpr` static property', () => {
+		assert.deepEqual(ImageTransform.qualityValueMapDpr, {
+			lowest: 18,
+			low: 25,
+			medium: 35,
+			high: 45,
+			highest: 55,
 			lossless: 100
 		});
 	});

--- a/test/unit/lib/transformers/cloudinary.js
+++ b/test/unit/lib/transformers/cloudinary.js
@@ -133,7 +133,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_auto,q_35/http://example.com/');
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,f_auto,q_30/http://example.com/');
 			});
 
 		});


### PR DESCRIPTION
We now have a different quality map for when a DPR is set, this ensures
that high-DPR images aren't huge in terms of file size.

This should address #73

(yes I know there's still an imgix transformer in there, I'll remove in another PR)