### PR TITLE
Never send the User-Agent to Cloudinary

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -68,8 +68,7 @@ function createProxy(errorHandler) {
 	const requestHeaderWhitelist = [
 		'accept',
 		'accept-encoding',
-		'accept-language',
-		'user-agent'
+		'accept-language'
 	];
 
 	// Handle proxy requests, allowing modification of a request
@@ -83,6 +82,7 @@ function createProxy(errorHandler) {
 
 		// Set our own headers to send to the third party
 		proxyRequest.setHeader('Host', url.parse(proxyOptions.target).host);
+		proxyRequest.setHeader('User-Agent', 'Origami Image Service (https://github.com/Financial-Times/origami-image-service)');
 	}
 
 	// Handle proxy responses, allowing modification of a response

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -145,7 +145,8 @@ describe('lib/image-service', () => {
 						'accept': 'foo',
 						'cookie': 'qux',
 						'host': 'www.example.com',
-						'x-identifying-information': 'oops'
+						'x-identifying-information': 'oops',
+						'user-agent': 'my-ua'
 					}
 				};
 				response = {};
@@ -156,17 +157,21 @@ describe('lib/image-service', () => {
 				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'cookie');
 				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'host');
 				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'x-identifying-information');
+				assert.calledWithExactly(httpProxy.mockProxyRequest.removeHeader, 'user-agent');
 			});
 
 			it('should leave all whitelisted headers from the proxy request intact', () => {
 				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept-encoding');
 				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept-language');
 				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'accept');
-				assert.neverCalledWith(httpProxy.mockProxyRequest.removeHeader, 'user-agent');
 			});
 
 			it('should set the `Host` header of the proxy request to the host in `proxyOptions.target`', () => {
 				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'Host', 'foo.bar');
+			});
+
+			it('should set the `User-Agent` header of the proxy request to identify the Image Service', () => {
+				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'User-Agent', 'Origami Image Service (https://github.com/Financial-Times/origami-image-service)');
 			});
 
 		});


### PR DESCRIPTION
We don't understand their JPEG XR logic, so we're not sending them the
user-agent for now. We'll only use JPEG XR if the Accept header
indicates support.