### PR TITLE
Add immutable cache cloudinary flag for FTCMS images

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -219,6 +219,36 @@ module.exports = class ImageTransform {
 	}
 
 	/**
+	 * Get the immutable property of the transformed image.
+	 * @return {String | Undefined}
+	 */
+	getImmutable() {
+		return this.immutable;
+	}
+
+	/**
+	 * Set the immutable color of the transformed image.
+	 * @param {String} [value] - The background color. A comma-delimited list of hex codes and named colors.
+	 */
+	setImmutable(value) {
+		this.immutable = ImageTransform.sanitizeImmutableValue(value);
+	}
+
+	/**
+	 * Sanitize an image transform URI value.
+	 * @param {String} value - The URI to sanitize.
+	 * @param {String} [errorMessage] - The error message to use when the URI is invalid.
+	 * @throws Will throw an error if the URI is invalid.
+	 * @static
+	 */
+	static sanitizeImmutableValue(value, errorMessage = 'Expected a Boolean value') {
+		if (typeof value !== 'boolean') {
+			throw new Error(errorMessage);
+		}
+		return value;
+	}
+
+	/**
 	 * Sanitize an image transform URI value.
 	 * @param {String} value - The URI to sanitize.
 	 * @param {String} [errorMessage] - The error message to use when the URI is invalid.

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -39,6 +39,10 @@ function processImage(config) {
 			transform.setTint();
 		}
 
+		if (request.params.immutable) {
+			transform.setImmutable(true);
+		}
+
 		// Create a Cloudinary transform
 		const appliedTransform = cloudinaryTransform(transform, {
 			cloudinaryAccountName: config.cloudinaryAccountName,

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -85,6 +85,11 @@ module.exports = app => {
 		});
 	}
 
+	function markImageAsImmutable(request, response, next) {
+		request.params.immutable = true;
+		next();
+	}
+
 	// Image with a custom scheme, matches:
 	// /v2/images/raw/fticon:...
 	// /v2/images/raw/fthead:...
@@ -107,6 +112,7 @@ module.exports = app => {
 		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
 		mapParams,
 		mapScheme,
+		markImageAsImmutable,
 		convertToCmsScheme(),
 		getCmsUrl(app.origami.options),
 		requireValidSourceParam,
@@ -121,6 +127,7 @@ module.exports = app => {
 		/^\/v2\/images\/(raw|debug|metadata|purge)\/((ftcms)(:|%3A).*)$/i,
 		mapParams,
 		mapScheme,
+		markImageAsImmutable,
 		getCmsUrl(app.origami.options),
 		requireValidSourceParam,
 		processImageRequest(app.origami.options),

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -51,6 +51,11 @@ function buildCloudinaryTransforms(transform) {
 	if (tint) {
 		cloudinaryTransforms.effect = `tint:100:${tint.join(':')}`;
 	}
+
+	const immutable = transform.getImmutable();
+	if (immutable) {
+		cloudinaryTransforms.flags.push('immutable_cache');
+	}
 	return cloudinaryTransforms;
 }
 

--- a/test/integration/v2/images-debug.js
+++ b/test/integration/v2/images-debug.js
@@ -24,9 +24,10 @@ describe('GET /v2/images/debug…', function() {
 				height: 456,
 				quality: 72,
 				uri: testImageUris.http,
-				width: 123
+				width: 123,
+				immutable: true
 			});
-			assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,h_456,q_72,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img$'));
+			assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img$'));
 		}).end(done);
 	});
 

--- a/test/unit/lib/image-transform.js
+++ b/test/unit/lib/image-transform.js
@@ -339,6 +339,27 @@ describe('lib/image-transform', () => {
 
 		});
 
+		describe('.setImmutable() / .getImmutable()', () => {
+
+			beforeEach(() => {
+				sinon.stub(ImageTransform, 'sanitizeImmutableValue').returns(true);
+				instance.setImmutable(true);
+			});
+
+			it('[set] calls the `sanitizeImmutableValue` static method with `value`', () => {
+				assert.calledOnce(ImageTransform.sanitizeImmutableValue);
+				assert.calledWithExactly(
+					ImageTransform.sanitizeImmutableValue,
+					true
+				);
+			});
+
+			it('[get] returns the sanitized `value`', () => {
+				assert.strictEqual(instance.getImmutable(), true);
+			});
+
+		});
+
 	});
 
 	it('has a `sanitizeUriValue` static method', () => {
@@ -740,6 +761,39 @@ describe('lib/image-transform', () => {
 
 			it('the message can be set with a second parameter', () => {
 				assert.throws(() => ImageTransform.sanitizeColorListValue('0f', 'foo'), 'foo');
+			});
+
+		});
+
+	});
+
+	it('has a `sanitizeImmutableValue` static method', () => {
+		assert.isFunction(ImageTransform.sanitizeImmutableValue);
+	});
+
+	describe('.sanitizeImmutableValue(value)', () => {
+
+		describe('when `value` is a Boolean', () => {
+
+			it('returns `value`', () => {
+				assert.deepEqual(ImageTransform.sanitizeImmutableValue(true), true);
+				assert.deepEqual(ImageTransform.sanitizeImmutableValue(false), false);
+			});
+
+		});
+
+		describe('when `value` is `undefined`', () => {
+
+			it('throws an error', () => {
+				assert.throws(() => ImageTransform.sanitizeImmutableValue(undefined), 'Expected a Boolean value');
+			});
+
+		});
+
+		describe('when an error is thrown', () => {
+
+			it('the message can be set with a second parameter', () => {
+				assert.throws(() => ImageTransform.sanitizeImmutableValue(0, 'foo'), 'foo');
 			});
 
 		});

--- a/test/unit/lib/middleware/process-image-request.js
+++ b/test/unit/lib/middleware/process-image-request.js
@@ -149,6 +149,33 @@ describe('lib/middleware/process-image-request', () => {
 
 			});
 
+			describe('when the image request is "immutable" ', () => {
+
+				beforeEach(() => {
+					mockImageTransform.setImmutable = sinon.spy();
+					origamiService.mockRequest.params.immutable = true;
+					middleware(origamiService.mockRequest, origamiService.mockResponse, next);
+				});
+
+				it('sets the image transform `immutable` property to true', () => {
+					assert.calledOnce(mockImageTransform.setImmutable);
+					assert.strictEqual(mockImageTransform.setImmutable.firstCall.args[0], true);
+				});
+			});
+
+			describe('when the image request is not "immutable" ', () => {
+
+				beforeEach(() => {
+					mockImageTransform.setImmutable = sinon.spy();
+					origamiService.mockRequest.params.immutable = false;
+					middleware(origamiService.mockRequest, origamiService.mockResponse, next);
+				});
+
+				it('sets the image transform `immutable` property to false', () => {
+					assert.notCalled(mockImageTransform.setImmutable);
+				});
+			});
+
 			describe('when ImageTransform throws an error', () => {
 				let imageTransformError;
 

--- a/test/unit/lib/transformers/cloudinary.js
+++ b/test/unit/lib/transformers/cloudinary.js
@@ -33,7 +33,7 @@ describe('lib/transformers/cloudinary', () => {
 		});
 
 		it('returns a Cloudinary fetch URL', () => {
-			assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+			assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 		});
 
 		describe('when `transform` has a `width` property', () => {
@@ -44,7 +44,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72,w_123/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72,w_123/http://example.com/$'));
 			});
 
 		});
@@ -57,7 +57,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,h_123,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,h_123,q_72/http://example.com/$'));
 			});
 
 		});
@@ -70,7 +70,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,dpr_2,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,dpr_2,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});
@@ -83,7 +83,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fit,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fit,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});
@@ -96,7 +96,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});
@@ -109,7 +109,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_limit,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_limit,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});
@@ -122,7 +122,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,g_auto:faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,g_auto:faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -135,7 +135,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,g_auto:no_faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,g_auto:no_faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -148,7 +148,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_png,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_png,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});
@@ -161,7 +161,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_30/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_30/http://example.com/$'));
 			});
 
 		});
@@ -174,7 +174,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});
@@ -187,7 +187,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});
@@ -200,7 +200,20 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+			});
+
+		});
+
+		describe('when `transform` has an `immutable` property', () => {
+
+			beforeEach(() => {
+				transform.setImmutable(true);
+				cloudinaryUrl = cloudinaryTransform(transform, options);
+			});
+
+			it('returns the expected Cloudinary fetch URL', () => {
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});

--- a/test/unit/lib/transformers/cloudinary.js
+++ b/test/unit/lib/transformers/cloudinary.js
@@ -33,7 +33,7 @@ describe('lib/transformers/cloudinary', () => {
 		});
 
 		it('returns a Cloudinary fetch URL', () => {
-			assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+			assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 		});
 
 		describe('when `transform` has a `width` property', () => {
@@ -44,7 +44,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72,w_123/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72,w_123/http://example.com/$'));
 			});
 
 		});
@@ -57,7 +57,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,h_123,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,h_123,q_72/http://example.com/$'));
 			});
 
 		});
@@ -70,7 +70,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,dpr_2,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,dpr_2,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -83,7 +83,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fit,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fit,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -96,7 +96,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -109,7 +109,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_limit,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_limit,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -122,7 +122,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,g_auto:faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,g_auto:faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -135,7 +135,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,g_auto:no_faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,g_auto:no_faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -148,7 +148,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_png,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_png,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -161,7 +161,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_30/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_30/http://example.com/$'));
 			});
 
 		});
@@ -174,7 +174,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -187,7 +187,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -200,7 +200,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});


### PR DESCRIPTION
I looked at adding the immutable cache control setting into image service for cloudinary requests for FT CMS images (These are the only images we know 100% are immutable). -- http://cloudinary.com/product_updates/immutable_cache_control_response