### PR TITLE
Pass the user-agent through to Cloudinary

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -8,7 +8,6 @@ const morgan = require('morgan');
 const notFound = require('./middleware/not-found');
 const oneWeek = 60 * 60 * 24 * 7;
 const path = require('path');
-const pkg = require('../package.json');
 const requireAll = require('require-all');
 const url = require('url');
 
@@ -69,7 +68,8 @@ function createProxy(errorHandler) {
 	const requestHeaderWhitelist = [
 		'accept',
 		'accept-encoding',
-		'accept-language'
+		'accept-language',
+		'user-agent'
 	];
 
 	// Handle proxy requests, allowing modification of a request
@@ -83,7 +83,6 @@ function createProxy(errorHandler) {
 
 		// Set our own headers to send to the third party
 		proxyRequest.setHeader('Host', url.parse(proxyOptions.target).host);
-		proxyRequest.setHeader('User-Agent', `${pkg.name}/${pkg.version}`);
 	}
 
 	// Handle proxy responses, allowing modification of a response

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -3,7 +3,6 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const path = require('path');
-const pkg = require('../../../package.json');
 const sinon = require('sinon');
 
 describe('lib/image-service', () => {
@@ -146,7 +145,6 @@ describe('lib/image-service', () => {
 						'accept': 'foo',
 						'cookie': 'qux',
 						'host': 'www.example.com',
-						'user-agent': 'test',
 						'x-identifying-information': 'oops'
 					}
 				};
@@ -157,7 +155,6 @@ describe('lib/image-service', () => {
 			it('should remove all non-whitelisted headers from the proxy request', () => {
 				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'cookie');
 				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'host');
-				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'user-agent');
 				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'x-identifying-information');
 			});
 
@@ -165,14 +162,11 @@ describe('lib/image-service', () => {
 				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept-encoding');
 				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept-language');
 				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept');
+				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'user-agent');
 			});
 
 			it('should set the `Host` header of the proxy request to the host in `proxyOptions.target`', () => {
 				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'Host', 'foo.bar');
-			});
-
-			it('should set the `User-Agent` header of the proxy request to the image service name/version', () => {
-				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'User-Agent', `${pkg.name}/${pkg.version}`);
 			});
 
 		});


### PR DESCRIPTION
This gives us JPEG XR support, which wasn't working before.