### PR TITLE
Strip hashes from transform URLs

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -212,6 +212,9 @@ module.exports = class ImageTransform {
 		if (/^\/\//.test(value)) {
 			value = `http:${value}`;
 		}
+		if (value.indexOf('#') !== -1) {
+			value = value.split('#')[0];
+		}
 		const parsedUri = url.parse(value);
 		const scheme = (parsedUri.protocol ? parsedUri.protocol.slice(0, -1) : parsedUri.protocol);
 		if (!ImageTransform.validUriSchemes.includes(scheme)) {

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -344,6 +344,23 @@ describe('lib/image-transform', () => {
 
 		});
 
+		describe('when `value` contains a hash character', () => {
+
+			it('returns `value` without any of the content after the hash', () => {
+				assert.strictEqual(ImageTransform.sanitizeUriValue('http://foo/#bar'), 'http://foo/');
+				assert.strictEqual(ImageTransform.sanitizeUriValue('http%3A%2F%2Ffoo%2F%23bar'), 'http://foo/');
+			});
+
+		});
+
+		describe('when `value` contains a double-encoded hash character', () => {
+
+			it('returns `value` with the hash intact', () => {
+				assert.strictEqual(ImageTransform.sanitizeUriValue('http://foo/%2523bar'), 'http://foo/%23bar');
+			});
+
+		});
+
 		describe('when `value` is a string with an invalid scheme', () => {
 
 			it('throws an error', () => {


### PR DESCRIPTION
This reduces the size of a lot of URLs, and the hash character would
never reach the origin image server anyway.