### PR TITLE
Revert the removal of Cloudinary usage metrics

### DIFF
--- a/lib/cloudinary-metrics.js
+++ b/lib/cloudinary-metrics.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const cloudinary = require('cloudinary');
+const pingInterval = 5 * 60 * 1000; // 5 minutes
+
+module.exports = class CloudinaryMetrics {
+
+	constructor(app) {
+		this.log = app.origami.log;
+		this.metrics = app.origami.metrics;
+		this.options = app.origami.options;
+
+		cloudinary.config({
+			cloud_name: this.options.cloudinaryAccountName,
+			api_key: this.options.cloudinaryApiKey,
+			api_secret: this.options.cloudinaryApiSecret
+		});
+
+		this.pingUsage();
+		setInterval(this.pingUsage.bind(this), pingInterval);
+	}
+
+	pingUsage() {
+		// We need to catch because Cloudinary will throw
+		// instead of rejecting if an API key isn't supplied
+		try {
+			return cloudinary.api.usage()
+				.then(result => {
+					this.metrics.count('cloudinary.transformations.usage', result.transformations.usage);
+					this.metrics.count('cloudinary.transformations.limit', result.transformations.limit);
+					this.metrics.count('cloudinary.objects.usage', result.objects.usage);
+					this.metrics.count('cloudinary.objects.limit', result.objects.limit);
+					this.metrics.count('cloudinary.bandwidth.usage', result.bandwidth.usage);
+					this.metrics.count('cloudinary.bandwidth.limit', result.bandwidth.limit);
+					this.metrics.count('cloudinary.storage.usage', result.storage.usage);
+					this.metrics.count('cloudinary.storage.limit', result.storage.limit);
+				})
+				.catch(error => {
+					this.log.error(`Cloudinary Metrics Failure (usage): ${error.message}`);
+				});
+		} catch (error) {
+			this.log.error(`Cloudinary Metrics Failure (usage): ${error.message}`);
+		}
+	}
+
+};

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const CloudinaryMetrics = require('./cloudinary-metrics');
 const HealthChecks = require('./health-checks');
 const httpError = require('http-errors');
 const httpProxy = require('http-proxy');
@@ -27,6 +28,8 @@ function imageService(options) {
 	mountRoutes(app);
 	app.use(origamiService.middleware.notFound());
 	app.use(origamiService.middleware.errorHandler());
+
+	new CloudinaryMetrics(app);
 
 	return app;
 }

