### PR TITLE
Use only alphanumeric and dashes for surrogate keys

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -119,7 +119,9 @@ function createProxy(errorHandler) {
 		const keyForImageType = proxyResponse.headers['Content-Type'];
 		const keyForScheme = request.params.scheme;
 
-		proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} ${keyForImageType} ${keyForScheme}`;
+		const normaliseKeys = key => (key || '').replace(/[^a-z0-9-]/gi, '').toLowerCase();
+
+		proxyResponse.headers['Surrogate-Key'] = `${normaliseKeys(keyForAllImages)} ${normaliseKeys(keyForImageType)} ${normaliseKeys(keyForScheme)}`;
 
 		if (request.transform && request.transform.getDpr()) {
 			proxyResponse.headers['Content-Dpr'] = request.transform.getDpr();

--- a/test/integration/v2/images-raw.js
+++ b/test/integration/v2/images-raw.js
@@ -258,57 +258,57 @@ describe('GET /v2/images/raw…', function() {
 		describe('adds specific keys for image content types', function() {
 			describe('ftbrand', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.ftbrand}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/png/);
+				itRespondsWithHeader('surrogate-key', /imagepng/);
 			});
 
 			describe('ftcms', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.ftcms}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/jpeg/);
+				itRespondsWithHeader('surrogate-key', /imagejpeg/);
 			});
 
 			describe('fthead', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.fthead}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/png/);
+				itRespondsWithHeader('surrogate-key', /imagepng/);
 			});
 
 			describe('fticon', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.fticon}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/svg\+xml/);
+				itRespondsWithHeader('surrogate-key', /imagesvgxml/);
 			});
 
 			describe('ftlogo', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.ftlogo}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/svg\+xml/);
+				itRespondsWithHeader('surrogate-key', /imagesvgxml/);
 			});
 
 			describe('ftpodcast', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.ftpodcast}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/png/);
+				itRespondsWithHeader('surrogate-key', /imagepng/);
 			});
 
 			describe('ftsocial', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.ftsocial}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/svg\+xml/);
+				itRespondsWithHeader('surrogate-key', /imagesvgxml/);
 			});
 
 			describe('http', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.httpftcms}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/jpeg/);
+				itRespondsWithHeader('surrogate-key', /imagejpeg/);
 			});
 
 			describe('https', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.httpsftcms}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/jpeg/);
+				itRespondsWithHeader('surrogate-key', /imagejpeg/);
 			});
 
 			describe('protocolRelative', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.protocolRelativeftcms}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/jpeg/);
+				itRespondsWithHeader('surrogate-key', /imagejpeg/);
 			});
 
 			describe('specialisttitle', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.specialisttitle}?source=test`);
-				itRespondsWithHeader('surrogate-key', /image\/svg\+xml/);
+				itRespondsWithHeader('surrogate-key', /imagesvgxml/);
 			});
 		});
 

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -193,7 +193,7 @@ describe('lib/image-service', () => {
 					'Expires': 'Thu, 08 Jan 1970 00:00:10 GMT',
 					'FT-Image-Format': 'default',
 					'Last-Modified': 'some time',
-					'Surrogate-Key': 'origami-image-service image/jpeg http',
+					'Surrogate-Key': 'origami-image-service imagejpeg http',
 					'Vary': 'FT-image-format, Content-Dpr'
 				});
 			});


### PR DESCRIPTION
During the Cloudinary issues yesterday we wanted to purge the broken images from the CDN but found that surrogate keys which contains spaces, slashes, or non-ascii characters are difficult to use. We control our surrogate keys so I thought we can strip back the keys to only alphanumeric and dashes, that way they are still human readable and simple to use when purging.