### PR TITLE
Use strong etags for all non-proxied responses

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -29,6 +29,8 @@ function imageService(options) {
 	app.use(origamiService.middleware.notFound());
 	app.use(origamiService.middleware.errorHandler());
 
+	app.set('etag', 'strong');
+
 	new CloudinaryMetrics(app);
 
 	return app;


### PR DESCRIPTION
http://expressjs.com/en/api.html#etag.options.table

This setting is only applied to requests which are not proxied.
For proxied requests, we use the proxied responses etag value.