### PR TITLE
Add the images/metadata endpoint

### DIFF
--- a/lib/middleware/get-image-meta.js
+++ b/lib/middleware/get-image-meta.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const httpError = require('http-errors');
+const probe = require('probe-image-size');
+
+module.exports = getImageMeta;
+
+function getImageMeta(request, response, next) {
+	// Get the image meta data
+	probe({
+
+		// Request the applied transform
+		url: request.appliedTransform,
+
+		// We need to pass on these client headers to support WebP.
+		// Note: JPEG XR is not supported by the library we use to
+		// calculate image dimensions, so we don't send the
+		// User-Agent, falling back to JPEG
+		headers: {
+			Accept: request.headers.accept
+		}
+
+	}, (error, result) => {
+
+		// Handle errors
+		if (error) {
+			if (error.code === 'ECONTENT') {
+				return next(httpError(500, 'Metadata could not be extracted from the requested image'));
+			}
+			if (error.status && error.status >= 400 && error.status < 500) {
+				return next(httpError(error.status));
+			}
+			return next(error);
+		}
+
+		// Match the V1 Image Service metadata JSON
+		response.send({
+			dpr: request.transform.getDpr() || 1,
+			type: result.mime,
+			filesize: result.length,
+			width: result.width,
+			height: result.height
+		});
+	});
+}

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -4,6 +4,7 @@ const convertToCmsScheme = require('../../middleware/convert-to-cms-scheme');
 const createResponseInterceptor = require('../../response-interceptor');
 const getCmsUrl = require('../../middleware/get-cms-url');
 const mapCustomScheme = require('../../middleware/map-custom-scheme');
