### PR TITLE
Try setting a specific Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Financial-Times/origami-image-service.git"
   },
   "engines": {
-    "node": "^6",
+    "node": "6.10.0",
     "npm": "^4"
   },
   "main": "./lib/image-service.js",


### PR DESCRIPTION
This is temporary, I'm trying to debug the memory leak we're seeing and
this is the simplest way to verify that Node.js 6.10.1 is the cause.