### PR TITLE
Unique surrogate key for each image being transformed ✨

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -141,7 +141,7 @@ function createProxy(errorHandler) {
 
 		const normaliseKeys = key => (key || '').replace(/[^a-z0-9-]/gi, '').toLowerCase();
 
-		proxyResponse.headers['Surrogate-Key'] = `${normaliseKeys(keyForAllImages)} ${normaliseKeys(keyForImageType)} ${normaliseKeys(keyForScheme)}`;
+		proxyResponse.headers['Surrogate-Key'] = `${normaliseKeys(keyForAllImages)} ${normaliseKeys(keyForImageType)} ${normaliseKeys(keyForScheme)} ${request.params.schemeUrl}`;
 
 		if (request.transform && request.transform.getDpr()) {
 			proxyResponse.headers['Content-Dpr'] = request.transform.getDpr();

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -18,6 +18,7 @@ function getCmsUrl() {
 		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
 		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img${query}`;
 		const v2Uri = `http://prod-upp-image-read.ft.com/${cmsId}${query}`;
+		request.params.schemeUrl = `ftcms:${cmsId}`;
 
 		// Keep track of which API we last checked
 		let lastRequestedUri = v2Uri;

--- a/lib/middleware/map-custom-scheme.js
+++ b/lib/middleware/map-custom-scheme.js
@@ -9,6 +9,8 @@ function mapCustomScheme(config) {
 	return (request, response, next) => {
 
 		const originalUrl = request.params.imageUrl;
+		request.params.schemeUrl = originalUrl;
+
 		let customSchemeUrl;
 
 		// Build a cache-busting string – the current ISO week

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -18,6 +18,7 @@ module.exports = app => {
 	// Map param numbers to named params
 	function mapParams(request, response, next) {
 		request.params.imageMode = request.params[0];
+		request.params.schemeUrl = request.params[1];
 		request.params.imageUrl = request.params[1];
 		next();
 	}
@@ -65,7 +66,8 @@ module.exports = app => {
 
 		// Proxy to Cloudinary
 		app.proxy.web(request, response, {
-			target: request.appliedTransform
+			target: request.appliedTransform,
+			imageKey: request.params.imageUrl
 		});
 	}
 

--- a/test/integration/v2/images-raw.js
+++ b/test/integration/v2/images-raw.js
@@ -409,5 +409,77 @@ describe('GET /v2/images/raw…', function() {
 				itRespondsWithHeader('surrogate-key', /specialisttitle/);
 			});
 		});
+
+		describe('adds key for specific image requested', function() {
+			describe('ftbrand', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.ftbrand}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftbrand\:brussels\-blog/);
+			});
+
+			describe('ftcms', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.ftcms}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftcms\:6c5a2f8c\-18ca\-4afa\-80ff\-7d56e41172b1/);
+			});
+
+			describe('fthead', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.fthead}?source=test`);
+				itRespondsWithHeader('surrogate-key', /fthead\:martin\-wolf/);
+			});
+
+			describe('fticon', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.fticon}?source=test`);
+				itRespondsWithHeader('surrogate-key', /fticon\:cross/);
+			});
+
+			describe('ftlogo', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.ftlogo}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftlogo\:brand\-ft/);
+			});
+
+			describe('ftpodcast', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.ftpodcast}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftpodcast\:arts/);
+			});
+
+			describe('ftsocial', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.ftsocial}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftsocial\:whatsapp/);
+			});
+
+			describe('httpftcms', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.httpftcms}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftcms\:a60ae24b\-b87f\-439c\-bf1b\-6e54946b4cf2/);
+			});
+
+			describe('httpsftcms', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.httpsftcms}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftcms\:a60ae24b\-b87f\-439c\-bf1b\-6e54946b4cf2/);
+			});
+
+			describe('http', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.http}?source=test`);
+				itRespondsWithHeader('surrogate-key', /http\:\/\/assets1\.howtospendit\.ft\-static\.com\/images\/06\/cf\/71\/06cf7131\-fd60\-43b8\-813a\-a296acd81561\_main\_crop\.jpg/);
+			});
+
+			describe('https', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.https}?source=test`);
+				itRespondsWithHeader('surrogate-key', /https\:\/\/assets1\.howtospendit\.ft\-static\.com\/images\/06\/cf\/71\/06cf7131\-fd60\-43b8\-813a\-a296acd81561\_main\_crop\.jpg/);
+			});
+
+			describe('protocolRelativeftcms', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.protocolRelativeftcms}?source=test`);
+				itRespondsWithHeader('surrogate-key', /ftcms\:a60ae24b\-b87f\-439c\-bf1b\-6e54946b4cf2/);
+			});
+
+			describe('protocolRelative', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.protocolRelative}?source=test`);
+				itRespondsWithHeader('surrogate-key', /\/\/assets1\.howtospendit\.ft\-static\.com\/images\/06\/cf\/71\/06cf7131\-fd60\-43b8\-813a\-a296acd81561\_main\_crop\.jpg/);
+			});
+
+			describe('specialisttitle', function() {
+				setupRequest('GET', `/v2/images/raw/${testImageUris.specialisttitle}?source=test`);
+				itRespondsWithHeader('surrogate-key', /specialisttitle\:ned\-logo/);
+			});
+		});
 	});
 });

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -173,7 +173,8 @@ describe('lib/image-service', () => {
 					app: origamiService.mockApp,
 					headers: {},
 					params: {
-						scheme: 'http'
+						scheme: 'http',
+						schemeUrl: 'http://example.com/picture.png'
 					}
 				};
 				handler(proxyResponse, request);
@@ -195,7 +196,7 @@ describe('lib/image-service', () => {
 					'Expires': 'Thu, 08 Jan 1970 00:00:10 GMT',
 					'FT-Image-Format': 'default',
 					'Last-Modified': 'some time',
-					'Surrogate-Key': 'origami-image-service imagejpeg http',
+					'Surrogate-Key': 'origami-image-service imagejpeg http http://example.com/picture.png',
 					'Vary': 'FT-image-format, Content-Dpr'
 				});
 			});


### PR DESCRIPTION
If this lands, it would be possible to add another purge endpoint which is used to purge a specific image.

Example:
Image wanting to be purged --
https://www.ft.com/__origami/service/image/v2/images/raw/ftsocial-v2:twitter?source=docs
How to purge the image (You would need the api header set with the correct api key) --
https://www.ft.com/__origami/service/image/v2/images/purge/ftsocial-v2:twitter?source=docs
That purge endpoint could grab the surrogate key which is specific to that original image and purge it.