### PR TITLE
Cache-bust the Cloudinary health-check every 5 minutes

### DIFF
--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -13,9 +13,6 @@ module.exports = class HealthChecks {
 		cloudinary.config({
 			cloud_name: options.cloudinaryAccountName
 		});
-		this.cloudinaryCheckUrl = cloudinary.url('https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img', {
-			type: 'fetch'
-		});
 
 		const customSchemeCheckBaseUrl = options.customSchemeStore.replace(/\/+$/, '');
 		this.customSchemeCheckUrl = `${customSchemeCheckBaseUrl}/fticon/v1/cross.svg`;
@@ -46,7 +43,10 @@ module.exports = class HealthChecks {
 	}
 
 	retrieveData() {
-		this.pingService('cloudinary', this.cloudinaryCheckUrl);
+		const interval = (5 * 60 * 1000);
+		const date = new Date(Math.floor(Date.now() / interval) * interval);
+		const cloudinaryCheckUrl = `https://www.ft.com/__origami/service/imageset-data/1x1.gif?cachebust=${date.toISOString()}`;
+		this.pingService('cloudinary', cloudinary.url(cloudinaryCheckUrl, {type: 'fetch'}));
 		this.pingService('customSchemeStore', this.customSchemeCheckUrl);
 	}
 

--- a/test/unit/mock/cloudinary.mock.js
+++ b/test/unit/mock/cloudinary.mock.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	config: sinon.stub(),
+	url: sinon.stub()
+};


### PR DESCRIPTION
This means that we're guaranteed to notice cloudinary issues within 5
minutes, and Cloudinary issues will definitely trigger healthcheck
warnings.