### PR TITLE
Allow empty transform parameters

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -252,8 +252,8 @@ module.exports = class ImageTransform {
 	 * @static
 	 */
 	static sanitizeNumericValue(value, errorMessage = 'Expected a whole positive number') {
-		if (value === undefined) {
-			return value;
+		if (value === undefined || value === '') {
+			return undefined;
 		}
 		if (typeof value !== 'string' && typeof value !== 'number') {
 			throw new Error(errorMessage);
@@ -274,8 +274,8 @@ module.exports = class ImageTransform {
 	 * @static
 	 */
 	static sanitizeEnumerableValue(value, allowedValues, errorMessage) {
-		if (value === undefined) {
-			return value;
+		if (value === undefined || value === '') {
+			return undefined;
 		}
 		if (arguments.length < 3) {
 			errorMessage = `Expected one of ${allowedValues.join(', ')}`;
@@ -294,8 +294,8 @@ module.exports = class ImageTransform {
 	 * @static
 	 */
 	static sanitizeColorValue(value, errorMessage = 'Expected a valid color') {
-		if (value === undefined) {
-			return value;
+		if (value === undefined || value === '') {
+			return undefined;
 		}
 		value = value.trim();
 		if (value === 'transparent') {

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -469,6 +469,14 @@ describe('lib/image-transform', () => {
 
 		});
 
+		describe('when `value` is an empty string', () => {
+
+			it('returns `undefined`', () => {
+				assert.isUndefined(ImageTransform.sanitizeNumericValue(''));
+			});
+
+		});
+
 		describe('when `value` is smaller than `1`', () => {
 
 			it('throws an error', () => {
@@ -524,6 +532,14 @@ describe('lib/image-transform', () => {
 
 			it('returns `undefined`', () => {
 				assert.isUndefined(ImageTransform.sanitizeEnumerableValue());
+			});
+
+		});
+
+		describe('when `value` is an empty string', () => {
+
+			it('returns `undefined`', () => {
+				assert.isUndefined(ImageTransform.sanitizeEnumerableValue(''));
 			});
 
 		});
@@ -597,6 +613,14 @@ describe('lib/image-transform', () => {
 
 			it('returns `undefined`', () => {
 				assert.isUndefined(ImageTransform.sanitizeColorValue());
+			});
+
+		});
+
+		describe('when `value` is an empty string', () => {
+
+			it('returns `undefined`', () => {
+				assert.isUndefined(ImageTransform.sanitizeColorValue(''));
 			});
 
 		});


### PR DESCRIPTION
This allows end-users to specify transform parameters without a value,
and makes V2 more compatible with V1.

Resolves #195 (cc @quarterto, @rowanbeentje)