### PR TITLE
Add /v2/images/purge endpoint

### DIFF
--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -40,6 +40,9 @@ module.exports = app => {
 			case 'metadata':
 				getImageMeta(request, response, next);
 				break;
+			case 'purge':
+				response.redirect(`/v2/purge/url/?url=${encodeURIComponent(request.params.imageUrl)}`);
+				break;
 			default:
 				next();
 				break;
@@ -87,7 +90,7 @@ module.exports = app => {
 	// /v2/images/raw/fthead:...
 	// /v2/images/debug/ftlogo:...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata)\/((fticon|fthead|ftsocial|ftpodcast|ftlogo|ftbrand|specialisttitle)(\-v\d+)?(:|%3A).*)$/i,
+		/^\/v2\/images\/(raw|debug|metadata|purge)\/((fticon|fthead|ftsocial|ftpodcast|ftlogo|ftbrand|specialisttitle)(\-v\d+)?(:|%3A).*)$/i,
 		mapParams,
 		mapScheme,
 		mapCustomScheme(app.origami.options),
@@ -101,7 +104,7 @@ module.exports = app => {
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
+		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
 		mapParams,
 		mapScheme,
 		convertToCmsScheme(),
@@ -115,7 +118,7 @@ module.exports = app => {
 	// /v2/images/raw/ftcms:...
 	// /v2/images/debug/ftcms:...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata)\/((ftcms)(:|%3A).*)$/i,
+		/^\/v2\/images\/(raw|debug|metadata|purge)\/((ftcms)(:|%3A).*)$/i,
 		mapParams,
 		mapScheme,
 		getCmsUrl(app.origami.options),
@@ -129,7 +132,7 @@ module.exports = app => {
 	// /v2/images/raw/http://...
 	// /v2/images/debug/http://...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata)\/((https?(:|%3A))?(\/|%2F)*.*)$/i,
+		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*.*)$/i,
 		mapParams,
 		mapScheme,
 		requireValidSourceParam,


### PR DESCRIPTION
This will do a purge using the purge url method. The purge url method will cause the original image and all transformations of it to be purged Cloudinary and scheduled to be purged from Fastly after the purge has propagated through Cloudinary's CDN.