### PR TITLE
Try Node.js 6.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Financial-Times/origami-image-service.git"
   },
   "engines": {
-    "node": "6.10.0",
+    "node": "^6.10.2",
     "npm": "^4"
   },
   "main": "./lib/image-service.js",


### PR DESCRIPTION
This should address any memory leaks that appeared in v6.10.1. I'm
un-pinning the version and using a caret again.

This resolves #264