### PR TITLE
Handle broken Cloudinary responses

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -135,7 +135,7 @@ function createProxy(errorHandler) {
 		const accept = JSON.stringify(request.headers['accept'] || null);
 		const imageFormat = JSON.stringify(proxyResponse.headers['Content-Type'] || null);
 		const ftImageFormat = JSON.stringify(proxyResponse.headers['FT-Image-Format'] || null);
-		console.log(`IMAGE-PROXY-DEBUG: ua=${userAgent} nua=${normalisedUserAgent} accept=${accept} ftImageFormat=${ftImageFormat} imageFormat=${imageFormat}`);
+		request.app.origami.log.info(`IMAGE-PROXY-DEBUG: ua=${userAgent} nua=${normalisedUserAgent} accept=${accept} ftImageFormat=${ftImageFormat} imageFormat=${imageFormat}`);
 
 		// ==============================
 

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const HealthChecks = require('./health-checks');
+const httpError = require('http-errors');
 const httpProxy = require('http-proxy');
 const oneWeek = 60 * 60 * 24 * 7;
 const origamiService = require('@financial-times/origami-service');
@@ -91,6 +92,16 @@ function createProxy(errorHandler) {
 				response.cloudinaryError.message = 'The requested image could not be found';
 				response.cloudinaryError.status = 404;
 			}
+			return;
+		}
+
+		// If we have a 40x/50x response at this point, Cloudinary
+		// is so broken that it can't even send its own X-CLD-Error
+		// header. We need to handle this to prevent these errors
+		// from being cached
+		if (proxyResponse.statusCode >= 400) {
+			proxyResponse.headers = {};
+			response.cloudinaryError = httpError(proxyResponse.statusCode);
 			return;
 		}
 

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -105,6 +105,15 @@ function createProxy(errorHandler) {
 			return;
 		}
 
+		// If we have a 30x response at this point, something has
+		// gone pretty wrong with Cloudinary's fetch API – it should
+		// never redirect
+		if (proxyResponse.statusCode >= 300) {
+			proxyResponse.headers = {};
+			response.cloudinaryError = httpError(500);
+			return;
+		}
+
 		// Define our own headers for proxy responses
 		proxyResponse.headers = {
 			'Access-Control-Allow-Origin': '*',

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -107,6 +107,7 @@ describe('lib/image-service', () => {
 				};
 				proxyRequest = httpProxy.mockProxyRequest;
 				request = {
+					app: origamiService.mockApp,
 					headers: {
 						'accept-encoding': 'bar',
 						'accept-language': 'baz',
@@ -169,6 +170,7 @@ describe('lib/image-service', () => {
 					'last-modified': 'some time'
 				};
 				request = {
+					app: origamiService.mockApp,
 					headers: {},
 					params: {
 						scheme: 'http'

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -333,6 +333,29 @@ describe('lib/image-service', () => {
 
 			});
 
+			describe('when the proxy response has a 30x status', () => {
+				let response;
+
+				beforeEach(() => {
+					proxyResponse.statusCode = 302;
+					proxyResponse.headers.location = 'https://redirect/';
+					console.log(proxyResponse.headers);
+					response = {};
+					handler(proxyResponse, request, response);
+				});
+
+				it('sets the headers of the proxy response to an empty object', () => {
+					assert.deepEqual(httpProxy.mockProxyResponse.headers, {});
+				});
+
+				it('sets the response `cloudinaryError` property to an error object representing the error', () => {
+					assert.instanceOf(response.cloudinaryError, Error);
+					assert.strictEqual(response.cloudinaryError.message, 'Internal Server Error');
+					assert.strictEqual(response.cloudinaryError.status, 500);
+				});
+
+			});
+
 		});
 
 		it('adds a listener on the HTTP proxy\'s `error` event', () => {

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -312,6 +312,27 @@ describe('lib/image-service', () => {
 
 			});
 
+			describe('when the proxy response has no `X-Cld-Error` header but has a non-200 status', () => {
+				let response;
+
+				beforeEach(() => {
+					proxyResponse.statusCode = 503;
+					response = {};
+					handler(proxyResponse, request, response);
+				});
+
+				it('sets the headers of the proxy response to an empty object', () => {
+					assert.deepEqual(httpProxy.mockProxyResponse.headers, {});
+				});
+
+				it('sets the response `cloudinaryError` property to an error object representing the error', () => {
+					assert.instanceOf(response.cloudinaryError, Error);
+					assert.strictEqual(response.cloudinaryError.message, 'Service Unavailable');
+					assert.strictEqual(response.cloudinaryError.status, 503);
+				});
+
+			});
+
 		});
 
 		it('adds a listener on the HTTP proxy\'s `error` event', () => {

--- a/test/unit/mock/log.mock.js
+++ b/test/unit/mock/log.mock.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	error: sinon.spy(),
+	info: sinon.spy(),
+	warn: sinon.spy()
+};

--- a/test/unit/mock/origami-service.mock.js
+++ b/test/unit/mock/origami-service.mock.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const log = require('./log.mock');
 const sinon = require('sinon');
 require('sinon-as-promised');
 
@@ -11,6 +12,7 @@ const mockApp = module.exports.mockApp = {
 	get: sinon.stub(),
 	listen: sinon.stub(),
 	locals: {},
+	origami: {log},
 	set: sinon.stub(),
 	use: sinon.stub()
 };
@@ -27,6 +29,7 @@ origamiService.middleware = {
 };
 
 module.exports.mockRequest = {
+	app: mockApp,
 	headers: {},
 	query: {},
 	params: {}


### PR DESCRIPTION
This PR correctly handles non-200 Cloudinary responses which are so broken that they don't send their usual `X-Cld-Error` header. We saw this happen recently with the AWS failures.