### PR TITLE
Add a healthcheck for UPP images

### DIFF
--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -17,7 +17,7 @@ module.exports = class HealthChecks {
 		const customSchemeCheckBaseUrl = options.customSchemeStore.replace(/\/+$/, '');
 		this.customSchemeCheckUrl = `${customSchemeCheckBaseUrl}/fticon/v1/cross.svg`;
 
-		this.uppImagesUrl = 'http://prod-upp-image-read.ft.com/';
+		this.uppImagesUrl = 'http://prod-upp-image-read.ft.com/__gtg';
 
 		this.statuses = {
 			customSchemeStore: {

--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -17,6 +17,8 @@ module.exports = class HealthChecks {
 		const customSchemeCheckBaseUrl = options.customSchemeStore.replace(/\/+$/, '');
 		this.customSchemeCheckUrl = `${customSchemeCheckBaseUrl}/fticon/v1/cross.svg`;
 
+		this.uppImagesUrl = 'http://prod-upp-image-read.ft.com/';
+
 		this.statuses = {
 			customSchemeStore: {
 				id: 'custom-scheme-store',
@@ -35,6 +37,15 @@ module.exports = class HealthChecks {
 				businessImpact: 'Users may not be able to view images if they\'re not pre-cached',
 				technicalSummary: 'Transforms an image with Cloudinary and checks that it responds successfully',
 				panicGuide: 'Check the cloudinary status page https://status.cloudinary.com/'
+			},
+			uppImages: {
+				id: 'upp-images',
+				name: 'Images can be retrieved from the Universal Publishing Platform',
+				ok: true,
+				severity: 2,
+				businessImpact: 'Users may not be able to view images served by Universal Publishing Platform',
+				technicalSummary: 'Hits the given url and checks that it responds successfully',
+				panicGuide: `Check that the UPP endpoint ${this.customSchemeCheckUrl} still exists and that the AWS Region is up`
 			}
 		};
 
@@ -48,6 +59,7 @@ module.exports = class HealthChecks {
 		const cloudinaryCheckUrl = `https://www.ft.com/__origami/service/imageset-data/1x1.gif?cachebust=${date.toISOString()}`;
 		this.pingService('cloudinary', cloudinary.url(cloudinaryCheckUrl, {type: 'fetch'}));
 		this.pingService('customSchemeStore', this.customSchemeCheckUrl);
+		this.pingService('uppImages', this.uppImagesUrl);
 	}
 
 	pingService(name, url) {

--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -45,7 +45,7 @@ module.exports = class HealthChecks {
 				severity: 2,
 				businessImpact: 'Users may not be able to view images served by Universal Publishing Platform',
 				technicalSummary: 'Hits the given url and checks that it responds successfully',
-				panicGuide: `Check that the UPP endpoint ${this.customSchemeCheckUrl} still exists and that the AWS Region is up`
+				panicGuide: `Check that the UPP endpoint ${this.uppImagesUrl} still exists and that the AWS Region is up`
 			}
 		};
 

--- a/test/unit/lib/health-checks.js
+++ b/test/unit/lib/health-checks.js
@@ -53,6 +53,10 @@ describe('lib/health-checks', () => {
 			assert.strictEqual(instance.customSchemeCheckUrl, 'http://customschemestore/fticon/v1/cross.svg');
 		});
 
+		it('has a `uppImagesUrl` property', () => {
+			assert.strictEqual(instance.uppImagesUrl, 'http://prod-upp-image-read.ft.com/');
+		});
+
 		it('has a `statuses` property', () => {
 			assert.isObject(instance.statuses);
 		});
@@ -63,6 +67,10 @@ describe('lib/health-checks', () => {
 
 		it('has a `statuses.customSchemeStore` property', () => {
 			assert.isObject(instance.statuses.customSchemeStore);
+		});
+
+		it('has a `statuses.uppImages` property', () => {
+			assert.isObject(instance.statuses.uppImages);
 		});
 
 		it('calls `retrieveData`', () => {
@@ -108,9 +116,14 @@ describe('lib/health-checks', () => {
 				assert.calledWithExactly(instance.pingService, 'cloudinary', 'mock-cloudinary-url');
 			});
 
-			it('calls `pingService` with the navigation data store URL', () => {
+			it('calls `pingService` with the custom scheme store URL', () => {
 				assert.called(instance.pingService);
 				assert.calledWithExactly(instance.pingService, 'customSchemeStore', instance.customSchemeCheckUrl);
+			});
+
+			it('calls `pingService` with the UPP image store URL', () => {
+				assert.called(instance.pingService);
+				assert.calledWithExactly(instance.pingService, 'uppImages', instance.uppImagesUrl);
 			});
 
 		});

--- a/test/unit/lib/health-checks.js
+++ b/test/unit/lib/health-checks.js
@@ -54,7 +54,7 @@ describe('lib/health-checks', () => {
 		});
 
 		it('has a `uppImagesUrl` property', () => {
-			assert.strictEqual(instance.uppImagesUrl, 'http://prod-upp-image-read.ft.com/');
+			assert.strictEqual(instance.uppImagesUrl, 'http://prod-upp-image-read.ft.com/__gtg');
 		});
 
 		it('has a `statuses` property', () => {


### PR DESCRIPTION
This is waiting on a non-cached endpoint that we should be able to poll against.