### PR TITLE
Cache ftcms images in Fastly for a year

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -4,6 +4,7 @@ const HealthChecks = require('./health-checks');
 const httpError = require('http-errors');
 const httpProxy = require('http-proxy');
 const oneWeek = 60 * 60 * 24 * 7;
+const oneYear = oneWeek * 52;
 const origamiService = require('@financial-times/origami-service');
 const requireAll = require('require-all');
 const url = require('url');
@@ -134,6 +135,15 @@ function createProxy(errorHandler) {
 			proxyResponse.headers['FT-Image-Format'] = 'jpegxr';
 		} else {
 			proxyResponse.headers['FT-Image-Format'] = 'default';
+		}
+
+		switch (request.params.scheme) {
+			case 'ftcms':
+				proxyResponse.headers['Surrogate-Control'] = `max-age=${oneYear}, stale-while-revalidate=${oneYear}, stale-if-error=${oneYear}`;
+				break;
+			default:
+				proxyResponse.headers['Surrogate-Control'] = proxyResponse.headers['Cache-Control'];
+				break;
 		}
 
 		const keyForAllImages = 'origami-image-service';

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -196,6 +196,7 @@ describe('lib/image-service', () => {
 					'Expires': 'Thu, 08 Jan 1970 00:00:10 GMT',
 					'FT-Image-Format': 'default',
 					'Last-Modified': 'some time',
+					'Surrogate-Control': 'public, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800',
 					'Surrogate-Key': 'origami-image-service imagejpeg http http://example.com/picture.png',
 					'Vary': 'FT-image-format, Content-Dpr'
 				});
@@ -354,6 +355,22 @@ describe('lib/image-service', () => {
 					assert.strictEqual(response.cloudinaryError.status, 500);
 				});
 
+			});
+
+			describe('when the request is for an FTCMS image', () => {
+				it('Sets the Surrogate-Control header to a year', () => {
+					request.params.scheme = 'ftcms';
+					handler(proxyResponse, request);
+					assert.strictEqual(httpProxy.mockProxyResponse.headers['Surrogate-Control'], 'max-age=31449600, stale-while-revalidate=31449600, stale-if-error=31449600');
+				});
+			});
+
+			describe('when the request is not for an FTCMS image', () => {
+				it('Sets the Surrogate-Control header to a year', () => {
+					request.params.scheme = 'https';
+					handler(proxyResponse, request);
+					assert.strictEqual(httpProxy.mockProxyResponse.headers['Surrogate-Control'], 'public, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800');
+				});
 			});
 
 		});


### PR DESCRIPTION
FTCMS image IDs are unique, any changes made to an FTCMS image will cause a new FTCMS ID to be generated. This enables us to cache these images for a huge amount of time! 🎉 