### PR TITLE
Remove the week from custom scheme cache-busts

### DIFF
--- a/lib/middleware/map-custom-scheme.js
+++ b/lib/middleware/map-custom-scheme.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const currentWeekNumber = require('current-week-number');
 const ImageTransform = require('../image-transform');
 
 module.exports = mapCustomScheme;
@@ -13,14 +12,10 @@ function mapCustomScheme(config) {
 
 		let customSchemeUrl;
 
-		// Build a cache-busting string – the current ISO week
-		const date = new Date();
-		const cacheBust = `${date.getFullYear()}-W${currentWeekNumber(date)}-1+${config.customSchemeCacheBust}`;
-
 		// Replace any custom schemes in the request URI with
 		// their HTTP/HTTPS equivalents.
 		try {
-			customSchemeUrl = ImageTransform.resolveCustomSchemeUri(originalUrl, config.customSchemeStore, cacheBust);
+			customSchemeUrl = ImageTransform.resolveCustomSchemeUri(originalUrl, config.customSchemeStore, config.customSchemeCacheBust);
 		} catch (error) {
 			error.status = 400;
 			return next(error);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -221,11 +221,6 @@
       "from": "cryptiles@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
-    "current-week-number": {
-      "version": "1.0.7",
-      "from": "current-week-number@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/current-week-number/-/current-week-number-1.0.7.tgz"
-    },
     "dashdash": {
       "version": "1.14.1",
       "from": "dashdash@>=1.12.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "base-64": "^0.1.0",
     "cloudinary": "^1",
     "colornames": "^1",
-    "current-week-number": "^1.0.7",
     "date-fns": "^1.28.0",
     "dnscache": "^1.0.1",
     "dotenv": "^2",

--- a/test/unit/lib/middleware/map-custom-scheme.js
+++ b/test/unit/lib/middleware/map-custom-scheme.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 
 describe('lib/middleware/map-custom-scheme', () => {
 	let clock;
-	let currentWeekNumber;
 	let ImageTransform;
 	let mapCustomScheme;
 	let origamiService;
@@ -16,9 +15,6 @@ describe('lib/middleware/map-custom-scheme', () => {
 			resolveCustomSchemeUri: sinon.stub()
 		};
 		mockery.registerMock('../image-transform', ImageTransform);
-
-		currentWeekNumber = sinon.stub().returns(1);
-		mockery.registerMock('current-week-number', currentWeekNumber);
 
 		clock = sinon.useFakeTimers();
 
@@ -63,7 +59,7 @@ describe('lib/middleware/map-custom-scheme', () => {
 
 			it('calls `ImageTransform.resolveCustomSchemeUri` with the `imageUrl` request param, the configured base URL, and a cache-buster', () => {
 				assert.calledOnce(ImageTransform.resolveCustomSchemeUri);
-				assert.calledWithExactly(ImageTransform.resolveCustomSchemeUri, 'foo:bar', 'mock-store', '1970-W1-1+mock-bust');
+				assert.calledWithExactly(ImageTransform.resolveCustomSchemeUri, 'foo:bar', 'mock-store', 'mock-bust');
 			});
 
 			it('sets the `imageUrl` request param to the returned URL', () => {


### PR DESCRIPTION
This is no longer needed as we can purge individual images from both
Cloudinary and Fastly now.

Resolves #248.