### PR TITLE
Format querystring correct for svg-tint urls

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -335,7 +335,7 @@ module.exports = class ImageTransform {
 		let pathname = path.join(parsedUri.hostname, parsedUri.pathname || '');
 		let queryString = parsedUri.search || '';
 		if (cacheBust) {
-			queryString = (queryString ? `${queryString}&${cacheBust}` : `?${cacheBust}`);
+			queryString = (queryString ? `${queryString}&cacheBust=${cacheBust}` : `?cacheBust=${cacheBust}`);
 		}
 
 		// Replace trailing slashes in the base URL and

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -3,13 +3,13 @@
 const ImageTransform = require('../image-transform');
 const cloudinaryTransform = require('../transformers/cloudinary');
 const httpError = require('http-errors');
+const url = require('url');
 
 module.exports = processImage;
 
 function processImage(config) {
 	return (request, response, next) => {
 		let transform;
-
 		// Add the URI from the path to the query so we can
 		// pass it into the transform as one object
 		request.query.uri = request.params[0];
@@ -30,13 +30,14 @@ function processImage(config) {
 		// we need to route it through the /images/svgtint
 		// endpoint. This involves modifying the URI.
 		if ((transform.format === 'svg' || /\.svg/i.test(transform.uri)) && transform.tint) {
+			const hasQueryString = url.parse(transform.uri).search;
 			const encodedUri = encodeURIComponent(transform.uri);
 			// We only use the first comma-delimited tint colour
 			// that we find, additional colours are obsolete
 			const tint = transform.tint[0];
 			const hostname = (config.hostname || request.hostname);
 			const basePath = config.basePath || '';
-			transform.setUri(`${request.protocol}://${hostname}${basePath}/v2/images/svgtint/${encodedUri}?color=${tint}`);
+			transform.setUri(`${request.protocol}://${hostname}${basePath}/v2/images/svgtint/${encodedUri}${hasQueryString ? '&' : '?'}color=${tint}`);
 			// Clear the tint so that SVGs converted to rasterised
 			// formats don't get double-tinted
 			transform.setTint();

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -869,7 +869,7 @@ describe('lib/image-transform', () => {
 				it('returns the expected URI', () => {
 					assert.strictEqual(
 						ImageTransform.resolveCustomSchemeUri('fthead-v1:example', 'http://base/images/', 'busted'),
-						'http://base/images/fthead/v1/example.png?busted'
+						'http://base/images/fthead/v1/example.png?cacheBust=busted'
 					);
 				});
 
@@ -880,7 +880,7 @@ describe('lib/image-transform', () => {
 				it('returns the expected URI', () => {
 					assert.strictEqual(
 						ImageTransform.resolveCustomSchemeUri('fticon-v1:example', 'http://base/images/', 'busted'),
-						'http://base/images/fticon/v1/example.svg?busted'
+						'http://base/images/fticon/v1/example.svg?cacheBust=busted'
 					);
 				});
 
@@ -891,7 +891,7 @@ describe('lib/image-transform', () => {
 				it('returns the expected URI', () => {
 					assert.strictEqual(
 						ImageTransform.resolveCustomSchemeUri('fticon-v1:example?foo=bar', 'http://base/images/', 'busted'),
-						'http://base/images/fticon/v1/example.svg?foo=bar&busted'
+						'http://base/images/fticon/v1/example.svg?foo=bar&cacheBust=busted'
 					);
 				});
 

--- a/test/unit/lib/middleware/process-image-request.js
+++ b/test/unit/lib/middleware/process-image-request.js
@@ -110,7 +110,7 @@ describe('lib/middleware/process-image-request', () => {
 
 				it('sets the image transform `uri` property to route through the SVG tinter', () => {
 					assert.calledOnce(mockImageTransform.setUri);
-					assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://hostname/v2/images/svgtint/transform-uri%3Ffoo?color=ff0000');
+					assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://hostname/v2/images/svgtint/transform-uri%3Ffoo&color=ff0000');
 				});
 
 				it('removes the tint property from the image transform', () => {
@@ -128,7 +128,7 @@ describe('lib/middleware/process-image-request', () => {
 
 					it('sets the image transform `uri` property to route through the SVG tinter', () => {
 						assert.calledOnce(mockImageTransform.setUri);
-						assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://config-hostname/v2/images/svgtint/transform-uri%3Ffoo?color=ff0000');
+						assert.strictEqual(mockImageTransform.setUri.firstCall.args[0], 'proto://config-hostname/v2/images/svgtint/transform-uri%3Ffoo&color=ff0000');
 					});
 
 				});


### PR DESCRIPTION
Currently we add `?` to the end of the uri without checking if a querystring alerady exists. This causes the tinting parameter to not work. E.G. https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-myft?source=next&tint=%23FDF8F2,%23FDF8F2&format=svg should be off-white but comes back black.

This PR resolves this issue by detecting if a querystring is present already.

This issue came about due to the cachebusting feature which was added today.

I've marked this as high priority as I believe this is an issue for all ft schemes which use the svg tinter.