### PR TITLE
Redirect to v1 instead of showing an error

### DIFF
--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -1,15 +1,11 @@
 'use strict';
 
-const httpError = require('http-errors');
-
 module.exports = (app, router) => {
 
-	// v1 documentation page (gone)
-	router.use('/v1', (request, response, next) => {
-		const error = httpError(501);
-		const url = `http://image.webservices.ft.com/v1${request.url}`;
-		error.explanation = `Version 1 of the image service can be found at <a href="${url}">${url}</a>.`;
-		next(error);
+	// v1 endpoint redirect
+	router.use('/v1', (request, response) => {
+		const url = `https://image.webservices.ft.com/v1${request.url}`;
+		response.redirect(301, url);
 	});
 
 };

--- a/test/integration/v1/docs.js
+++ b/test/integration/v1/docs.js
@@ -1,11 +1,17 @@
 'use strict';
 
-const itRespondsWithContentType = require('../helpers/it-responds-with-content-type');
+const itRespondsWithHeader = require('../helpers/it-responds-with-header');
 const itRespondsWithStatus = require('../helpers/it-responds-with-status');
 const setupRequest = require('../helpers/setup-request');
 
 describe('GET /v1/', function() {
 	setupRequest('GET', '/v1/');
-	itRespondsWithStatus(501);
-	itRespondsWithContentType('text/html');
+	itRespondsWithStatus(301);
+	itRespondsWithHeader('Location', 'https://image.webservices.ft.com/v1/');
+});
+
+describe('GET /v1/images/raw/fticon:cross?source=test', function() {
+	setupRequest('GET', '/v1/images/raw/fticon:cross?source=test');
+	itRespondsWithStatus(301);
+	itRespondsWithHeader('Location', 'https://image.webservices.ft.com/v1/images/raw/fticon:cross?source=test');
 });


### PR DESCRIPTION
I think this is nicer behaviour - it allows users to more easily switch
between versions of the service while they're testing it. It can change
to a 410 Gone status once v1 is decommissioned.