### PR TITLE
Enable purging to work from ft.com and improve the documentation

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -169,7 +169,7 @@ function createProxy(errorHandler) {
 		const normaliseKeys = (key = '') => key.toLowerCase();
 		const encodeKeys = (key = '') => base64.encode(utf8.encode(key));
 
-		proxyResponse.headers['Surrogate-Key'] = `keyForAllImages-${keyForAllImages} keyForImageType-${encodeKeys(normaliseKeys(keyForImageType))} keyForScheme-${encodeKeys(normaliseKeys(keyForScheme))} keyForSchemeUrl-${encodeKeys(request.params.schemeUrl)}`;
+		proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} ${encodeKeys(normaliseKeys(keyForImageType))} ${encodeKeys(normaliseKeys(keyForScheme))} ${encodeKeys(request.params.schemeUrl)}`;
 
 		if (request.transform && request.transform.getDpr()) {
 			proxyResponse.headers['Content-Dpr'] = request.transform.getDpr();

--- a/lib/routes/purge.js
+++ b/lib/routes/purge.js
@@ -17,6 +17,8 @@ module.exports = app => {
 		'/v2/docs/api/',
 		'/v2/docs/migration',
 		'/v2/docs/migration/',
+		'/v2/docs/purge',
+		'/v2/docs/purge/',
 		'/v2/docs/url-builder',
 		'/v2/docs/url-builder/'
 	];

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -41,7 +41,7 @@ module.exports = app => {
 				getImageMeta(request, response, next);
 				break;
 			case 'purge':
-				response.redirect(`/v2/purge/url/?url=${encodeURIComponent(request.params.imageUrl)}`);
+				response.redirect(`${request.basePath}v2/purge/url/?url=${encodeURIComponent(request.params.imageUrl)}`);
 				break;
 			default:
 				next();

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -230,7 +230,7 @@ describe('lib/image-service', () => {
 					'FT-Image-Format': 'default',
 					'Last-Modified': 'some time',
 					'Surrogate-Control': 'public, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800',
-					'Surrogate-Key': 'keyForAllImages-origami-image-service keyForImageType-image/jpeg-mock-utf8-mock-base64 keyForScheme-http-mock-utf8-mock-base64 keyForSchemeUrl-http://example.com/PICTURE.png-mock-utf8-mock-base64',
+					'Surrogate-Key': 'origami-image-service image/jpeg-mock-utf8-mock-base64 http-mock-utf8-mock-base64 http://example.com/PICTURE.png-mock-utf8-mock-base64',
 					'Vary': 'FT-image-format, Content-Dpr'
 				});
 			});

--- a/views/api.html
+++ b/views/api.html
@@ -35,6 +35,8 @@
 								<dd>Output a JSON object which outlines the image transform found in the query string.</dd>
 								<dt>metadata</dt>
 								<dd>Output a JSON object with dimensions of the image (in pixels) that the <code>raw</code> mode would output.</dd>
+								<dt>purge</dt>
+								<dd>Purge the original image and all images based on the original image from Cloudinary and Fastly. The image can take up to one hour to purge from Cloudinary and up to two hours to purge from Fastly.</dd>
 							</dl>
 						</td>
 					</tr>

--- a/views/purge.html
+++ b/views/purge.html
@@ -15,9 +15,20 @@
 				To use these endpoints you need to set the header <code>FT-Origami-Api-Key</code> with your API key. If you would like an API key, please request one by emailing <code>origami.support@ft.com</code> and explaining what you are wanting the API key for.
 			</p>
 
+			<h3>GET /v2/images/purge/<var>:uri</var></h3>
+
+			<p>Finds the correct HTTP URL equivalent of the <code>uri</code> being requested to purge and redirects to <code>/v2/purge/url?url=<var>:URL-to-purge</var> to initaite the purge request.</p>
+
+			<h3>GET /v2/purge/url?url=<var>:URL-to-purge</var></h3>
+
+			<p>
+				Purge the original image and all images based on the original image from Cloudinary and Fastly. The image can take up to one hour to purge from Cloudinary and up to two hours to purge from Fastly.
+			</p>
+
 			<h3>GET /v2/purge/key?key=<var>:surrogate-key</var></h3>
 			<p>
 				Purge from Fastly all resources which are tagged with the surrogate-key.
+				You can view the surrogate-keys by adding the header <code>FT-Debug: true</code> to a request.
 				The types of surrogate-keys available are as follows:
 			</p>
 
@@ -41,77 +52,25 @@
 						<td>scheme</td>
 						<td>
 							<p>Each scheme has it's own surrogate key in order to remove all images requested with the scheme from Fastly.</p>
-							<p>List of schemes and their surrogate-key equivalent:</p>
-							<dl>
-								<dt>http</dt>
-								<dd><code>http</code></dd>
-								<dt>https</dt>
-								<dd><code>https</code></dd>
-								<dt>ftcms</dt>
-								<dd><code>ftcms</code></dd>
-								<dt>fticon-v1</dt>
-								<dd><code>fticon</code></dd>
-								<dt>fthead-v1</dt>
-								<dd><code>fthead</code></dd>
-								<dt>ftsocial-v2</dt>
-								<dd><code>ftsocial</code></dd>
-								<dt>ftpodcast-v1</dt>
-								<dd><code>ftpodcast</code></dd>
-								<dt>ftlogo-v1</dt>
-								<dd><code>ftlogo</code></dd>
-								<dt>ftbrand-v1</dt>
-								<dd><code>ftbrand</code></dd>
-								<dt>specialisttitle-v1</dt>
-								<dd><code>specialisttitle</code></dd>
-							</dl>
+							<p>The scheme surrogate key is the third value in the surrogate-key header.</p>
 						</td>
 					</tr>
 					<tr>
 						<td>image response type</td>
 						<td>
 							<p>The response type of the image is used as a surrogate key, purging this will remove all images of the same response type from Fastly.</p>
-							<p>The value of the surrogate key is normalised by converting the response type to lowercase and only alphanumeric and dashes are used</p>
-							<p>List of example image response types and their surrogate-key equivalent:</p>
-							<dl>
-								<dt>image/png</dt>
-								<dd><code>imagepng</code></dd>
-								<dt>image/svg+xml</dt>
-								<dd><code>imagesvgxml</code></dd>
-								<dt>image/webp</dt>
-								<dd><code>imagewebp</code></dd>
-								<dt>image/jpeg</dt>
-								<dd><code>imagejpeg</code></dd>
-								<dt>image/gif</dt>
-								<dd><code>imagegif</code></dd>
-							</dl>
+							<p>The image type surrogate key is the second value in the surrogate-key header.</p>
 						</td>
 					</tr>
 					<tr>
 						<td>requested image</td>
 						<td>
-							<p>The requested image is used as a surrogate key, purging this will remove all transforms based on the original image from Fastly.</p>
-							<p>The value of the surrogate key is the scheme and identifier used for the image.</p>
-							<p>List of example images and their surrogate-key equivalent:</p>
-							<dl>
-								<dt>ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1</dt>
-								<dd><code>ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1</code></dd>
-								<dt>http://im.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img</dt>
-								<dd><code>ftcms:a60ae24b-b87f-439c-bf1b-6e54946b4cf2</code></dd>
-								<dt>fticon-v1:book</dt>
-								<dd><code>fticon-v1:book</code></dd>
-								<dt>http://s3-eu-west-1.amazonaws.com/fthtsi-assets-production/ez/images/7/0/1/9/1219107-1-eng-GB/Adriana-Degreas-bikini-set-@-MATCHESFASHION.COM.png</dt>
-								<dd><code>http://s3-eu-west-1.amazonaws.com/fthtsi-assets-production/ez/images/7/0/1/9/1219107-1-eng-GB/Adriana-Degreas-bikini-set-@-MATCHESFASHION.COM.png</code></dd>
-							</dl>
+							<p>The requested image is used as a surrogate key, purging this will remove all images based on the original image from Fastly.</p>
+							<p>The requested image surrogate key is the fourth value in the surrogate-key header.</p>
 						</td>
 					</tr>
 				</table>
 			</div>
-
-			<h3>GET /v2/purge/url?url=<var>:URL-to-purge</var></h3>
-
-			<p>
-				Purge from Fastly a specific URL.
-			</p>
 		</div>
 	</div>
 </div>

--- a/views/purge.html
+++ b/views/purge.html
@@ -17,13 +17,13 @@
 
 			<h3>GET /v2/purge/key?key=<var>:surrogate-key</var></h3>
 			<p>
-				Purge from CDN all resources which are tagged with the surrogate-key.
+				Purge from Fastly all resources which are tagged with the surrogate-key.
 				The types of surrogate-keys available are as follows:
 			</p>
 
 			<aside>
 				<h5>Purging keys will not purge from Cloudinary</h5>
-				<p>Currently the Origami Image Service can only purge keys from Fastly. The original image will still be stored by Cloudinary's CDN unless the image URL can be modified to cache-bust their CDN layer.</p>
+				<p>Currently the Origami Image Service can only purge keys from Fastly. The original image will still be stored by Cloudinary.</p>
 			</aside>
 			<div class="o-techdocs-table-wrapper">
 				<table>
@@ -34,13 +34,13 @@
 					<tr>
 						<td>everything</td>
 						<td>
-							<p>The surrogate key <code>origami-image-service</code> is added to every image, purging this will remove all images from the CDN. Recommended to only use this in extreme circumstances.</p>
+							<p>The surrogate key <code>origami-image-service</code> is added to every image, purging this will remove all images from Fastly. Recommended to only use this in extreme circumstances.</p>
 						</td>
 					</tr>
 					<tr>
 						<td>scheme</td>
 						<td>
-							<p>Each scheme has it's own surrogate key in order to remove all images requested with the scheme from the CDN.</p>
+							<p>Each scheme has it's own surrogate key in order to remove all images requested with the scheme from Fastly.</p>
 							<p>List of schemes and their surrogate-key equivalent:</p>
 							<dl>
 								<dt>http</dt>
@@ -69,7 +69,7 @@
 					<tr>
 						<td>image response type</td>
 						<td>
-							<p>The response type of the image is used as a surrogate key, purging this will remove all images of the same response type from the CDN.</p>
+							<p>The response type of the image is used as a surrogate key, purging this will remove all images of the same response type from Fastly.</p>
 							<p>The value of the surrogate key is normalised by converting the response type to lowercase and only alphanumeric and dashes are used</p>
 							<p>List of example image response types and their surrogate-key equivalent:</p>
 							<dl>
@@ -89,7 +89,7 @@
 					<tr>
 						<td>requested image</td>
 						<td>
-							<p>The requested image is used as a surrogate key, purging this will remove all transforms based on the original image from the CDN.</p>
+							<p>The requested image is used as a surrogate key, purging this will remove all transforms based on the original image from Fastly.</p>
 							<p>The value of the surrogate key is the scheme and identifier used for the image.</p>
 							<p>List of example images and their surrogate-key equivalent:</p>
 							<dl>
@@ -110,7 +110,7 @@
 			<h3>GET /v2/purge/url?url=<var>:URL-to-purge</var></h3>
 
 			<p>
-				Purge from CDN a specific URL.
+				Purge from Fastly a specific URL.
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
# What's changed?

- Revert the surrogate keys back to their original form. Updating a surrogate key value is a complicated task to complete for so many requests. If we updated the surrogate keys and then decided to purge one of the new surrogate keys (E.G. All webp images), it would only purge the requests that were sent with the new surrogate key and not the old one (E.G. Not all webp images would be purged).

- Updated the purging documentation to remove the incorrect surrogate-key examples and instead to inform the reader which surrogate key corresponds to the specific task they are trying to achieve.

- Made the `/v2/purge/` route use the origami-base-path value to enable this route to work correctly on FT.com

- Added the purging documentation paths to the in-built purging mechanism which is used when deploying the application to QA and production environments. This means that the documentation pages won't ever show old versions of the documentation.
