### PR TITLE
Remove the hack to serve pages on /origami/

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -143,12 +143,6 @@ function mountRoutes(app) {
 	});
 	app.use(app.imageServiceConfig.basePath, express.static('public'));
 	app.use(app.imageServiceConfig.basePath, router);
-
-	// 👇 Temporary
-	app.use('/origami/service/image', express.static('public'));
-	app.use('/origami/service/image', router);
-	// 👆 Temporary
-
 	requireAll({
 		dirname: `${__dirname}/routes`,
 		resolve: initRoute => initRoute(app, router)

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -388,6 +388,7 @@ describe('lib/image-service', () => {
 		});
 
 		it('mounts a static middleware at `config.basePath`', () => {
+			assert.calledOnce(express.static);
 			assert.calledWithExactly(express.static, 'public');
 			assert.calledWithExactly(express.mockApp.use, config.basePath, express.mockStaticMiddleware);
 		});


### PR DESCRIPTION
This reverts commit 226d0ad127228ad9b165f04c647b8d4365e4b568.

@JakeChampion, this should be merged after the CDN deploys to prod.