### PR TITLE
Use PREFERRED_HOSTNAME as hostname if it is set

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@ module.exports = {
 	cloudinaryAccountName: process.env.CLOUDINARY_ACCOUNT_NAME,
 	customSchemeStore: process.env.CUSTOM_SCHEME_STORE,
 	environment: process.env.NODE_ENV || 'development',
-	hostname: process.env.HOSTNAME,
+	hostname: process.env.PREFERRED_HOSTNAME || process.env.HOSTNAME,
 	log: console,
 	logLevel: process.env.LOG_LEVEL || 'info',
 	port: process.env.PORT || 8080


### PR DESCRIPTION
The way to get svg-tinting to work from a local running image-service is to expose it to the internet using something like ngrok.io. In order for this to work we need to override what the hostname is.