### PR TITLE
FTCMS multi region

### DIFF
--- a/lib/middleware/convert-to-cms-scheme.js
+++ b/lib/middleware/convert-to-cms-scheme.js
@@ -3,7 +3,7 @@
 module.exports = convertToCmsScheme;
 
 function convertToCmsScheme() {
-	const cmsRegExp = /^https?:\/\/(?:com\.ft\.imagepublish\.prod(-us)?\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.img)?(\?.+)?$/i;
+	const cmsRegExp = /^https?:\/\/(?:prod-upp-image-read\.ft\.com|com\.ft\.imagepublish\.prod(-us)?\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.img)?(\?.+)?$/i;
 	return (request, response, next) => {
 		const match = request.params[0].match(cmsRegExp);
 		if (match && match[2]) {

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -29,19 +29,14 @@ function getCmsUrl() {
 				return requestPromise({
 					uri: v1Uri,
 					method: 'HEAD'
+				}).then(secondResponse => {
+					// Cool, we've got an image from v1
+					if (secondResponse.statusCode <= 400) {
+						return v1Uri;
+					}
+					// If the v1 image can't be found, we error
+					throw httpError(404, `Unable to get image ${cmsId} from FT CMS v1 or v2`);
 				});
-			})
-			.then(secondResponse => {
-				// We have a valid v2 URI already, pass it on
-				if (typeof secondResponse === 'string') {
-					return secondResponse;
-				}
-				// Cool, we've got an image from v1
-				if (secondResponse.statusCode <= 400) {
-					return v1Uri;
-				}
-				// If the v1 image can't be found, we error
-				throw httpError(404, `Unable to get image ${cmsId} from FT CMS v1 or v2`);
 			})
 			.then(resolvedUrl => {
 				request.params[0] = resolvedUrl;

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -13,7 +13,7 @@ function getCmsUrl() {
 		const cmsId = uriParts.shift();
 		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
 		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img${query}`;
-		const v2Uri = `http://com.ft.imagepublish.prod.s3.amazonaws.com/${cmsId}${query}`;
+		const v2Uri = `http://prod-upp-image-read.ft.com/${cmsId}${query}`;
 
 		// First try fetching the v1 image
 		requestPromise({

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -15,32 +15,32 @@ function getCmsUrl() {
 		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img${query}`;
 		const v2Uri = `http://prod-upp-image-read.ft.com/${cmsId}${query}`;
 
-		// First try fetching the v1 image
+		// First try fetching the v2 image
 		requestPromise({
-			uri: v1Uri,
+			uri: v2Uri,
 			method: 'HEAD'
 		})
 			.then(firstResponse => {
-				// Cool, we've got an image from v1
+				// Cool, we've got an image from v2
 				if (firstResponse.statusCode <= 400) {
-					return v1Uri;
+					return v2Uri;
 				}
-				// If the v1 image can't be found, try v2
+				// If the v2 image can't be found, try v1
 				return requestPromise({
-					uri: v2Uri,
+					uri: v1Uri,
 					method: 'HEAD'
 				});
 			})
 			.then(secondResponse => {
-				// We have a valid v1 URI, pass it on
+				// We have a valid v2 URI already, pass it on
 				if (typeof secondResponse === 'string') {
 					return secondResponse;
 				}
-				// Cool, we've got an image from v2
+				// Cool, we've got an image from v1
 				if (secondResponse.statusCode <= 400) {
-					return v2Uri;
+					return v1Uri;
 				}
-				// If the v2 image can't be found, we error
+				// If the v1 image can't be found, we error
 				throw httpError(404, `Unable to get image ${cmsId} from FT CMS v1 or v2`);
 			})
 			.then(resolvedUrl => {

--- a/lib/routes/v2/images-debug.js
+++ b/lib/routes/v2/images-debug.js
@@ -34,7 +34,7 @@ module.exports = (app, router) => {
 	// /v2/images/debug/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
 	router.get(
-		/^\/v2\/images\/debug\/(https?(:|%3A)(\/|%2F){2}(com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
+		/^\/v2\/images\/debug\/(https?(:|%3A)(\/|%2F){2}(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
 		convertToCmsScheme(),
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),

--- a/lib/routes/v2/images-raw.js
+++ b/lib/routes/v2/images-raw.js
@@ -52,7 +52,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/raw/http://im.ft-static.com/...
 	router.get(
-		/^\/v2\/images\/raw\/(https?(:|%3A)(\/|%2F){2}(com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
+		/^\/v2\/images\/raw\/(https?(:|%3A)(\/|%2F){2}(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
 		convertToCmsScheme(),
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),

--- a/test/unit/lib/middleware/convert-to-cms-scheme.js
+++ b/test/unit/lib/middleware/convert-to-cms-scheme.js
@@ -45,6 +45,19 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 
 			});
 
+			describe('when the request param (0) points to an image in prod-upp-image-read.ft.com', () => {
+
+				beforeEach(done => {
+					express.mockRequest.params[0] = 'http://prod-upp-image-read.ft.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
+					middleware(express.mockRequest, express.mockResponse, done);
+				});
+
+				it('sets the request param (0) to an `ftcms` URL with the image ID', () => {
+					assert.strictEqual(express.mockRequest.params[0], 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
+				});
+
+			});
+
 			describe('when the request param (0) points to an image in the imagepublish S3 bucket', () => {
 
 				beforeEach(done => {

--- a/test/unit/lib/middleware/get-cms-url.js
+++ b/test/unit/lib/middleware/get-cms-url.js
@@ -37,7 +37,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 		describe('middleware(request, response, next)', () => {
 			const v1Uri = 'http://im.ft-static.com/content/images/mock-id.img';
-			const v2Uri = 'http://com.ft.imagepublish.prod.s3.amazonaws.com/mock-id';
+			const v2Uri = 'http://prod-upp-image-read.ft.com/mock-id';
 
 			beforeEach(done => {
 				express.mockRequest.params[0] = 'ftcms:mock-id';

--- a/test/unit/lib/middleware/get-cms-url.js
+++ b/test/unit/lib/middleware/get-cms-url.js
@@ -42,9 +42,9 @@ describe('lib/middleware/get-cms-url', () => {
 			beforeEach(done => {
 				express.mockRequest.params[0] = 'ftcms:mock-id';
 
-				// V1 responds with success
+				// V2 responds with success
 				requestPromise.withArgs({
-					uri: v1Uri,
+					uri: v2Uri,
 					method: 'HEAD'
 				}).resolves({
 					statusCode: 200
@@ -53,35 +53,35 @@ describe('lib/middleware/get-cms-url', () => {
 				middleware(express.mockRequest, express.mockResponse, done);
 			});
 
-			it('attempts to fetch the v1 API URL corresponding to the CMS ID', () => {
+			it('attempts to fetch the v2 API URL corresponding to the CMS ID', () => {
 				assert.calledOnce(requestPromise);
 				assert.calledWith(requestPromise, {
-					uri: v1Uri,
+					uri: v2Uri,
 					method: 'HEAD'
 				});
 			});
 
-			it('sets the request param (0) to the v1 API URL corresponding to the CMS ID', () => {
-				assert.strictEqual(express.mockRequest.params[0], v1Uri);
+			it('sets the request param (0) to the v2 API URL corresponding to the CMS ID', () => {
+				assert.strictEqual(express.mockRequest.params[0], v2Uri);
 			});
 
-			describe('when the v1 API cannot find the image', () => {
+			describe('when the v2 API cannot find the image', () => {
 
 				beforeEach(done => {
 					requestPromise.reset();
 					express.mockRequest.params[0] = 'ftcms:mock-id';
 
-					// V1 responds with a 404
+					// V2 responds with a 404
 					requestPromise.withArgs({
-						uri: v1Uri,
+						uri: v2Uri,
 						method: 'HEAD'
 					}).resolves({
 						statusCode: 404
 					});
 
-					// V2 responds with success
+					// V1 responds with success
 					requestPromise.withArgs({
-						uri: v2Uri,
+						uri: v1Uri,
 						method: 'HEAD'
 					}).resolves({
 						statusCode: 200
@@ -90,16 +90,16 @@ describe('lib/middleware/get-cms-url', () => {
 					middleware(express.mockRequest, express.mockResponse, done);
 				});
 
-				it('attempts to fetch the v2 API URL corresponding to the CMS ID', () => {
+				it('attempts to fetch the v1 API URL corresponding to the CMS ID', () => {
 					assert.calledTwice(requestPromise);
 					assert.calledWith(requestPromise, {
-						uri: v2Uri,
+						uri: v1Uri,
 						method: 'HEAD'
 					});
 				});
 
-				it('sets the request param (0) to the v2 API URL corresponding to the CMS ID', () => {
-					assert.strictEqual(express.mockRequest.params[0], v2Uri);
+				it('sets the request param (0) to the v1 API URL corresponding to the CMS ID', () => {
+					assert.strictEqual(express.mockRequest.params[0], v1Uri);
 				});
 
 			});
@@ -111,17 +111,17 @@ describe('lib/middleware/get-cms-url', () => {
 					requestPromise.reset();
 					express.mockRequest.params[0] = 'ftcms:mock-id';
 
-					// V1 responds with a 404
+					// V2 responds with a 404
 					requestPromise.withArgs({
-						uri: v1Uri,
+						uri: v2Uri,
 						method: 'HEAD'
 					}).resolves({
 						statusCode: 404
 					});
 
-					// V2 responds with a 404
+					// V1 responds with a 404
 					requestPromise.withArgs({
-						uri: v2Uri,
+						uri: v1Uri,
 						method: 'HEAD'
 					}).resolves({
 						statusCode: 404
@@ -147,9 +147,9 @@ describe('lib/middleware/get-cms-url', () => {
 					requestPromise.reset();
 					express.mockRequest.params[0] = 'ftcms:mock-id?foo=bar';
 
-					// V1 responds with success
+					// V2 responds with success
 					requestPromise.withArgs({
-						uri: `${v1Uri}?foo=bar`,
+						uri: `${v2Uri}?foo=bar`,
 						method: 'HEAD'
 					}).resolves({
 						statusCode: 200
@@ -161,7 +161,7 @@ describe('lib/middleware/get-cms-url', () => {
 				it('attempts to fetch the API URLs with the querystring intact', () => {
 					assert.calledOnce(requestPromise);
 					assert.calledWith(requestPromise, {
-						uri: `${v1Uri}?foo=bar`,
+						uri: `${v2Uri}?foo=bar`,
 						method: 'HEAD'
 					});
 				});
@@ -175,9 +175,9 @@ describe('lib/middleware/get-cms-url', () => {
 					requestPromise.reset();
 					express.mockRequest.params[0] = 'ftcms:mock-id';
 
-					// V1 errors
+					// V2 errors
 					requestPromise.withArgs({
-						uri: v1Uri,
+						uri: v2Uri,
 						method: 'HEAD'
 					}).rejects(new Error('mock error'));
 


### PR DESCRIPTION
## Use a resilient multi-region host for `ftcms` images

We were using the EU region S3 bucket to serve images with an `ftcms` scheme. We're now using the multi-region host: prod-upp-image-read.ft.com

## Switch the `ftcms` image lookup logic

Currently we first check v1 of the API for images, then fall back to v2. As v2 is now multi-region and where newer images will be stored, we now default to v2 and use v1 as a fallback.
