### PR TITLE
Simplify routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We configure Origami Image Service using environment variables. In development, 
 
 The service can also be configured by sending HTTP headers, these would normally be set in your CDN config:
 
-  * `X-Service-Base-Path`: The base path for the service, this gets prepended to all paths in the HTML and ensures that redirects work when the CDN rewrites URLs.
+  * `FT-Origami-Service-Base-Path`: The base path for the service, this gets prepended to all paths in the HTML and ensures that redirects work when the CDN rewrites URLs.
 
 
 Testing

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ We configure Origami Image Service using environment variables. In development, 
   * `CUSTOM_SCHEME_STORE`: The location of the images used in custom schemes. This should be set to the base path under which images live.
   * `CUSTOM_SCHEME_CACHE_BUST`: A key used to manually cache-bust custom scheme images.
 
+The service can also be configured by sending HTTP headers, these would normally be set in your CDN config:
+
+  * `X-Service-Base-Path`: The base path for the service, this gets prepended to all paths in the HTML and ensures that redirects work when the CDN rewrites URLs.
+
 
 Testing
 -------

--- a/config.js
+++ b/config.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-	basePath: '/__origami/service/image',
 	cloudinaryAccountName: process.env.CLOUDINARY_ACCOUNT_NAME,
 	cloudinaryApiKey: process.env.CLOUDINARY_API_KEY,
 	cloudinaryApiSecret: process.env.CLOUDINARY_API_SECRET,

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const express = require('@financial-times/n-express');
+const getBasePath = require('./middleware/get-base-path');
 const handleErrors = require('./middleware/handle-errors');
 const healthChecks = require('./health-checks');
 const httpProxy = require('http-proxy');
