### PR TITLE
Disable service metrics

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -48,6 +48,7 @@ function createExpressApp() {
 		healthChecksAppName: `Origami Image Service in ${process.env.REGION || 'unknown region'}`,
 		withHandlebars: true,
 		withAssets: false,
+		withServiceMetrics: false,
 		layoutsDir: path.resolve(__dirname, '../views/layouts'),
 		partialsDir: [path.resolve(__dirname, '../views')]
 	});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "heroku-node-settings index.js"
   },
   "dependencies": {
-    "@financial-times/n-express": "^17.15.5",
+    "@financial-times/n-express": "^17.16.0",
     "cloudinary": "^1",
     "colornames": "^1",
     "dotenv": "^2",

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -99,6 +99,12 @@ describe('lib/image-service', () => {
 			assert.isFalse(options.withAssets);
 		});
 
+		it('disables service metrics', () => {
+			const options = express.firstCall.args[0];
+			assert.isObject(options);
+			assert.isFalse(options.withServiceMetrics);
+		});
+
 		it('creates an error handling middleware', () => {
 			assert.calledOnce(handleErrors);
 			assert.calledWith(handleErrors, config);


### PR DESCRIPTION
We don't use these metrics, and they're triggering a bunch of Sentry
errors. n-express 17.16.0 allows us to disable them.