### PR TITLE
Update user-agent to conform to specified conventional syntax

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -78,7 +78,7 @@ function createProxy(errorHandler) {
 
 		// Set our own headers to send to the third party
 		proxyRequest.setHeader('Host', url.parse(proxyOptions.target).host);
-		proxyRequest.setHeader('User-Agent', 'Origami Image Service (https://github.com/Financial-Times/origami-image-service)');
+		proxyRequest.setHeader('User-Agent', 'FT-Origami-Image-Service/2 (https://github.com/Financial-Times/origami-image-service)');
 	}
 
 	// Handle proxy responses, allowing modification of a response

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -156,7 +156,7 @@ describe('lib/image-service', () => {
 			});
 
 			it('should set the `User-Agent` header of the proxy request to identify the Image Service', () => {
-				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'User-Agent', 'Origami Image Service (https://github.com/Financial-Times/origami-image-service)');
+				assert.calledWithExactly(httpProxy.mockProxyRequest.setHeader, 'User-Agent', 'FT-Origami-Image-Service/2 (https://github.com/Financial-Times/origami-image-service)');
 			});
 
 		});


### PR DESCRIPTION
The syntax for a User-Agent header is `<product>/<product-version> <comment>`.

Looking into the Cloudinary reports I can see that Cloudinary is currently seeing two user-agents: `Origami` and `Image`. Updating the User-Agent header to conform to the conventional syntax [1] _should_ make Cloudinary recognise our service as one user-agent instead of two.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#Syntax