### PR TITLE
Allow custom scheme URLs to have querystrings

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -329,9 +329,10 @@ module.exports = class ImageTransform {
 			throw new Error(schemeErrorMessage);
 		}
 
-		// Grab the URI scheme and pathname
+		// Grab the URI scheme, pathname, and query
 		let scheme = parsedUri.protocol.replace(':', '');
 		let pathname = path.join(parsedUri.hostname, parsedUri.pathname || '');
+		const queryString = parsedUri.search || '';
 
 		// Replace trailing slashes in the base URL and
 		// path so that we can safely concatenate them
@@ -373,7 +374,7 @@ module.exports = class ImageTransform {
 				if(!path.extname(pathname)) {
 					pathname = `${pathname}.svg`;
 				}
-				return `${baseUrl}/${outputScheme}/${version}/${pathname}`;
+				return `${baseUrl}/${outputScheme}/${version}/${pathname}${queryString}`;
 
 			// PNG-based schemes. Here we're mostly adding
 			// the .png extension if there isn't an extension
@@ -383,7 +384,7 @@ module.exports = class ImageTransform {
 				if(!path.extname(pathname)) {
 					pathname = `${pathname}.png`;
 				}
-				return `${baseUrl}/${outputScheme}/${version}/${pathname}`;
+				return `${baseUrl}/${outputScheme}/${version}/${pathname}${queryString}`;
 
 			// For HTTP, HTTPS, and FTCMS schemes we return
 			// the URL as-is for processing later

--- a/lib/middleware/convert-to-cms-scheme.js
+++ b/lib/middleware/convert-to-cms-scheme.js
@@ -3,11 +3,14 @@
 module.exports = convertToCmsScheme;
 
 function convertToCmsScheme() {
-	const cmsRegExp = /^https?:\/\/(?:com\.ft\.imagepublish\.prod(-us)?\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.img)?$/i;
+	const cmsRegExp = /^https?:\/\/(?:com\.ft\.imagepublish\.prod(-us)?\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.img)?(\?.+)?$/i;
 	return (request, response, next) => {
 		const match = request.params[0].match(cmsRegExp);
 		if (match && match[2]) {
 			request.params[0] = `ftcms:${match[2]}`;
+			if (match[3]) {
+				request.params[0] += match[3];
+			}
 		}
 		next();
 	};

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -8,9 +8,11 @@ function getCmsUrl() {
 	return (request, response, next) => {
 
 		// Grab the CMS ID and construct the v1 and v2 API URLs
-		const cmsId = request.params[0].split(':').pop();
-		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img`;
-		const v2Uri = `http://com.ft.imagepublish.prod.s3.amazonaws.com/${cmsId}`;
+		let uriParts = request.params[0].split(':').pop().split('?');
+		const cmsId = uriParts.shift();
+		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
+		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img${query}`;
+		const v2Uri = `http://com.ft.imagepublish.prod.s3.amazonaws.com/${cmsId}${query}`;
 
 		// Use HEAD requests so we don't have to wait for
 		// the full image to load

--- a/lib/middleware/map-custom-scheme.js
+++ b/lib/middleware/map-custom-scheme.js
@@ -27,7 +27,7 @@ function mapCustomScheme(config) {
 			// If the custom scheme URL has been set, make sure
 			// we default the format correctly
 			if (!request.query.format) {
-				const match = customSchemeUrl.match(/\.(png|svg)$/);
+				const match = customSchemeUrl.match(/\.(png|svg)(\?.*)?$/);
 				request.query.format = (match ? match[1] : undefined);
 			}
 		}

--- a/test/integration/v2/images-raw.js
+++ b/test/integration/v2/images-raw.js
@@ -49,14 +49,32 @@ describe('GET /v2/images/raw…', function() {
 		itRespondsWithContentType('image/jpeg');
 	});
 
+	describe('/ftcms:… (ftcms scheme with querystring)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.ftcms}%3Ffoo%3Dbar?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+
 	describe('/fticon:… (fticon scheme)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.fticon}?source=test`);
 		itRespondsWithStatus(200);
 		itRespondsWithContentType('image/svg+xml');
 	});
 
+	describe('/fticon:… (fticon scheme with querystring)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.fticon}%3Ffoo%3Dbar?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+	});
+
 	describe('/fthead:… (fthead scheme)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.fthead}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/png');
+	});
+
+	describe('/fthead:… (fthead scheme with querystring)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.fthead}%3Ffoo%3Dbar?source=test`);
 		itRespondsWithStatus(200);
 		itRespondsWithContentType('image/png');
 	});

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -810,6 +810,25 @@ describe('lib/image-transform', () => {
 
 		});
 
+		describe('when `uri` has a querystring', () => {
+
+			it('returns the expected URI', () => {
+				assert.strictEqual(
+					ImageTransform.resolveCustomSchemeUri('http://foo/bar?foo=bar', 'http://base/images'),
+					'http://foo/bar?foo=bar'
+				);
+				assert.strictEqual(
+					ImageTransform.resolveCustomSchemeUri('fthead-v1:example?foo=bar', 'http://base/images'),
+					'http://base/images/fthead/v1/example.png?foo=bar'
+				);
+				assert.strictEqual(
+					ImageTransform.resolveCustomSchemeUri('fticon-v1:example?foo=bar', 'http://base/images'),
+					'http://base/images/fticon/v1/example.svg?foo=bar'
+				);
+			});
+
+		});
+
 		describe('when `baseUrl` has a trailing slash', () => {
 
 			it('returns the expected URI', () => {

--- a/test/unit/lib/middleware/convert-to-cms-scheme.js
+++ b/test/unit/lib/middleware/convert-to-cms-scheme.js
@@ -84,6 +84,19 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 
 			});
 
+			describe('when the request param (0) has a querystring', () => {
+
+				beforeEach(done => {
+					express.mockRequest.params[0] = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img?foo=bar';
+					middleware(express.mockRequest, express.mockResponse, done);
+				});
+
+				it('sets the request param (0) to an `ftcms` URL with the query intact', () => {
+					assert.strictEqual(express.mockRequest.params[0], 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef?foo=bar');
+				});
+
+			});
+
 		});
 
 	});

--- a/test/unit/lib/middleware/map-custom-scheme.js
+++ b/test/unit/lib/middleware/map-custom-scheme.js
@@ -134,6 +134,31 @@ describe('lib/middleware/map-custom-scheme', () => {
 
 			});
 
+			describe('when the resolved URL has a querystring', () => {
+
+				beforeEach(() => {
+					next.reset();
+					express.mockRequest.params[0] = 'foo:bar';
+					delete express.mockRequest.query.format;
+					ImageTransform.resolveCustomSchemeUri.returns('http://mock-store/foo/bar.svg?foo=bar');
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sets the request param (0) to the returned URL', () => {
+					assert.strictEqual(express.mockRequest.params[0], 'http://mock-store/foo/bar.svg?foo=bar');
+				});
+
+				it('sets the `format` query parameter to the resolved URLs file extension', () => {
+					assert.strictEqual(express.mockRequest.query.format, 'svg');
+				});
+
+				it('calls `next` with no error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
+			});
+
 			describe('when `ImageTransform.resolveCustomSchemeUri` throws', () => {
 				let resolutionError;
 


### PR DESCRIPTION
Currently a querystring in a custom scheme URL is ignored. We would like
to have a way to cache-bust these URLs for use in the registry.