### PR TITLE
Set the format when requesting images with custom schemes

### DIFF
--- a/data/comparison-images.json
+++ b/data/comparison-images.json
@@ -321,6 +321,42 @@
 		"v1ImageSize": "890"
 	},
 	{
+		"name": "FTICON-V1",
+		"description": "An icon using the 'fticon-v1' scheme.",
+		"shouldMatch": true,
+		"uri": "fticon-v1:cross",
+		"transform": "width=100&format=png",
+		"v1ImageFormat": "image/png",
+		"v1ImageSize": "650"
+	},
+	{
+		"name": "FTICON with no format set",
+		"description": "An icon using the 'fticon' scheme with no format set.",
+		"shouldMatch": true,
+		"uri": "fticon:cross",
+		"transform": "",
+		"v1ImageFormat": "image/svg+xml",
+		"v1ImageSize": "265"
+	},
+	{
+		"name": "FTICON-V1 with no format set",
+		"description": "An icon using the 'fticon-v1' scheme with no format set.",
+		"shouldMatch": true,
+		"uri": "fticon-v1:cross",
+		"transform": "",
+		"v1ImageFormat": "image/svg+xml",
+		"v1ImageSize": "212"
+	},
+	{
+		"name": "FTICON with no format set and a background color",
+		"description": "An icon using the 'fticon' scheme with no format set and a background color.",
+		"shouldMatch": true,
+		"uri": "fticon:cross",
+		"transform": "bgcolor=ff0000",
+		"v1ImageFormat": "image/svg+xml",
+		"v1ImageSize": "265"
+	},
+	{
 		"name": "Background colour",
 		"isSection": true
 	},

--- a/lib/middleware/map-custom-scheme.js
+++ b/lib/middleware/map-custom-scheme.js
@@ -7,13 +7,29 @@ module.exports = mapCustomScheme;
 function mapCustomScheme(config) {
 	return (request, response, next) => {
 
+		const originalUrl = request.params[0];
+		let customSchemeUrl;
+
 		// Replace any custom schemes in the request URI with
 		// their HTTP/HTTPS equivalents.
 		try {
-			request.params[0] = ImageTransform.resolveCustomSchemeUri(request.params[0], config.customSchemeStore);
+			customSchemeUrl = ImageTransform.resolveCustomSchemeUri(originalUrl, config.customSchemeStore);
 		} catch (error) {
 			error.status = 400;
 			return next(error);
+		}
+
+		// If the custom scheme URL has been set, make sure
+		// we default the extension correctly
+		if (customSchemeUrl !== originalUrl) {
+			request.params[0] = customSchemeUrl;
+
+			// If the custom scheme URL has been set, make sure
+			// we default the format correctly
+			if (!request.query.format) {
+				const match = customSchemeUrl.match(/\.(png|svg)$/);
+				request.query.format = (match ? match[1] : undefined);
+			}
 		}
 
 		next();

--- a/test/unit/lib/middleware/map-custom-scheme.js
+++ b/test/unit/lib/middleware/map-custom-scheme.js
@@ -46,7 +46,7 @@ describe('lib/middleware/map-custom-scheme', () => {
 			beforeEach(() => {
 				next = sinon.spy();
 				express.mockRequest.params[0] = 'foo:bar';
-				ImageTransform.resolveCustomSchemeUri.returns('http://foo.bar/');
+				ImageTransform.resolveCustomSchemeUri.returns('http://mock-store/foo/bar.svg');
 				middleware(express.mockRequest, express.mockResponse, next);
 			});
 
@@ -59,9 +59,79 @@ describe('lib/middleware/map-custom-scheme', () => {
 				assert.strictEqual(express.mockRequest.params[0], ImageTransform.resolveCustomSchemeUri.firstCall.returnValue);
 			});
 
+			it('sets the `format` query parameter to the resolved URLs file extension', () => {
+				assert.strictEqual(express.mockRequest.query.format, 'svg');
+			});
+
 			it('calls `next` with no error', () => {
 				assert.calledOnce(next);
 				assert.calledWithExactly(next);
+			});
+
+			describe('when `ImageTransform.resolveCustomSchemeUri` returns the original URL untouched', () => {
+
+				beforeEach(() => {
+					next.reset();
+					express.mockRequest.params[0] = 'foo:bar';
+					delete express.mockRequest.query.format;
+					ImageTransform.resolveCustomSchemeUri.returns(express.mockRequest.params[0]);
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not change the request param (0)', () => {
+					assert.strictEqual(express.mockRequest.params[0], 'foo:bar');
+				});
+
+				it('does not change the `format` query parameter', () => {
+					assert.isUndefined(express.mockRequest.query.format);
+				});
+
+				it('calls `next` with no error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
+			});
+
+			describe('when the `format` query parameter is already set', () => {
+
+				beforeEach(() => {
+					next.reset();
+					express.mockRequest.params[0] = 'foo:bar';
+					express.mockRequest.query.format = 'foo';
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not change the `format` query parameter', () => {
+					assert.strictEqual(express.mockRequest.query.format, 'foo');
+				});
+
+				it('calls `next` with no error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
+			});
+
+			describe('when the resolved URL does not have a valid extension', () => {
+
+				beforeEach(() => {
+					next.reset();
+					express.mockRequest.params[0] = 'foo:bar';
+					delete express.mockRequest.query.format;
+					ImageTransform.resolveCustomSchemeUri.returns('http://mock-store/foo/bar.img');
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not set the `format` query parameter', () => {
+					assert.isUndefined(express.mockRequest.query.format);
+				});
+
+				it('calls `next` with no error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
 			});
 
 			describe('when `ImageTransform.resolveCustomSchemeUri` throws', () => {


### PR DESCRIPTION
This matches the behaviour of v1, and means that FTICON SVGs are
returned as SVGs by default when no format parameter is set.

Resolves #94