### PR TITLE
Set a 25 second timeout on proxy requests

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -34,6 +34,7 @@ function imageService(options) {
 function createProxy(errorHandler) {
 	const proxy = httpProxy.createProxyServer({
 		ignorePath: true,
+		proxyTimeout: 25000, // 25 seconds
 		secure: false
 	});
 	proxy.on('proxyReq', proxyRequestHandler);
@@ -44,6 +45,9 @@ function createProxy(errorHandler) {
 		}
 		if (error.code === 'ECONNRESET') {
 			const resetError = error;
+			// Possible timeout because of this:
+			// https://github.com/nodejitsu/node-http-proxy/issues/718
+			resetError.syscall = resetError.syscall || 'possible timeout';
 			error = new Error(`Proxy connection reset when requesting "${request.url}" (${resetError.syscall})`);
 		}
 		if (error.code === 'ETIMEDOUT') {

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -98,6 +98,7 @@ describe('lib/image-service', () => {
 			assert.calledOnce(httpProxy.createProxyServer);
 			assert.calledWithExactly(httpProxy.createProxyServer, {
 				ignorePath: true,
+				proxyTimeout: 25000,
 				secure: false
 			});
 		});
@@ -469,6 +470,22 @@ describe('lib/image-service', () => {
 				it('calls the error handling middleware with a descriptive error', () => {
 					assert.instanceOf(serviceErrorHandler.firstCall.args[0], Error);
 					assert.strictEqual(serviceErrorHandler.firstCall.args[0].message, 'Proxy request timed out when requesting "mock-url" (mock-syscall)');
+				});
+
+			});
+
+			describe('when the error is possibly a proxy timeout', () => {
+
+				beforeEach(() => {
+					serviceErrorHandler.reset();
+					proxyError.code = 'ECONNRESET';
+					proxyError.syscall = undefined;
+					handler(proxyError, origamiService.mockRequest, origamiService.mockResponse);
+				});
+
+				it('calls the error handling middleware with a descriptive error', () => {
+					assert.instanceOf(serviceErrorHandler.firstCall.args[0], Error);
+					assert.strictEqual(serviceErrorHandler.firstCall.args[0].message, 'Proxy connection reset when requesting "mock-url" (possible timeout)');
 				});
 
 			});


### PR DESCRIPTION
Heroku's timeout is 30 seconds, this means we won't see those and we can
handle these errors ourselves