### PR TITLE
Handle connection resets

### DIFF
--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -19,6 +19,9 @@ function getCmsUrl() {
 		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img${query}`;
 		const v2Uri = `http://prod-upp-image-read.ft.com/${cmsId}${query}`;
 
+		// Keep track of which API we last checked
+		let lastRequestedUri = v2Uri;
+
 		// First try fetching the v2 image
 		requestPromise({
 			uri: v2Uri,
@@ -30,6 +33,7 @@ function getCmsUrl() {
 					return v2Uri;
 				}
 				// If the v2 image can't be found, try v1
+				lastRequestedUri = v1Uri;
 				return requestPromise({
 					uri: v1Uri,
 					method: 'HEAD'
@@ -50,8 +54,11 @@ function getCmsUrl() {
 			})
 			.catch(error => {
 				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
-					const dnsError = error;
-					error = new Error(`DNS lookup failed for "${dnsError.hostname}"`);
+					error = new Error(`DNS lookup failed for "${lastRequestedUri}"`);
+				}
+				if (error.code === 'ECONNRESET') {
+					const resetError = error;
+					error = new Error(`Connection reset when requesting "${lastRequestedUri}" (${resetError.syscall})`);
 				}
 				next(error);
 			});

--- a/lib/middleware/tint-svg.js
+++ b/lib/middleware/tint-svg.js
@@ -50,6 +50,13 @@ function tintSvg() {
 			// If the request errors, report this using
 			// the standard error middleware
 			.on('error', error => {
+				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
+					error = new Error(`DNS lookup failed for "${uri}"`);
+				}
+				if (error.code === 'ECONNRESET') {
+					const resetError = error;
+					error = new Error(`Connection reset when requesting "${uri}" (${resetError.syscall})`);
+				}
 				return next(error);
 			})
 			// Pipe the image request through the tint


### PR DESCRIPTION
This handles errors in the CMS checking middleware and the SVG tinting
middleware. Hopefully this will help us debug our intermittent
ECONNRESET errors.