### PR TITLE
Correct malformed HTTP/HTTPS schemes

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -233,6 +233,10 @@ module.exports = class ImageTransform {
 		if (/^\/\//.test(value)) {
 			value = `http:${value}`;
 		}
+		// Replace malformed http:abc or http:/abc schemes
+		if (/^https?:/.test(value)) {
+			value = value.replace(/^(https?):\/*/, '$1://');
+		}
 		if (value.indexOf('#') !== -1) {
 			value = value.split('#')[0];
 		}

--- a/lib/middleware/convert-to-cms-scheme.js
+++ b/lib/middleware/convert-to-cms-scheme.js
@@ -3,7 +3,7 @@
 module.exports = convertToCmsScheme;
 
 function convertToCmsScheme() {
-	const cmsRegExp = /^(https?:)?\/\/(?:prod-upp-image-read\.ft\.com|com\.ft\.imagepublish\.prod(-us)?\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.(img|png|jpg|jpeg|gif))?(\?.+)?$/i;
+	const cmsRegExp = /^(https?:)?\/*(?:prod-upp-image-read\.ft\.com|com\.ft\.imagepublish\.prod(-us)?\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.(img|png|jpg|jpeg|gif))?(\?.+)?$/i;
 	return (request, response, next) => {
 		const match = request.params.imageUrl.match(cmsRegExp);
 		if (match && match[3]) {

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -99,7 +99,7 @@ module.exports = app => {
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F){2}(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
+		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
 		mapParams,
 		mapScheme,
 		convertToCmsScheme(),
@@ -127,7 +127,7 @@ module.exports = app => {
 	// /v2/images/raw/http://...
 	// /v2/images/debug/http://...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F){2}.*)$/i,
+		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F)*.*)$/i,
 		mapParams,
 		mapScheme,
 		requireValidSourceParam,

--- a/test/integration/v2/images-raw.js
+++ b/test/integration/v2/images-raw.js
@@ -16,6 +16,8 @@ const testImageUris = {
 	ftsocial: 'ftsocial:whatsapp',
 	httpftcms: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	httpsftcms: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	httpftcmsmalformed: 'http:/im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	httpsftcmsmalformed: 'https:im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	http: 'http://assets1.howtospendit.ft-static.com/images/06/cf/71/06cf7131-fd60-43b8-813a-a296acd81561_main_crop.jpg',
 	https: 'https://assets1.howtospendit.ft-static.com/images/06/cf/71/06cf7131-fd60-43b8-813a-a296acd81561_main_crop.jpg',
 	protocolRelative: '//assets1.howtospendit.ft-static.com/images/06/cf/71/06cf7131-fd60-43b8-813a-a296acd81561_main_crop.jpg',
@@ -45,6 +47,30 @@ describe('GET /v2/images/raw…', function() {
 
 	describe('/https%3A%2F%2F… (HTTPS scheme encoded)', function() {
 		setupRequest('GET', `/v2/images/raw/${encodeURIComponent(testImageUris.httpsftcms)}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+
+	describe('/http:/… (HTTP scheme unencoded malformed)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.httpftcmsmalformed}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+
+	describe('/https:… (HTTPS scheme unencoded malformed)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.httpsftcmsmalformed}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+
+	describe('/http%3A%2F… (HTTP scheme encoded malformed)', function() {
+		setupRequest('GET', `/v2/images/raw/${encodeURIComponent(testImageUris.httpftcmsmalformed)}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+
+	describe('/https%3A… (HTTPS scheme encoded malformed)', function() {
+		setupRequest('GET', `/v2/images/raw/${encodeURIComponent(testImageUris.httpsftcmsmalformed)}?source=test`);
 		itRespondsWithStatus(200);
 		itRespondsWithContentType('image/jpeg');
 	});

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -385,6 +385,24 @@ describe('lib/image-transform', () => {
 
 		});
 
+		describe('when `value` has a malformed http/https scheme with only one slash', () => {
+
+			it('returns `value` with the additional slash added', () => {
+				assert.strictEqual(ImageTransform.sanitizeUriValue('http:/foo/'), 'http://foo/');
+				assert.strictEqual(ImageTransform.sanitizeUriValue('https:/foo/'), 'https://foo/');
+			});
+
+		});
+
+		describe('when `value` has a malformed http/https scheme with no slashes', () => {
+
+			it('returns `value` with the additional slash added', () => {
+				assert.strictEqual(ImageTransform.sanitizeUriValue('http:foo/'), 'http://foo/');
+				assert.strictEqual(ImageTransform.sanitizeUriValue('https:foo/'), 'https://foo/');
+			});
+
+		});
+
 		describe('when `value` contains a hash character', () => {
 
 			it('returns `value` without any of the content after the hash', () => {


### PR DESCRIPTION
We've seen a few HTTP/HTTPS-schemed images that are malformed,
containing only one slash after the colon. After some testing, we
discovered that V1 of the service supports both http:/foo and http:foo
URLs. V2 now does too.