--- a/test/unit/lib/cloudinary-metrics.js
+++ b/test/unit/lib/cloudinary-metrics.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/cloudinary-metrics', () => {
+	let cloudinary;
+	let CloudinaryMetrics;
+	let origamiService;
+
+	beforeEach(() => {
+		cloudinary = require('../mock/cloudinary.mock');
+		mockery.registerMock('cloudinary', cloudinary);
+
+		origamiService = require('../mock/origami-service.mock');
+
+		CloudinaryMetrics = require('../../../lib/cloudinary-metrics');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(CloudinaryMetrics);
+	});
+
+	describe('new CloudinaryMetrics(app)', () => {
+		let instance;
+		let options;
+		let pingUsage;
+		let bindPingUsage;
+
+		beforeEach(() => {
+			sinon.stub(global, 'setInterval');
+			pingUsage = sinon.stub(CloudinaryMetrics.prototype, 'pingUsage');
+			bindPingUsage = sinon.spy(pingUsage, 'bind');
+			options = origamiService.mockApp.origami.options = {
+				cloudinaryAccountName: 'mock-account-name',
+				cloudinaryApiKey: 'mock-api-key',
+				cloudinaryApiSecret: 'mock-api-secret'
+			};
+			instance = new CloudinaryMetrics(origamiService.mockApp);
+			CloudinaryMetrics.prototype.pingUsage.restore();
+		});
+
+		afterEach(() => {
+			global.setInterval.restore();
+		});
+
+		it('configures Cloudinary', () => {
+			assert.calledOnce(cloudinary.config);
+			assert.calledWith(cloudinary.config, {
+				cloud_name: options.cloudinaryAccountName,
+				api_key: options.cloudinaryApiKey,
+				api_secret: options.cloudinaryApiSecret
+			});
+		});
+
+		it('calls `pingUsage`', () => {
+			assert.calledOnce(pingUsage);
+			assert.calledWithExactly(pingUsage);
+		});
+
+		it('sets an interval to retrieve data again', () => {
+			assert.calledOnce(global.setInterval);
+			assert.calledOnce(bindPingUsage);
+			assert.calledWithExactly(bindPingUsage, instance);
+			assert.calledWithExactly(global.setInterval, bindPingUsage.firstCall.returnValue, 5 * 60 * 1000);
+		});
+
+		it('has a `pingUsage` method', () => {
+			assert.isFunction(instance.pingUsage);
+		});
+
+		describe('.pingUsage()', () => {
+			let usageData;
+
+			beforeEach(() => {
+				usageData = {
+					transformations: {
+						usage: 1,
+						limit: 2
+					},
+					objects: {
+						usage: 3,
+						limit: 4
+					},
+					bandwidth: {
+						usage: 5,
+						limit: 6
+					},
+					storage: {
+						usage: 7,
+						limit: 8
+					}
+				};
+				cloudinary.api.usage.resolves(usageData);
+				return instance.pingUsage();
+			});
+
+			it('calls `cloudinary.api.usage`', () => {
+				assert.calledOnce(cloudinary.api.usage);
+				assert.calledWithExactly(cloudinary.api.usage);
+			});
+
+			it('increments metrics for transformations, objects, bandwidth, and storage', () => {
+				const metrics = origamiService.mockApp.origami.metrics;
+				assert.called(metrics.count);
+				assert.calledWithExactly(metrics.count, 'cloudinary.transformations.usage', 1);
+				assert.calledWithExactly(metrics.count, 'cloudinary.transformations.limit', 2);
+				assert.calledWithExactly(metrics.count, 'cloudinary.objects.usage', 3);
+				assert.calledWithExactly(metrics.count, 'cloudinary.objects.limit', 4);
+				assert.calledWithExactly(metrics.count, 'cloudinary.bandwidth.usage', 5);
+				assert.calledWithExactly(metrics.count, 'cloudinary.bandwidth.limit', 6);
+				assert.calledWithExactly(metrics.count, 'cloudinary.storage.usage', 7);
+				assert.calledWithExactly(metrics.count, 'cloudinary.storage.limit', 8);
+			});
+
+			describe('when `cloudinary.api.usage` rejects', () => {
+				let cloudinaryError;
+
+				beforeEach(() => {
+					cloudinaryError = new Error('mock cloudinary error');
+					origamiService.mockApp.origami.metrics.count.reset();
+					cloudinary.api.usage.rejects(cloudinaryError);
+					return instance.pingUsage().catch();
+				});
+
+				it('logs an error', () => {
+					assert.calledOnce(origamiService.mockApp.origami.log.error);
+					assert.calledWithExactly(origamiService.mockApp.origami.log.error, 'Cloudinary Metrics Failure (usage): mock cloudinary error');
+				});
+
+				it('does not increment metrics', () => {
+					assert.notCalled(origamiService.mockApp.origami.metrics.count);
+				});
+
+			});
+
+			describe('when `cloudinary.api.usage` throws', () => {
+				let cloudinaryError;
+
+				beforeEach(() => {
+					cloudinaryError = new Error('mock cloudinary error');
+					origamiService.mockApp.origami.metrics.count.reset();
+					cloudinary.api.usage.throws(cloudinaryError);
+					instance.pingUsage();
+				});
+
+				it('logs an error', () => {
+					assert.calledOnce(origamiService.mockApp.origami.log.error);
+					assert.calledWithExactly(origamiService.mockApp.origami.log.error, 'Cloudinary Metrics Failure (usage): mock cloudinary error');
+				});
+
+				it('does not increment metrics', () => {
+					assert.notCalled(origamiService.mockApp.origami.metrics.count);
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -8,6 +8,7 @@ const sinon = require('sinon');
 describe('lib/image-service', () => {
 	let about;
 	let basePath;
+	let CloudinaryMetrics;
 	let HealthChecks;
 	let httpProxy;
 	let imageService;
@@ -24,6 +25,9 @@ describe('lib/image-service', () => {
 
 		HealthChecks = require('../mock/health-checks.mock');
 		mockery.registerMock('./health-checks', HealthChecks);
+
+		CloudinaryMetrics = sinon.stub();
+		mockery.registerMock('./cloudinary-metrics', CloudinaryMetrics);
 
 		httpProxy = require('../mock/http-proxy.mock');
 		mockery.registerMock('http-proxy', httpProxy);
@@ -561,6 +565,12 @@ describe('lib/image-service', () => {
 			assert.called(origamiService.middleware.errorHandler);
 			assert.calledWithExactly(origamiService.middleware.errorHandler);
 			assert.calledWith(origamiService.mockApp.use, origamiService.middleware.errorHandler.firstCall.returnValue);
+		});
+
+		it('creates a CloudinaryMetrics object', () => {
+			assert.calledOnce(CloudinaryMetrics);
+			assert.calledWithNew(CloudinaryMetrics);
+			assert.calledWithExactly(CloudinaryMetrics, origamiService.mockApp);
 		});
 
 		it('returns the created application', () => {

--- a/test/unit/mock/cloudinary.mock.js
+++ b/test/unit/mock/cloudinary.mock.js
@@ -4,6 +4,9 @@ const sinon = require('sinon');
 require('sinon-as-promised');
 
 module.exports = {
+	api: {
+		usage: sinon.stub().resolves()
+	},
 	config: sinon.stub(),
 	url: sinon.stub(),
 	uploader: {

--- a/test/unit/mock/origami-service.mock.js
+++ b/test/unit/mock/origami-service.mock.js
@@ -12,7 +12,13 @@ const mockApp = module.exports.mockApp = {
 	get: sinon.stub(),
 	listen: sinon.stub(),
 	locals: {},
-	origami: {log},
+	origami: {
+		log,
+		metrics: {
+			count: sinon.stub()
+		},
+		options: {}
+	},
 	set: sinon.stub(),
 	use: sinon.stub()
 };


### PR DESCRIPTION
This reverts commit fe3e4a01b35b6091b1446237381a9d6015aa5708.
(So it's exactly the same PR as #261)