@@ -25,6 +26,7 @@ function imageService(config) {
 	if (!config.suppressLogs) {
 		app.use(morgan('combined'));
 	}
+	app.use(getBasePath);
 	mountRoutes(app);
 	app.use(notFound);
 	app.use(errorHandler);

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -18,9 +18,6 @@ function imageService(config) {
 	const app = createExpressApp(config);
 	const errorHandler = handleErrors(config);
 	app.proxy = createProxy(errorHandler);
-
-	config.basePath = config.basePath || '';
-	app.locals.basePath = config.basePath;
 	app.imageServiceConfig = config;
 
 	healthChecks.init(config);
@@ -148,18 +145,12 @@ function createProxy(errorHandler) {
 }
 
 function mountRoutes(app) {
-	const router = express.Router(); // eslint-disable-line new-cap
-	// 👇 Temporary
-	app.use(express.static('public'));
-	app.use(router);
-	// 👆 Temporary
 	app.get('/__gtg', (request, response) => {
 		response.status(200).send('OK');
 	});
-	app.use(app.imageServiceConfig.basePath, express.static('public'));
-	app.use(app.imageServiceConfig.basePath, router);
+	app.use(express.static('public'));
 	requireAll({
 		dirname: `${__dirname}/routes`,
-		resolve: initRoute => initRoute(app, router)
+		resolve: initRoute => initRoute(app)
 	});
 }

--- a/lib/middleware/get-base-path.js
+++ b/lib/middleware/get-base-path.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = getBasePath;
+
+function getBasePath(request, response, next) {
+	let basePath = request.headers['x-service-base-path'] || '/';
+	if (basePath.substr(0, 1) !== '/') {
+		basePath = `/${basePath}`;
+	}
+	if (basePath.substr(-1, 1) !== '/') {
+		basePath = `${basePath}/`;
+	}
+	request.basePath = response.locals.basePath = basePath;
+	next();
+}

--- a/lib/middleware/get-base-path.js
+++ b/lib/middleware/get-base-path.js
@@ -3,7 +3,7 @@
 module.exports = getBasePath;
 
 function getBasePath(request, response, next) {
-	let basePath = request.headers['x-service-base-path'] || '/';
+	let basePath = request.headers['ft-origami-service-base-path'] || '/';
 	if (!basePath.startsWith('/')) {
 		basePath = `/${basePath}`;
 	}

--- a/lib/middleware/get-base-path.js
+++ b/lib/middleware/get-base-path.js
@@ -4,10 +4,10 @@ module.exports = getBasePath;
 
 function getBasePath(request, response, next) {
 	let basePath = request.headers['x-service-base-path'] || '/';
-	if (basePath.substr(0, 1) !== '/') {
+	if (!basePath.startsWith('/')) {
 		basePath = `/${basePath}`;
 	}
-	if (basePath.substr(-1, 1) !== '/') {
+	if (!basePath.endsWith('/')) {
 		basePath = `${basePath}/`;
 	}
 	request.basePath = response.locals.basePath = basePath;

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -36,8 +36,7 @@ function processImage(config) {
 			// that we find, additional colours are obsolete
 			const tint = transform.tint[0];
 			const hostname = (config.hostname || request.hostname);
-			const basePath = config.basePath || '';
-			transform.setUri(`${request.protocol}://${hostname}${basePath}/v2/images/svgtint/${encodedUri}${hasQueryString ? '&' : '?'}color=${tint}`);
+			transform.setUri(`${request.protocol}://${hostname}/v2/images/svgtint/${encodedUri}${hasQueryString ? '&' : '?'}color=${tint}`);
 			// Clear the tint so that SVGs converted to rasterised
 			// formats don't get double-tinted
 			transform.setTint();

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -3,7 +3,7 @@ module.exports = app => {
 
 	// Service home page
 	app.get('/', (request, response) => {
-		response.redirect(301, '/v2/');
+		response.redirect(301, `${request.basePath}v2/`);
 	});
 
 };

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -1,8 +1,8 @@
 'use strict';
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// Service home page
-	router.get('/', (request, response) => {
+	app.get('/', (request, response) => {
 		response.redirect(301, '/v2/');
 	});
 

--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -1,9 +1,9 @@
 'use strict';
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// v1 endpoint redirect
-	router.use('/v1', (request, response) => {
+	app.use('/v1', (request, response) => {
 		const url = `https://image.webservices.ft.com/v1${request.url}`;
 		response.redirect(301, url);
 	});

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -2,10 +2,10 @@
 
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// v2 api documentation page
-	router.get('/v2/docs/api', (request, response) => {
+	app.get('/v2/docs/api', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/lib/routes/v2/docs/compare.js
+++ b/lib/routes/v2/docs/compare.js
@@ -3,7 +3,7 @@
 const images = require('../../../../data/comparison-images.json');
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// Prepare images
 	const comparisonImages = images.map(image => {
@@ -16,7 +16,7 @@ module.exports = (app, router) => {
 	});
 
 	// v2 image comparison page
-	router.get('/v2/docs/compare', (request, response) => {
+	app.get('/v2/docs/compare', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -2,10 +2,10 @@
 
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// v2 migration page
-	router.get('/v2/docs/migration', (request, response) => {
+	app.get('/v2/docs/migration', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -3,10 +3,10 @@
 const oneWeek = 60 * 60 * 24 * 7;
 const querystring = require('querystring');
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// v2 url-builder page
-	router.get('/v2/docs/url-builder', (request, response) => {
+	app.get('/v2/docs/url-builder', (request, response) => {
 
 		// Gather form data
 		const formData = {

--- a/lib/routes/v2/images-svgtint.js
+++ b/lib/routes/v2/images-svgtint.js
@@ -2,12 +2,12 @@
 
 const tintSvg = require('../../middleware/tint-svg');
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// Image with an HTTP or HTTPS scheme, matches:
 	// /v2/images/svgtint/https://...
 	// /v2/images/svgtint/http://...
-	router.get(
+	app.get(
 		/\/v2\/images\/svgtint\/(https?(:|%3A).*)$/,
 		tintSvg()
 	);

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -8,7 +8,7 @@ const mapCustomScheme = require('../../middleware/map-custom-scheme');
 const oneWeek = 60 * 60 * 24 * 7;
 const processImageRequest = require('../../middleware/process-image-request');
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// Map param numbers to named params
 	function mapParams(request, response, next) {
@@ -74,7 +74,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/fticon:...
 	// /v2/images/raw/fthead:...
 	// /v2/images/debug/ftlogo:...
-	router.get(
+	app.get(
 		/^\/v2\/images\/(raw|debug|metadata)\/((fticon|fthead|ftsocial|ftpodcast|ftlogo)(\-v\d+)?(:|%3A).*)$/i,
 		mapParams,
 		mapCustomScheme(app.imageServiceConfig),
@@ -86,7 +86,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/https://com.ft.imagepublish.prod.s3.amazonaws.com/...
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
-	router.get(
+	app.get(
 		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F){2}(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
 		mapParams,
 		convertToCmsScheme(),
@@ -98,7 +98,7 @@ module.exports = (app, router) => {
 	// Image with a custom scheme, matches:
 	// /v2/images/raw/ftcms:...
 	// /v2/images/debug/ftcms:...
-	router.get(
+	app.get(
 		/^\/v2\/images\/(raw|debug|metadata)\/((ftcms)(:|%3A).*)$/i,
 		mapParams,
 		getCmsUrl(app.imageServiceConfig),
@@ -110,7 +110,7 @@ module.exports = (app, router) => {
 	// /v2/images/raw/https://...
 	// /v2/images/raw/http://...
 	// /v2/images/debug/http://...
-	router.get(
+	app.get(
 		/\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F){2}.*)$/i,
 		mapParams,
 		processImageRequest(app.imageServiceConfig),

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -111,7 +111,7 @@ module.exports = app => {
 	// /v2/images/raw/http://...
 	// /v2/images/debug/http://...
 	app.get(
-		/\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F){2}.*)$/i,
+		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F){2}.*)$/i,
 		mapParams,
 		processImageRequest(app.imageServiceConfig),
 		handleImage

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -2,10 +2,10 @@
 
 const oneWeek = 60 * 60 * 24 * 7;
 
-module.exports = (app, router) => {
+module.exports = app => {
 
 	// v2 home page
-	router.get('/v2', (request, response) => {
+	app.get('/v2', (request, response) => {
 		response.set({
 			'Content-Type': 'text/html; charset=utf-8',
 			'Cache-Control': `public, stale-while-revalidate=${oneWeek}, max-age=${oneWeek}`

--- a/test/integration/helpers/setup-request.js
+++ b/test/integration/helpers/setup-request.js
@@ -2,9 +2,14 @@
 
 module.exports = setupRequest;
 
-function setupRequest(method, endpoint) {
+function setupRequest(method, endpoint, headers) {
 	method = method.toLowerCase();
 	beforeEach(function() {
 		this.request = this.agent[method](endpoint);
+		if (headers) {
+			Object.keys(headers).forEach(header => {
+				this.request.set(header, headers[header]);
+			});
+		}
 	});
 }

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -18,8 +18,7 @@ before(function() {
 		log: mockLog,
 		logLevel: process.env.LOG_LEVEL || 'trace',
 		port: process.env.PORT || null,
-		suppressLogs: true,
-		basePath: ''
+		suppressLogs: true
 	})
 	.then(service => {
 		this.agent = supertest.agent(service);

--- a/test/integration/v2/docs.js
+++ b/test/integration/v2/docs.js
@@ -11,10 +11,27 @@ describe('GET /v2/', function() {
 	itRespondsWithStatus(200);
 	itRespondsWithContentType('text/html');
 
-	it('has a <base> element with the expected baseUrl', function(done) {
+	it('has a <base> element with the expected path', function(done) {
 		this.request.expect(response => {
 			assert.isString(response.text);
 			assert.match(response.text, /<base\s+href="\/"\s*\/>/);
+		}).end(done);
+	});
+
+});
+
+describe('GET /v2/ with an X-Service-Base-Path header', function() {
+
+	setupRequest('GET', '/v2/', {
+		'X-Service-Base-Path': '/foo/bar/'
+	});
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('text/html');
+
+	it('has a <base> element with the expected path', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			assert.match(response.text, /<base\s+href="\/foo\/bar\/"\s*\/>/);
 		}).end(done);
 	});
 

--- a/test/integration/v2/docs.js
+++ b/test/integration/v2/docs.js
@@ -20,10 +20,10 @@ describe('GET /v2/', function() {
 
 });
 
-describe('GET /v2/ with an X-Service-Base-Path header', function() {
+describe('GET /v2/ with an FT-Origami-Service-Base-Path header', function() {
 
 	setupRequest('GET', '/v2/', {
-		'X-Service-Base-Path': '/foo/bar/'
+		'FT-Origami-Service-Base-Path': '/foo/bar/'
 	});
 	itRespondsWithStatus(200);
 	itRespondsWithContentType('text/html');

--- a/test/integration/v2/docs.js
+++ b/test/integration/v2/docs.js
@@ -1,11 +1,21 @@
 'use strict';
 
+const assert = require('proclaim');
 const itRespondsWithContentType = require('../helpers/it-responds-with-content-type');
 const itRespondsWithStatus = require('../helpers/it-responds-with-status');
 const setupRequest = require('../helpers/setup-request');
 
 describe('GET /v2/', function() {
+
 	setupRequest('GET', '/v2/');
 	itRespondsWithStatus(200);
 	itRespondsWithContentType('text/html');
+
+	it('has a <base> element with the expected baseUrl', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			assert.match(response.text, /<base\s+href="\/"\s*\/>/);
+		}).end(done);
+	});
+
 });

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -54,7 +54,6 @@ describe('lib/image-service', () => {
 
 		beforeEach(() => {
 			config = {
-				basePath: '/my/base/path',
 				environment: 'test',
 				port: 1234,
 				systemCode: 'example-system-code'
@@ -307,10 +306,6 @@ describe('lib/image-service', () => {
 			assert.strictEqual(express.mockApp.imageServiceConfig, config);
 		});
 
-		it('sets `app.locals.basePath` to `config.basePath`', () => {
-			assert.strictEqual(express.mockApp.locals.basePath, config.basePath);
-		});
-
 		it('initialises the health-checks', () => {
 			assert.calledOnce(healthChecks.init);
 			assert.calledWithExactly(healthChecks.init, config);
@@ -319,10 +314,6 @@ describe('lib/image-service', () => {
 		it('mounts Morgan middleware to log requests', () => {
 			assert.calledWithExactly(morgan, 'combined');
 			assert.calledWithExactly(express.mockApp.use, morgan.mockMiddleware);
-		});
-
-		it('registers a "/" route', () => {
-			assert.calledWith(express.mockApp.use, express.mockRouter);
 		});
 
 		it('registers a "/__gtg" route', () => {
@@ -356,27 +347,17 @@ describe('lib/image-service', () => {
 			assert.isFunction(requireAll.firstCall.args[0].resolve);
 		});
 
-		it('mounts a static middleware at /', () => {
-			assert.calledTwice(express.static);
+		it('mounts a static middleware', () => {
+			assert.calledOnce(express.static);
 			assert.calledWithExactly(express.static, 'public');
 			assert.calledWithExactly(express.mockApp.use, express.mockStaticMiddleware);
 		});
 
-		it('mounts a static middleware at `config.basePath`', () => {
-			assert.calledTwice(express.static);
-			assert.calledWithExactly(express.static, 'public');
-			assert.calledWithExactly(express.mockApp.use, config.basePath, express.mockStaticMiddleware);
-		});
-
-		it('mounts an express router at `config.basePath`', () => {
-			assert.calledWithExactly(express.mockApp.use, config.basePath, express.mockRouter);
-		});
-
-		it('calls each route with the Express application and Router', () => {
+		it('calls each route with the Express application', () => {
 			const route = sinon.spy();
 			requireAll.firstCall.args[0].resolve(route);
 			assert.calledOnce(route);
-			assert.calledWithExactly(route, express.mockApp, express.mockRouter);
+			assert.calledWithExactly(route, express.mockApp);
 		});
 
 		it('mounts middleware to handle routes that are not found', () => {
@@ -434,19 +415,6 @@ describe('lib/image-service', () => {
 					assert.strictEqual(caughtError, expressError);
 				});
 
-			});
-
-		});
-
-		describe('when `config.basePath` is not set', () => {
-
-			beforeEach(() => {
-				delete config.basePath;
-				returnedPromise = imageService(config);
-			});
-
-			it('sets `config.basePath` to an empty string', () => {
-				assert.strictEqual(config.basePath, '');
 			});
 
 		});

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -8,6 +8,7 @@ const sinon = require('sinon');
 describe('lib/image-service', () => {
 	let basePath;
 	let express;
+	let getBasePath;
 	let handleErrors;
 	let healthChecks;
 	let httpProxy;
@@ -21,6 +22,9 @@ describe('lib/image-service', () => {
 
 		express = require('../mock/n-express.mock');
 		mockery.registerMock('@financial-times/n-express', express);
+
+		getBasePath = sinon.spy();
+		mockery.registerMock('./middleware/get-base-path', getBasePath);
 
 		handleErrors = sinon.stub().returns(sinon.spy());
 		mockery.registerMock('./middleware/handle-errors', handleErrors);
@@ -314,6 +318,10 @@ describe('lib/image-service', () => {
 		it('mounts Morgan middleware to log requests', () => {
 			assert.calledWithExactly(morgan, 'combined');
 			assert.calledWithExactly(express.mockApp.use, morgan.mockMiddleware);
+		});
+
+		it('mounts the getBasePath middleware', () => {
+			assert.calledWithExactly(express.mockApp.use, getBasePath);
 		});
 
 		it('registers a "/__gtg" route', () => {

--- a/test/unit/lib/middleware/get-base-path.js
+++ b/test/unit/lib/middleware/get-base-path.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const assert = require('proclaim');
+const sinon = require('sinon');
+
+describe('lib/middleware/get-base-path', () => {
+	let express;
+	let getBasePath;
+
+	beforeEach(() => {
+
+		express = require('../../mock/n-express.mock');
+
+		getBasePath = require('../../../../lib/middleware/get-base-path');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(getBasePath);
+	});
+
+	describe('getBasePath(request, response, next)', () => {
+		let next;
+
+		beforeEach(() => {
+			next = sinon.spy();
+			getBasePath(express.mockRequest, express.mockResponse, next);
+		});
+
+		it('sets `request.basePath` to "/"', () => {
+			assert.strictEqual(express.mockRequest.basePath, '/');
+		});
+
+		it('sets `response.locals.basePath` to "/"', () => {
+			assert.strictEqual(express.mockResponse.locals.basePath, '/');
+		});
+
+		it('calls `next` with no error', () => {
+			assert.calledOnce(next);
+			assert.calledWithExactly(next);
+		});
+
+		describe('when the request has an `X-Service-Base-Url` header', () => {
+
+			beforeEach(() => {
+				next.reset();
+				express.mockRequest.headers['x-service-base-path'] = '/foo/bar/';
+				getBasePath(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('sets `request.basePath` to the header value', () => {
+				assert.strictEqual(express.mockRequest.basePath, '/foo/bar/');
+			});
+
+			it('sets `response.locals.basePath` to the header value', () => {
+				assert.strictEqual(express.mockResponse.locals.basePath, '/foo/bar/');
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+		});
+
+		describe('when the `X-Service-Base-Url` header does not begin or end with a slash', () => {
+
+			beforeEach(() => {
+				next.reset();
+				express.mockRequest.headers['x-service-base-path'] = 'foo/bar';
+				getBasePath(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('sets `request.basePath` to the header value with slashes added', () => {
+				assert.strictEqual(express.mockRequest.basePath, '/foo/bar/');
+			});
+
+			it('sets `response.locals.basePath` to the header value with slashes added', () => {
+				assert.strictEqual(express.mockResponse.locals.basePath, '/foo/bar/');
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/middleware/get-base-path.js
+++ b/test/unit/lib/middleware/get-base-path.js
@@ -39,11 +39,11 @@ describe('lib/middleware/get-base-path', () => {
 			assert.calledWithExactly(next);
 		});
 
-		describe('when the request has an `X-Service-Base-Url` header', () => {
+		describe('when the request has an `FT-Origami-Service-Base-Path` header', () => {
 
 			beforeEach(() => {
 				next.reset();
-				express.mockRequest.headers['x-service-base-path'] = '/foo/bar/';
+				express.mockRequest.headers['ft-origami-service-base-path'] = '/foo/bar/';
 				getBasePath(express.mockRequest, express.mockResponse, next);
 			});
 
@@ -62,11 +62,11 @@ describe('lib/middleware/get-base-path', () => {
 
 		});
 
-		describe('when the `X-Service-Base-Url` header does not begin or end with a slash', () => {
+		describe('when the `FT-Origami-Service-Base-Path` header does not begin or end with a slash', () => {
 
 			beforeEach(() => {
 				next.reset();
-				express.mockRequest.headers['x-service-base-path'] = 'foo/bar';
+				express.mockRequest.headers['ft-origami-service-base-path'] = 'foo/bar';
 				getBasePath(express.mockRequest, express.mockResponse, next);
 			});
 

--- a/test/unit/lib/middleware/process-image-request.js
+++ b/test/unit/lib/middleware/process-image-request.js
@@ -155,7 +155,7 @@ describe('lib/middleware/process-image-request', () => {
 
 				beforeEach(() => {
 					next.reset();
-					imageTransformError = new Error('image tranform error');
+					imageTransformError = new Error('image transform error');
 					ImageTransform.throws(imageTransformError);
 					middleware(express.mockRequest, express.mockResponse, next);
 				});

--- a/test/unit/mock/n-express.mock.js
+++ b/test/unit/mock/n-express.mock.js
@@ -17,8 +17,6 @@ const mockApp = module.exports.mockApp = {
 
 const mockServer = module.exports.mockServer = {};
 
-const mockRouter = module.exports.mockRouter = {};
-
 const mockStaticMiddleware = module.exports.mockStaticMiddleware = {};
 
 module.exports.mockRequest = {
@@ -38,5 +36,4 @@ module.exports.mockResponse = {
 
 mockApp.listen.resolves(mockServer);
 express.returns(mockApp);
-express.Router = sinon.stub().returns(mockRouter);
 express.static = sinon.stub().returns(mockStaticMiddleware);

--- a/test/unit/mock/n-express.mock.js
+++ b/test/unit/mock/n-express.mock.js
@@ -27,6 +27,7 @@ module.exports.mockRequest = {
 
 module.exports.mockResponse = {
 	app: mockApp,
+	locals: {},
 	redirect: sinon.stub().returnsThis(),
 	render: sinon.stub().returnsThis(),
 	send: sinon.stub().returnsThis(),

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title>{{title}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<base href="/"/>
+	<base href="{{basePath}}"/>
 
 	<script>
 		var cutsTheMustard = (

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title>{{title}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<base href="{{basePath}}/"/>
+	<base href="/"/>
 
 	<script>
 		var cutsTheMustard = (

--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -72,7 +72,7 @@
 									</a>
 									<div class="o-forms o-forms--wide">
 										<label for="builder-output" class="o-forms__label">URL for the optimised image</label>
-										<textarea class="url-builder-output" id="builder-output" class="o-forms__textarea" readonly>https://www.ft.com/__origami/service/image/{{imagePreviewUrl}}</textarea>
+										<textarea class="url-builder-output" id="builder-output" class="o-forms__textarea" readonly>https://www.ft.com{{basePath}}{{imagePreviewUrl}}</textarea>
 									</div>
 								{{/if}}
 							</div>

--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -72,7 +72,7 @@
 									</a>
 									<div class="o-forms o-forms--wide">
 										<label for="builder-output" class="o-forms__label">URL for the optimised image</label>
-										<textarea class="url-builder-output" id="builder-output" class="o-forms__textarea" readonly>https://www.ft.com{{basePath}}/{{imagePreviewUrl}}</textarea>
+										<textarea class="url-builder-output" id="builder-output" class="o-forms__textarea" readonly>https://www.ft.com/__origami/service/image/{{imagePreviewUrl}}</textarea>
 									</div>
 								{{/if}}
 							</div>


### PR DESCRIPTION
CDNs can now send an FT-Origami-Service-Base-Path header to change the
base path across the site documentation. This ensures that when the CDN
performs rewrites, they don't break. It also allows us to access the
service from either ft.com/__origami/... or the heroku URLs without
having to mount routes twice.