### PR TITLE
Support tinting of non-SVG images

### DIFF
--- a/data/comparison-images.json
+++ b/data/comparison-images.json
@@ -148,7 +148,7 @@
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
 		"transform": "width=250&quality=lossless",
 		"v1ImageFormat": "image/png",
-		"v1ImageSize": "79304"
+		"v1ImageSize": "87296"
 	},
 	{
 		"name": "Lowest and DPR 2",
@@ -419,8 +419,17 @@
 		"v1ImageSize": "68671"
 	},
 	{
+		"name": "SVG with tint converted to PNG",
+		"description": "A complex SVG image with the tint transform set and converted to PNG.",
+		"shouldMatch": true,
+		"uri": "https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg",
+		"transform": "tint=ff0000,00ff00&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "2356"
+	},
+	{
 		"name": "JPEG with tint",
-		"description": "A JPEG image with the tint transform set to the default value. Will not match because v2 does not support tinting of non-SVG images.",
+		"description": "A JPEG image with the tint transform set to the default value. Will not match exactly because the v2 tinting process is different.",
 		"shouldMatch": false,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
 		"transform": "tint",
@@ -429,7 +438,7 @@
 	},
 	{
 		"name": "JPEG with tint",
-		"description": "A JPEG image with the tint transform set to red. Will not match because v2 does not support tinting of non-SVG images.",
+		"description": "A JPEG image with the tint transform set to red. Will not match exactly because the v2 tinting process is different.",
 		"shouldMatch": false,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
 		"transform": "tint=ff0000",
@@ -438,7 +447,7 @@
 	},
 	{
 		"name": "JPEG with tint",
-		"description": "A JPEG image with the tint transform set to red and green. Will not match because v2 does not support tinting of non-SVG images.",
+		"description": "A JPEG image with the tint transform set to red and green. Will not match exactly because the v2 tinting process is different.",
 		"shouldMatch": false,
 		"uri": "ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1",
 		"transform": "tint=ff0000,00ff00",

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -37,6 +37,9 @@ function processImage(config) {
 			const hostname = (config.hostname || request.hostname);
 			const basePath = config.basePath || '';
 			transform.setUri(`${request.protocol}://${hostname}${basePath}/v2/images/svgtint/${encodedUri}?color=${tint}`);
+			// Clear the tint so that SVGs converted to rasterised
+			// formats don't get double-tinted
+			transform.setTint();
 		}
 
 		// Create a Cloudinary transform

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -32,6 +32,10 @@ function buildCloudinaryTransforms(transform) {
 		background: (transform.getBgcolor() ? `#${transform.getBgcolor()}` : undefined),
 		crop: getCloudinaryCropStrategy(transform.getFit())
 	};
+	const tint = transform.getTint();
+	if (tint) {
+		cloudinaryTransforms.effect = `tint:100:${tint.join(':')}`;
+	}
 	return cloudinaryTransforms;
 }
 

--- a/test/unit/lib/middleware/process-image-request.js
+++ b/test/unit/lib/middleware/process-image-request.js
@@ -98,6 +98,7 @@ describe('lib/middleware/process-image-request', () => {
 					mockImageTransform.tint = ['ff0000'];
 					mockImageTransform.uri = 'transform-uri?foo';
 					mockImageTransform.setUri = sinon.spy();
+					mockImageTransform.setTint = sinon.spy();
 					express.mockRequest.protocol = 'proto';
 					express.mockRequest.hostname = 'hostname';
 					middleware(express.mockRequest, express.mockResponse, next);
@@ -106,6 +107,11 @@ describe('lib/middleware/process-image-request', () => {
 				it('sets the image transform `uri` property to route through the SVG tinter', () => {
 					assert.calledOnce(mockImageTransform.setUri);
 					assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://hostname/v2/images/svgtint/transform-uri%3Ffoo?color=ff0000');
+				});
+
+				it('removes the tint property from the image transform', () => {
+					assert.calledOnce(mockImageTransform.setTint);
+					assert.calledWithExactly(mockImageTransform.setTint);
 				});
 
 				describe('when `config.hostname` is set', () => {

--- a/test/unit/lib/transformers/cloudinary.js
+++ b/test/unit/lib/transformers/cloudinary.js
@@ -151,6 +151,32 @@ describe('lib/transformers/cloudinary', () => {
 
 		});
 
+		describe('when `transform` has a `tint` property with one color', () => {
+
+			beforeEach(() => {
+				transform.setTint('f00');
+				cloudinaryUrl = cloudinaryTransform(transform, options);
+			});
+
+			it('returns the expected Cloudinary fetch URL', () => {
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,e_tint:100:ff0000,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/');
+			});
+
+		});
+
+		describe('when `transform` has a `tint` property with two colors', () => {
+
+			beforeEach(() => {
+				transform.setTint('f00,0f0');
+				cloudinaryUrl = cloudinaryTransform(transform, options);
+			});
+
+			it('returns the expected Cloudinary fetch URL', () => {
+				assert.strictEqual(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/fetch/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/');
+			});
+
+		});
+
 		describe('when `transform` is not an instance of ImageTransform', () => {
 
 			it('throws an error', () => {

--- a/views/migration.html
+++ b/views/migration.html
@@ -77,8 +77,9 @@
 			<h3>Tint</h3>
 
 			<p>
-				The <code>tint</code> query parameter no longer works with JPEG or PNG images. SVG
-				images can still be tinted, and they no longer require a colour to be specified twice.
+				The <code>tint</code> query parameter has changed, with results differing from v1.
+				You can see the differences illustrated on <a href="v2/docs/compare">the comparison page</a>.
+				SVG images can still be tinted, and they no longer require a colour to be specified twice.
 			</p>
 
 			<h3>Compression</h3>


### PR DESCRIPTION
So I know we agreed to deprecate this, but Cloudinary's support is
actually pretty good. The tints are different, but I think would allow
us to safely redirect tinted v1 images once we drop support for it.

<img width="584" alt="screen shot 2016-10-20 at 09 20 20" src="https://cloud.githubusercontent.com/assets/138944/19552135/7bcc471e-96a6-11e6-986b-17da89b41a36.png">
