### PR TITLE
Handle node memory flags via heroku-node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
   },
   "main": "./index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "heroku-node-settings index.js"
   },
   "dependencies": {
     "@financial-times/n-express": "^17.9.0",
     "cloudinary": "^1",
     "colornames": "^1",
     "dotenv": "^2",
+    "heroku-node-settings": "^1.0.2",
     "http-errors": "^1",
     "http-proxy": "^1",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
On local machine it will run `node index.js`
On heroku with a small dyno it will run `node --max_semi_space_size=2 --max_old_space_size=256 --max_executable_size=192 index.js`