### PR TITLE
Purge URLs with trailing slashes

### DIFF
--- a/scripts/purge.js
+++ b/scripts/purge.js
@@ -21,10 +21,15 @@ const paths = [
 	'/main.css',
 	'/main.js',
 	'/v1',
+	'/v1/',
 	'/v2',
+	'/v2/',
 	'/v2/docs/api',
+	'/v2/docs/api/',
 	'/v2/docs/compare',
-	'/v2/docs/migration'
+	'/v2/docs/compare/',
+	'/v2/docs/migration',
+	'/v2/docs/migration/'
 ];
 
 const endpoints = paths.map(path => hostname + path);

--- a/views/partials/navigation.html
+++ b/views/partials/navigation.html
@@ -1,7 +1,7 @@
 
 <ul class="o-techdocs-nav">
 	<li>
-		<a href="v2/">Overview</a>
+		<a href="v2">Overview</a>
 	</li>
 	<li>
 		<a href="v2/docs/api">API Reference</a>


### PR DESCRIPTION
I know this isn't ideal, but at the moment we have pages cached that are
different because we don't purge them with a trailing slash. I've made
the links across the site consistent, and am purging these URLs now.
Later it'd be worth redirecting to remove the slash, maybe.