### PR TITLE
Don't specify a port for integration tests

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -17,7 +17,7 @@ before(function() {
 		defaultLayout: 'main',
 		environment: 'test',
 		log: mockLog,
-		port: process.env.PORT || null,
+		port: null,
 		requestLogFormat: null
 	})
 	.listen()


### PR DESCRIPTION
Otherwise a port in the .env file will override this, causing
integration tests to fail.