+const getImageMeta = require('../../middleware/get-image-meta');
 const processImageRequest = require('../../middleware/process-image-request');
 
 module.exports = (app, router) => {
@@ -23,6 +24,9 @@ module.exports = (app, router) => {
 				break;
 			case 'debug':
 				debug(request, response, next);
+				break;
+			case 'metadata':
+				getImageMeta(request, response, next);
 				break;
 			default:
 				next();
@@ -67,7 +71,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/fthead:...
 	// /v2/images/debug/ftlogo:...
 	router.get(
-		/^\/v2\/images\/(raw|debug)\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/i,
+		/^\/v2\/images\/(raw|debug|metadata)\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/i,
 		mapParams,
 		mapCustomScheme(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
@@ -79,7 +83,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
 	router.get(
-		/^\/v2\/images\/(raw|debug)\/(https?(:|%3A)(\/|%2F){2}(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
+		/^\/v2\/images\/(raw|debug|metadata)\/(https?(:|%3A)(\/|%2F){2}(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
 		mapParams,
 		convertToCmsScheme(),
 		getCmsUrl(app.imageServiceConfig),
@@ -91,7 +95,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/ftcms:...
 	// /v2/images/debug/ftcms:...
 	router.get(
-		/^\/v2\/images\/(raw|debug)\/((ftcms)(:|%3A).*)$/i,
+		/^\/v2\/images\/(raw|debug|metadata)\/((ftcms)(:|%3A).*)$/i,
 		mapParams,
 		getCmsUrl(app.imageServiceConfig),
 		processImageRequest(app.imageServiceConfig),
@@ -103,7 +107,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/http://...
 	// /v2/images/debug/http://...
 	router.get(
-		/\/v2\/images\/(raw|debug)\/(https?(:|%3A).*)$/i,
+		/\/v2\/images\/(raw|debug|metadata)\/(https?(:|%3A).*)$/i,
 		mapParams,
 		processImageRequest(app.imageServiceConfig),
 		handleImage

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "http-errors": "^1",
     "http-proxy": "^1",
     "morgan": "^1",
+    "probe-image-size": "^2.2.0",
     "request": "^2",
     "require-all": "^2",
     "statuses": "^1",

--- a/test/integration/v2/images-metadata.js
+++ b/test/integration/v2/images-metadata.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const assert = require('proclaim');
+const itRespondsWithContentType = require('../helpers/it-responds-with-content-type');
+const itRespondsWithStatus = require('../helpers/it-responds-with-status');
+const setupRequest = require('../helpers/setup-request');
+
+const testImageUris = {
+	http: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
+};
+
+describe('GET /v2/images/metadata…', function() {
+
+	setupRequest('GET', `/v2/images/metadata/${testImageUris.http}?source=test&width=123&height=456&echo`);
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	it('responds with JSON representing the metadata of the requested image', function(done) {
+		this.request.expect(response => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.dpr, 1);
+			assert.strictEqual(response.body.type, 'image/jpeg');
+			assert.strictEqual(response.body.width, 123);
+			assert.strictEqual(response.body.height, 456);
+			assert.greaterThan(response.body.filesize, 5000);
+			assert.lessThan(response.body.filesize, 12000);
+		}).end(done);
+	});
+
+});

--- a/test/unit/lib/middleware/get-image-meta.js
+++ b/test/unit/lib/middleware/get-image-meta.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/middleware/get-image-meta', () => {
+	let express;
+	let getImageMeta;
+	let probe;
+
+	beforeEach(() => {
+
+		express = require('../../mock/n-express.mock');
+
+		probe = sinon.stub();
+		mockery.registerMock('probe-image-size', probe);
+
+		getImageMeta = require('../../../../lib/middleware/get-image-meta');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(getImageMeta);
+	});
+
+	describe('getImageMeta(request, response, next)', () => {
+		let mockResult;
+		let next;
+
+		beforeEach(() => {
+
+			express.mockRequest.appliedTransform = 'http://example.com/applied-transform';
+			express.mockRequest.transform = {
+				getDpr: sinon.stub().returns(123)
+			};
+			express.mockRequest.headers.accept = 'mock-accept';
+
+			mockResult = {
+				mime: 'foo/bar',
+				length: 123456,
+				width: 99,
+				height: 88
+			};
+			probe.yields(null, mockResult);
+
+			next = sinon.spy();
+			getImageMeta(express.mockRequest, express.mockResponse, next);
+		});
+
+		it('probes the transformed image to get meta data, passing through the Accept header', () => {
+			assert.calledOnce(probe);
+			assert.calledWith(probe, {
+				url: express.mockRequest.appliedTransform,
+				headers: {
+					Accept: express.mockRequest.headers.accept
+				}
+			});
+		});
+
+		it('responds with JSON containing the meta data', () => {
+			assert.calledOnce(express.mockResponse.send);
+			assert.calledWith(express.mockResponse.send, {
+				dpr: 123,
+				type: 'foo/bar',
+				filesize: 123456,
+				width: 99,
+				height: 88
+			});
+		});
+
+		describe('when the transformed image does not have a `dpr` set', () => {
+
+			beforeEach(() => {
+				express.mockResponse.send.reset();
+				express.mockRequest.transform.getDpr.returns(undefined);
+				getImageMeta(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('defaults to 1 in the response', () => {
+				assert.calledOnce(express.mockResponse.send);
+				assert.calledWith(express.mockResponse.send, {
+					dpr: 1,
+					type: 'foo/bar',
+					filesize: 123456,
+					width: 99,
+					height: 88
+				});
+			});
+
+		});
+
+		describe('when the probe errors with a code of "ECONTENT"', () => {
+			let probeError;
+
+			beforeEach(() => {
+				express.mockResponse.send.reset();
+				probeError = new Error();
+				probeError.code = 'ECONTENT';
+				probe.yields(probeError);
+				getImageMeta(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('calls `next` with a new error', () => {
+				assert.calledOnce(next);
+				assert.instanceOf(next.firstCall.args[0], Error);
+				assert.strictEqual(next.firstCall.args[0].status, 500);
+				assert.strictEqual(next.firstCall.args[0].message, 'Metadata could not be extracted from the requested image');
+				assert.notStrictEqual(next.firstCall.args[0], probeError);
+			});
+
+			it('does not respond', () => {
+				assert.notCalled(express.mockResponse.send);
+			});
+
+		});
+
+		describe('when the probe errors with a 404 status', () => {
+			let probeError;
+
+			beforeEach(() => {
+				express.mockResponse.send.reset();
+				probeError = new Error();
+				probeError.status = 404;
+				probe.yields(probeError);
+				getImageMeta(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('calls `next` with a new 404 error', () => {
+				assert.calledOnce(next);
+				assert.instanceOf(next.firstCall.args[0], Error);
+				assert.strictEqual(next.firstCall.args[0].status, 404);
+				assert.notStrictEqual(next.firstCall.args[0], probeError);
+			});
+
+			it('does not respond', () => {
+				assert.notCalled(express.mockResponse.send);
+			});
+
+		});
+
+		describe('when the probe errors with a 400 status', () => {
+			let probeError;
+
+			beforeEach(() => {
+				express.mockResponse.send.reset();
+				probeError = new Error();
+				probeError.status = 400;
+				probe.yields(probeError);
+				getImageMeta(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('calls `next` with a new 400 error', () => {
+				assert.calledOnce(next);
+				assert.instanceOf(next.firstCall.args[0], Error);
+				assert.strictEqual(next.firstCall.args[0].status, 400);
+				assert.notStrictEqual(next.firstCall.args[0], probeError);
+			});
+
+			it('does not respond', () => {
+				assert.notCalled(express.mockResponse.send);
+			});
+
+		});
+
+		describe('when the probe errors with a 500 status', () => {
+			let probeError;
+
+			beforeEach(() => {
+				express.mockResponse.send.reset();
+				probeError = new Error();
+				probeError.status = 500;
+				probe.yields(probeError);
+				getImageMeta(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('calls `next` with the probe error', () => {
+				assert.calledOnce(next);
+				assert.strictEqual(next.firstCall.args[0], probeError);
+			});
+
+			it('does not respond', () => {
+				assert.notCalled(express.mockResponse.send);
+			});
+
+		});
+
+		describe('when the probe errors with no code or status', () => {
+			let probeError;
+
+			beforeEach(() => {
+				express.mockResponse.send.reset();
+				probeError = new Error();
+				probe.yields(probeError);
+				getImageMeta(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('calls `next` with the probe error', () => {
+				assert.calledOnce(next);
+				assert.strictEqual(next.firstCall.args[0], probeError);
+			});
+
+			it('does not respond', () => {
+				assert.notCalled(express.mockResponse.send);
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/n-express.mock.js
+++ b/test/unit/mock/n-express.mock.js
@@ -22,6 +22,7 @@ const mockRouter = module.exports.mockRouter = {};
 const mockStaticMiddleware = module.exports.mockStaticMiddleware = {};
 
 module.exports.mockRequest = {
+	headers: {},
 	query: {},
 	params: {}
 };

--- a/views/api.html
+++ b/views/api.html
@@ -32,7 +32,9 @@
 								<dt>raw</dt>
 								<dd>Output raw image data.</dd>
 								<dt>debug</dt>
-								<dd>Output a JSON object which outlines the image transform found in the query string</dd>
+								<dd>Output a JSON object which outlines the image transform found in the query string.</dd>
+								<dt>metadata</dt>
+								<dd>Output a JSON object with dimensions of the image (in pixels) that the <code>raw</code> mode would output.</dd>
 							</dl>
 						</td>
 					</tr>

--- a/views/migration.html
+++ b/views/migration.html
@@ -38,7 +38,7 @@
 			<h2>Image modes</h2>
 
 			<p>
-				The image modes <code>metadata</code>, <code>data</code>, and <code>data-utfhack</code>
+				The image modes <code>data</code> and <code>data-utfhack</code>
 				have been removed from the service. The <code>debug</code> mode has been added.
 			</p>
 
@@ -112,6 +112,12 @@
 				If the <code>format</code> query parameter is set to <code>auto</code>, it will now
 				use <a href="http://cloudinary.com/documentation/image_transformations#automatic_format_selection">Cloudinary's automatic format detection</a>.
 				This includes serving WebP or JPEG-XR images for browsers which support them.
+			</p>
+
+			<h2>Metadata</h2>
+
+			<p>
+				The <code>images/metadata</code> endpoint now doesn't include a <code>cache</code> property.
 			</p>
 
 		</div>


### PR DESCRIPTION
This matches the `images/metadata` endpoint from v1, minus the cache
object. This allows users to check image dimensions before requesting
the actual image data.