### PR TITLE
Move image vary code from cdn to application

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -115,18 +115,21 @@ function createProxy(errorHandler) {
 			'Vary': originalHeaders['vary']
 		};
 
-		const validImageFormatHeaders = [
-			'webp',
-			'jpegxr',
-			'default'
-		];
-		if (validImageFormatHeaders.includes(request.headers['ft-image-format'])) {
-			proxyResponse.headers['FT-Image-Format'] = request.headers['ft-image-format'];
+		if (request.headers['accept'] && request.headers['accept'].includes('image/webp')) {
+			proxyResponse.headers['FT-Image-Format'] = 'webp';
+		} else if (/edge/.test(request.headers['ft-normalised-ua']) ||
+			/iemobile\/\d{2}/.test(request.headers['ft-normalised-ua']) ||
+			/ie\/(9|10|11)/.test(request.headers['ft-normalised-ua'])) {
+			proxyResponse.headers['FT-Image-Format'] = 'jpegxr';
+		} else {
+			proxyResponse.headers['FT-Image-Format'] = 'default';
 		}
 
 		if (request.transform && request.transform.getDpr()) {
 			proxyResponse.headers['Content-Dpr'] = request.transform.getDpr();
 		}
+
+		proxyResponse.headers['Vary'] = 'FT-image-format, Content-Dpr';
 
 	}
 

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -212,8 +212,9 @@ describe('lib/image-service', () => {
 					'Connection': 'keep-alive',
 					'Etag': '123',
 					'Expires': 'Thu, 08 Jan 1970 00:00:10 GMT',
+					'FT-Image-Format': 'default',
 					'Last-Modified': 'some time',
-					'Vary': undefined
+					'Vary': 'FT-image-format, Content-Dpr'
 				});
 			});
 
@@ -231,24 +232,68 @@ describe('lib/image-service', () => {
 
 			});
 
-			describe('when the request has an `FT-Image-Format` header set to "webp"', () => {
+			describe('when the request has an `accept` header which includes "image/webp"', () => {
 				beforeEach(() => {
-					request.headers['ft-image-format'] = 'webp';
+					request.headers['accept'] = 'image/webp';
 					handler(proxyResponse, request);
 				});
 
-				it('should echo the `FT-Image-Format` header in the response', () => {
+				it('should set the `FT-Image-Format` header in the response to "webp"', () => {
 					assert.strictEqual(httpProxy.mockProxyResponse.headers['FT-Image-Format'], 'webp');
 				});
 			});
 
-			describe('when the request has an `FT-Image-Format` header set to "jpegxr"', () => {
+			describe('when the request has an `FT-Normalised-UA` header set to "edge"', () => {
 				beforeEach(() => {
-					request.headers['ft-image-format'] = 'jpegxr';
+					request.headers['ft-normalised-ua'] = 'edge';
 					handler(proxyResponse, request);
 				});
 
-				it('should echo the `FT-Image-Format` header in the response', () => {
+				it('should set the `FT-Image-Format` header in the response to jpegxr', () => {
+					assert.strictEqual(httpProxy.mockProxyResponse.headers['FT-Image-Format'], 'jpegxr');
+				});
+			});
+
+			describe('when the request has an `FT-Normalised-UA` header set to "iemobile"', () => {
+				beforeEach(() => {
+					request.headers['ft-normalised-ua'] = 'iemobile/10';
+					handler(proxyResponse, request);
+				});
+
+				it('should set the `FT-Image-Format` header in the response to jpegxr', () => {
+					assert.strictEqual(httpProxy.mockProxyResponse.headers['FT-Image-Format'], 'jpegxr');
+				});
+			});
+
+			describe('when the request has an `FT-Normalised-UA` header set to "ie/9"', () => {
+				beforeEach(() => {
+					request.headers['ft-normalised-ua'] = 'ie/9';
+					handler(proxyResponse, request);
+				});
+
+				it('should set the `FT-Image-Format` header in the response to jpegxr', () => {
+					assert.strictEqual(httpProxy.mockProxyResponse.headers['FT-Image-Format'], 'jpegxr');
+				});
+			});
+
+			describe('when the request has an `FT-Normalised-UA` header set to "ie/10"', () => {
+				beforeEach(() => {
+					request.headers['ft-normalised-ua'] = 'ie/10';
+					handler(proxyResponse, request);
+				});
+
+				it('should set the `FT-Image-Format` header in the response to jpegxr', () => {
+					assert.strictEqual(httpProxy.mockProxyResponse.headers['FT-Image-Format'], 'jpegxr');
+				});
+			});
+
+			describe('when the request has an `FT-Normalised-UA` header set to "ie/11"', () => {
+				beforeEach(() => {
+					request.headers['ft-normalised-ua'] = 'ie/11';
+					handler(proxyResponse, request);
+				});
+
+				it('should set the `FT-Image-Format` header in the response to jpegxr', () => {
 					assert.strictEqual(httpProxy.mockProxyResponse.headers['FT-Image-Format'], 'jpegxr');
 				});
 			});


### PR DESCRIPTION
This is required for https://github.com/Financial-Times/ft.com-cdn/pull/256 to work.
```
=============================== Coverage summary ===============================
Statements   : 100% ( 356/356 )
Branches     : 100% ( 154/154 )
Functions    : 100% ( 58/58 )
Lines        : 100% ( 355/355 )
================================================================================
```