### PR TITLE
Enable all transformations of an image to be purged from fastly and cloudinary

### DIFF
--- a/lib/middleware/purge-url.js
+++ b/lib/middleware/purge-url.js
@@ -3,16 +3,30 @@
 const httpError = require('http-errors');
 const cloudinary = require('cloudinary');
 const purgeFromFastly = require('../purge-from-fastly');
+const ImageTransform = require('../image-transform');
+const base64 = require('base-64');
+const utf8 = require('utf8');
 
-module.exports = function ({cloudinaryAccountName, cloudinaryApiKey, cloudinaryApiSecret, fastlyApiKey}) {
+function encodeKeys(key = '') {
+	return base64.encode(utf8.encode(key));
+}
 
+module.exports = function ({
+	cloudinaryAccountName,
+	cloudinaryApiKey,
+	cloudinaryApiSecret,
+	fastlyApiKey,
+	fastlyServiceId,
+	customSchemeStore,
+	customSchemeCacheBust
+}) {
 	cloudinary.config({
 		cloud_name: cloudinaryAccountName,
 		api_key: cloudinaryApiKey,
 		api_secret: cloudinaryApiSecret
 	});
 
-	const scheduleToPurgeFromFastly = purgeFromFastly(fastlyApiKey);
+	const scheduleToPurgeFromFastly = purgeFromFastly(fastlyApiKey, fastlyServiceId);
 
 	return function purgeUrlMiddleware(request, response, next) {
 		if (!request.query.url) {
@@ -22,21 +36,26 @@ module.exports = function ({cloudinaryAccountName, cloudinaryApiKey, cloudinaryA
 		const url = decodeURIComponent(request.query.url);
 
 		return cloudinary.uploader.destroy(
-			url,
-			() => {},
-			{
-				public_id: url,
-				invalidate: true,
-				resource_type: 'image',
-				type: 'fetch'
-			}
-		)
+				url,
+				() => {}, {
+					public_id: url,
+					invalidate: true,
+					resource_type: 'image',
+					type: 'fetch'
+				}
+			)
 			.then(() => {
-				return url;
-			})
-			.then(scheduleToPurgeFromFastly)
-			.then(dateToPurge => {
-				response.status(200).send(`Purged ${url} from Cloudinary, will purge from Fastly at ${dateToPurge}`);
+				if (request.query.transforms) {
+					const keyForCustomSchemeUrl = encodeKeys(ImageTransform.resolveCustomSchemeUri(url, customSchemeStore, customSchemeCacheBust));
+					const dateToPurge = scheduleToPurgeFromFastly(keyForCustomSchemeUrl, {
+						isKey: true
+					});
+					response.status(200).send(`Purged ${url} from Cloudinary, will purge key ${keyForCustomSchemeUrl} from Fastly at ${dateToPurge}`);
+
+				} else {
+					const dateToPurge = scheduleToPurgeFromFastly(url);
+					response.status(200).send(`Purged ${url} from Cloudinary, will purge from Fastly at ${dateToPurge}`);
+				}
 			})
 			.catch(error => next(httpError(500, error)));
 	};

--- a/lib/purge-from-fastly.js
+++ b/lib/purge-from-fastly.js
@@ -65,7 +65,7 @@ module.exports = (fastlyApiKey, fastlyServiceId) => {
 					}
 				}
 
-        delete urlsToPurge[nowHour];
+				delete urlsToPurge[nowHour];
 
 			}, differenceInMilliseconds(dateToPurge, new Date()));
 		}

--- a/lib/purge-from-fastly.js
+++ b/lib/purge-from-fastly.js
@@ -10,32 +10,45 @@ let timer;
 
 const urlsToPurge = {};
 
