### PR TITLE
Cache DNS for 1 minute

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,17 @@
 'use strict';
 
+const dnscache = require('dnscache');
 const dotenv = require('dotenv');
 const imageService = require('./lib/image-service');
 const throng = require('throng');
+
+// Cache DNS, but with a very low TTL until this issue is
+// resolved: https://github.com/yahoo/dnscache/issues/14
+dnscache({
+	cachesize: 1000,
+	enable: true,
+	ttl: 60
+});
 
 dotenv.load({
 	silent: true

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -281,6 +281,11 @@
       "from": "destroy@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
+    "dnscache": {
+      "version": "1.0.1",
+      "from": "dnscache@latest",
+      "resolved": "https://registry.npmjs.org/dnscache/-/dnscache-1.0.1.tgz"
+    },
     "dotenv": {
       "version": "2.0.0",
       "from": "dotenv@>=2.0.0 <3.0.0",
@@ -556,6 +561,16 @@
       "version": "4.17.4",
       "from": "lodash@>=4.17.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+    },
+    "lodash._baseclone": {
+      "version": "4.5.7",
+      "from": "lodash._baseclone@>=4.5.0 <4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz"
+    },
+    "lodash.clone": {
+      "version": "4.3.2",
+      "from": "lodash.clone@>=4.3.2 <4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.3.2.tgz"
     },
     "lodash.defaults": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "colornames": "^1",
     "current-week-number": "^1.0.7",
     "date-fns": "^1.28.0",
+    "dnscache": "^1.0.1",
     "dotenv": "^2",
     "fastly-purge": "^1.0.1",
     "heroku-node-settings": "^1.0.2",


### PR DESCRIPTION
This may give us some performance improvements, as well as reducing the
likelihood of seeing DNS resolution errors