-module.exports = fastlyApiKey => {
+module.exports = (fastlyApiKey, fastlyServiceId) => {
 
 	if (!fastlyApiKey) {
 		throw new Error('Function requires a Fastly API key to be passed in as the first argument.');
+	}
+
+	if (!fastlyServiceId) {
+		throw new Error('Function requires a Fastly Service ID to be passed in as the second argument.');
 	}
 
 	const fastly = new FastlyPurge(fastlyApiKey, {
 		softPurge: true
 	});
 
-	return function addToPurgeQueue(url) {
+	return function addToPurgeQueue(url, options) {
+		options = options || {};
+		const isKey = options.isKey;
 
 		const dateToPurge = startOfHour(addHours(new Date(), 2));
 		const hourToPurge = getHours(dateToPurge);
 
 		if (!urlsToPurge[hourToPurge]) {
-			urlsToPurge[hourToPurge] = new Set();
+			urlsToPurge[hourToPurge] = {};
+			urlsToPurge[hourToPurge].urls = new Set();
+			urlsToPurge[hourToPurge].keys = new Set();
 		}
 
-		urlsToPurge[hourToPurge].add(url);
+		if (isKey) {
+			urlsToPurge[hourToPurge].keys.add(url);
+		} else {
+			urlsToPurge[hourToPurge].urls.add(url);
+		}
 
 		if (!timer) {
 			timer = setTimeout(() => {
 				timer = undefined;
 				const nowHour = getHours(new Date());
-				const urls = urlsToPurge[nowHour];
+				const urls = urlsToPurge[nowHour].urls;
+				const keys = urlsToPurge[nowHour].keys;
 
 				for (const url of urls) {
 					fastly.url(url, {
@@ -46,6 +59,19 @@ module.exports = fastlyApiKey => {
 							addToPurgeQueue(url);
 						} else {
 							console.log(`Purged ${url} from Fastly`);
+						}
+					});
+				}
+
+				for (const key of keys) {
+					fastly.key(fastlyServiceId, key, {
+						apiKey: fastlyApiKey
+					}, error => {
+						if (error) {
+							console.log(`Could not purge ${key} from Fastly, will re-attempt in an hour.`);
+							addToPurgeQueue(url, { isKey: true });
+						} else {
+							console.log(`Purged ${key} from Fastly`);
 						}
 					});
 				}

--- a/lib/purge-from-fastly.js
+++ b/lib/purge-from-fastly.js
@@ -64,6 +64,22 @@ module.exports = (fastlyApiKey, fastlyServiceId) => {
 						});
 					}
 				}
+				
+				if (keys) {
+					for (const key of keys) {
+						fastly.key(fastlyServiceId, key, {
+							apiKey: fastlyApiKey
+						}, error => {
+							if (error) {
+								console.log(`Could not purge ${key} from Fastly, will re-attempt in an hour.`);
+								addToPurgeQueue(url, { isKey: true });
+							} else {
+								console.log(`Purged ${key} from Fastly`);
+							}
+							keys.delete(key);
+						});
+					}
+				}
 
 				delete urlsToPurge[nowHour];
 

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -17,7 +17,7 @@ before(function() {
 		defaultLayout: 'main',
 		environment: 'test',
 		log: mockLog,
-		port: null,
+		port: 0,
 		requestLogFormat: null
 	})
 	.listen()

--- a/test/unit/lib/middleware/purge-url.js
+++ b/test/unit/lib/middleware/purge-url.js
@@ -126,9 +126,10 @@ describe('lib/middleware/purge-url', () => {
 					});
 
 					describe('when the request specifies to remove all transforms of the original image', () => {
-						let key = 'key';
+						let key;
 
 						beforeEach(() => {
+							key = 'key';
 							origamiService.mockRequest.query.transforms = 'true';
 							ImageTransform.resolveCustomSchemeUri.returns(key);
 							base64.encode.returnsArg(0);
@@ -145,7 +146,7 @@ describe('lib/middleware/purge-url', () => {
 						it('finds the key for the scheme url and uses it to schedule a purge from Fasly', () => {
 							return middleware(origamiService.mockRequest, origamiService.mockResponse, origamiService.mockNext)
 								.then(() => {
-									assert.calledWithExactly(ImageTransform.resolveCustomSchemeUri, url, config.customSchemeStore, config.customSchemeCacheBust)
+									assert.calledWithExactly(ImageTransform.resolveCustomSchemeUri, url, config.customSchemeStore, config.customSchemeCacheBust);
 									assert.calledWithExactly(FastlyPurge.mockInstance, key, {
 										isKey: true
 									});

--- a/test/unit/lib/middleware/purge-url.js
+++ b/test/unit/lib/middleware/purge-url.js
@@ -9,6 +9,9 @@ describe('lib/middleware/purge-url', () => {
 	let purgeUrl;
 	let FastlyPurge;
 	let cloudinary;
+	let ImageTransform;
+	let base64;
+	let utf8;
 
 	beforeEach(() => {
 		origamiService = require('../../mock/origami-service.mock');
@@ -18,6 +21,15 @@ describe('lib/middleware/purge-url', () => {
 
 		cloudinary = require('../../mock/cloudinary.mock');
 		mockery.registerMock('cloudinary', cloudinary);
+
+		ImageTransform = require('../../mock/image-transform.mock');
+		mockery.registerMock('../image-transform', ImageTransform);
+
+		base64 = require('../../mock/base-64.mock');
+		mockery.registerMock('base-64', base64);
+
+		utf8 = require('../../mock/utf8.mock');
+		mockery.registerMock('utf8', utf8);
 
 		purgeUrl = require('../../../../lib/middleware/purge-url');
 	});
@@ -32,9 +44,12 @@ describe('lib/middleware/purge-url', () => {
 		beforeEach(() => {
 			config = {
 				fastlyApiKey: 'api-key',
+				fastlyServiceId: 'service-id',
 				cloudinaryAccountName: 'cloudinaryAccountName',
 				cloudinaryApiKey: 'cloudinaryApiKey',
-				cloudinaryApiSecret: 'cloudinaryApiSecret'
+				cloudinaryApiSecret: 'cloudinaryApiSecret',
+				customSchemeStore: 'customSchemeStore',
+				customSchemeCacheBust: 'customSchemeCacheBust'
 			};
 
 			middleware = purgeUrl(config);
@@ -53,7 +68,7 @@ describe('lib/middleware/purge-url', () => {
 		});
 
 		it('constructs a purgeFromFastly object with passed in configuration', () => {
-			assert.calledWithExactly(FastlyPurge, 'api-key');
+			assert.calledWithExactly(FastlyPurge, 'api-key', 'service-id');
 		});
 
 		describe('middleware(request, response, next)', () => {
@@ -97,6 +112,7 @@ describe('lib/middleware/purge-url', () => {
 						return middleware(origamiService.mockRequest, origamiService.mockResponse, origamiService.mockNext)
 							.then(() => {
 								assert.called(FastlyPurge.mockInstance);
+								assert.calledWithExactly(FastlyPurge.mockInstance, url);
 							});
 					});
 
@@ -107,6 +123,43 @@ describe('lib/middleware/purge-url', () => {
 								assert.calledWithExactly(origamiService.mockResponse.status, 200);
 								assert.calledWithExactly(origamiService.mockResponse.send, `Purged ${url} from Cloudinary, will purge from Fastly at ${dateToPurge}`);
 							});
+					});
+
+					describe('when the request specifies to remove all transforms of the original image', () => {
+						let key = 'key';
+
+						beforeEach(() => {
+							origamiService.mockRequest.query.transforms = 'true';
+							ImageTransform.resolveCustomSchemeUri.returns(key);
+							base64.encode.returnsArg(0);
+							utf8.encode.returnsArg(0);
+						});
+
+						it('purges from cloudinary', () => {
+							return middleware(origamiService.mockRequest, origamiService.mockResponse, origamiService.mockNext)
+								.then(() => {
+									assert.called(cloudinary.uploader.destroy);
+								});
+						});
+
+						it('finds the key for the scheme url and uses it to schedule a purge from Fasly', () => {
+							return middleware(origamiService.mockRequest, origamiService.mockResponse, origamiService.mockNext)
+								.then(() => {
+									assert.calledWithExactly(ImageTransform.resolveCustomSchemeUri, url, config.customSchemeStore, config.customSchemeCacheBust)
+									assert.calledWithExactly(FastlyPurge.mockInstance, key, {
+										isKey: true
+									});
+								});
+						});
+
+						it('returns a 200 with a messaging indicating when it will purge from Fastly', () => {
+							return middleware(origamiService.mockRequest, origamiService.mockResponse, origamiService.mockNext)
+								.then(() => {
+									assert.notCalled(origamiService.mockNext);
+									assert.calledWithExactly(origamiService.mockResponse.status, 200);
+									assert.calledWithExactly(origamiService.mockResponse.send, `Purged ${url} from Cloudinary, will purge key ${key} from Fastly at ${dateToPurge}`);
+								});
+						});
 					});
 				});
 

--- a/test/unit/lib/purge-from-fastly.js
+++ b/test/unit/lib/purge-from-fastly.js
@@ -12,9 +12,13 @@ describe('lib/purge-from-fastly', () => {
 	let differenceInMilliseconds;
 	let purgeFromFastly;
 	let url;
+	let key;
 
 	beforeEach(() => {
+		key = 'key';
+
 		url = 'http://www.ft.com/__origami/service/images/v2/images/raw/https://www.example.com/cats.png?source=test';
+
 		FastlyPurge = require('../mock/fastly-purge.mock');
 		mockery.registerMock('fastly-purge', FastlyPurge);
 
@@ -44,14 +48,23 @@ describe('lib/purge-from-fastly', () => {
 	});
 
 	describe('purgeFromFastly(fastlyApiKey)', () => {
+		it('throws an error', () => {
+			assert.throws(() => purgeFromFastly("api-key"));
+		});
+	});
+
+	describe('purgeFromFastly(fastlyApiKey, fastlyServiceId)', () => {
 		let instance;
 		let fastlyApiKey;
 		let clock;
+		let fastlyServiceId;
+
 		beforeEach(() => {
 			fastlyApiKey = 'api-key';
+			fastlyServiceId = 'service-id';
 			clock = sinon.useFakeTimers();
 			sinon.stub(global, 'setTimeout');
-			instance = purgeFromFastly(fastlyApiKey);
+			instance = purgeFromFastly(fastlyApiKey, fastlyServiceId);
 		});
 
 		afterEach(() => {
@@ -69,7 +82,7 @@ describe('lib/purge-from-fastly', () => {
 			assert.isFunction(instance);
 		});
 
-		describe('purgeFromFastly(fastlyApiKey(url)', () => {
+		describe('purgeFromFastly(fastlyApiKey)(url)', () => {
 			let timeoutStartTime;
 			let twoHoursLater;
 
@@ -117,6 +130,35 @@ describe('lib/purge-from-fastly', () => {
 				setTimeout.getCall(0).callArg(0);
 				assert.calledOnce(FastlyPurge.mockInstance.url);
 				assert.equal(FastlyPurge.mockInstance.url.firstCall.args[0], url);
+
+			});
+
+			it('purges a key from Fastly when timeout is fired', () => {
+				FastlyPurge.mockInstance.key.yields();
+				setTimeout.yields();
+				instance(key, {
+					isKey: true
+				});
+				assert.notCalled(FastlyPurge.mockInstance.url);
+				assert.calledOnce(FastlyPurge.mockInstance.key);
+				assert.calledWith(FastlyPurge.mockInstance.key, fastlyServiceId, key, {
+					apiKey: fastlyApiKey
+				});
+			});
+
+			it('purges a key from Fastly only once', () => {
+				FastlyPurge.mockInstance.key.yields();
+				instance(key, {
+					isKey: true
+				});
+				instance(key, {
+					isKey: true
+				});
+				setTimeout.getCall(0).callArg(0);
+				assert.calledOnce(FastlyPurge.mockInstance.key);
+				assert.calledWith(FastlyPurge.mockInstance.key, fastlyServiceId, key, {
+					apiKey: fastlyApiKey
+				});
 
 			});
 

--- a/test/unit/lib/purge-from-fastly.js
+++ b/test/unit/lib/purge-from-fastly.js
@@ -49,7 +49,7 @@ describe('lib/purge-from-fastly', () => {
 
 	describe('purgeFromFastly(fastlyApiKey)', () => {
 		it('throws an error', () => {
-			assert.throws(() => purgeFromFastly("api-key"));
+			assert.throws(() => purgeFromFastly('api-key'));
 		});
 	});
 

--- a/test/unit/mock/base-64.mock.js
+++ b/test/unit/mock/base-64.mock.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+module.exports = {
+	encode: sinon.stub()
+};

--- a/test/unit/mock/image-transform.mock.js
+++ b/test/unit/mock/image-transform.mock.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	resolveCustomSchemeUri: sinon.stub()
+};

--- a/test/unit/mock/utf8.mock.js
+++ b/test/unit/mock/utf8.mock.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+module.exports = {
+	encode: sinon.stub()
+};

--- a/views/purge.html
+++ b/views/purge.html
@@ -19,10 +19,10 @@
 
 			<p>Finds the correct HTTP URL equivalent of the <code>uri</code> being requested to purge and redirects to <code>/v2/purge/url?url=<var>:URL-to-purge</var> to initaite the purge request.</p>
 
-			<h3>GET /v2/purge/url?url=<var>:URL-to-purge</var></h3>
+			<h3>GET /v2/purge/url?url=<var>:URL-to-purge</var><var>&transforms</var></h3>
 
 			<p>
-				Purge the original image and all images based on the original image from Cloudinary and Fastly. The image can take up to one hour to purge from Cloudinary and up to two hours to purge from Fastly.
+				Purge the original image and all images based on the original image from Cloudinary and Fastly. The image can take up to one hour to purge from Cloudinary and up to two hours to purge from Fastly. If the <code>transforms</code> query parameter is also supplied in the request then all transforms of the original image will be purged from Fastly.
 			</p>
 
 			<h3>GET /v2/purge/key?key=<var>:surrogate-key</var></h3>


### PR DESCRIPTION
This issues a purge of the original image from cloudinary (which we mark to invalidate all cloudinary transforms) and then purges from Fastly using the scheme-url surrogate-key value for the particular image being purged.