### PR TITLE
Add tests for jpeg output format when 'format' parameter is auto

### DIFF
--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -237,6 +237,83 @@ describe('GET /v2/images/raw…', function() {
 		itRespondsWithContentType('text/html');
 	});
 
+	describe('when the \'format\' query parameter is \'auto\'', () => {
+
+		const firefoxUA = 'Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0';
+		const chromeUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.75 Safari/537.36';
+		const ieUA = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
+
+		[
+			{
+				accept: '*/*',
+				userAgent: firefoxUA,
+				expectedContentType: 'image/jpeg',
+				expectedFtImageFormat: 'default'
+			},
+			{
+				accept: 'image/webp',
+				userAgent: firefoxUA,
+				expectedContentType: 'image/webp',
+				expectedFtImageFormat: 'webp'
+			},
+			{
+				accept: 'image/jxr',
+				userAgent: firefoxUA,
+				expectedContentType: 'image/vnd.ms-photo',
+				expectedFtImageFormat: 'jpegxr'
+			},
+			{
+				accept: '*/*',
+				userAgent: chromeUA,
+				expectedContentType: 'image/jpeg',
+				expectedFtImageFormat: 'default'
+			},
+			{
+				accept: 'image/webp',
+				userAgent: chromeUA,
+				expectedContentType: 'image/webp',
+				expectedFtImageFormat: 'webp'
+			},
+			{
+				accept: 'image/jxr',
+				userAgent: chromeUA,
+				expectedContentType: 'image/vnd.ms-photo',
+				expectedFtImageFormat: 'jpegxr'
+			},
+			{
+				accept: '*/*',
+				userAgent: ieUA,
+				expectedContentType: 'image/jpeg',
+				expectedFtImageFormat: 'default'
+			},
+			{
+				accept: 'image/webp',
+				userAgent: ieUA,
+				expectedContentType: 'image/webp',
+				expectedFtImageFormat: 'webp'
+			},
+			{
+				accept: 'image/jxr',
+				userAgent: ieUA,
+				expectedContentType: 'image/vnd.ms-photo',
+				expectedFtImageFormat: 'jpegxr'
+			},
+		].forEach(({accept, userAgent, expectedContentType, expectedFtImageFormat}) => {
+			describe(`when the 'user-agent' header is ${userAgent} and the 'accepts' header is ${accept}`, function() {
+				setupRequest(
+                    'GET',
+                    `/v2/images/raw/${testImageUris.nonUtf8Characters}?source=test&format=auto`,
+                    {
+                        accept: accept,
+                        'user-agent': userAgent,
+                    }
+                );
+				itRespondsWithHeader('Content-Type', expectedContentType);
+				itRespondsWithHeader('FT-Image-Format', expectedFtImageFormat);
+			});
+		});
+	});
+
 	context('when an image is returned, surrogate keys are added', function() {
 		describe('adds generic key for all image requests:', function() {
 			describe('ftbrand', function() {

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -24,8 +24,7 @@ const testImageUris = {
 	protocolRelative: '//origami-images.ft.com/ftsocial/v1/twitter.svg',
 	protocolRelativeftcms: '//im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	specialisttitle: 'specialisttitle:ned-logo',
-	nonUtf8Characters: 'http://s3-eu-west-1.amazonaws.com/fthtsi-assets-production/ez/images/0/9/3/2/1212390-1-eng-GB/Y+et+Beaute%CC%81+Tranquille.jpg',
-	jpeg: 'http://prod-upp-image-read.ft.com/3520df36-8c20-11e6-8cb7-e7ada1d123b1'
+	nonUtf8Characters: 'http://s3-eu-west-1.amazonaws.com/fthtsi-assets-production/ez/images/0/9/3/2/1212390-1-eng-GB/Y+et+Beaute%CC%81+Tranquille.jpg'
 };
 
 describe('GET /v2/images/raw…', function() {
@@ -303,7 +302,7 @@ describe('GET /v2/images/raw…', function() {
 			describe(`when the 'user-agent' header is ${userAgent} and the 'accepts' header is ${accept}`, function() {
 				setupRequest(
                     'GET',
-                    `/v2/images/raw/${testImageUris.jpeg}?source=test&format=auto`,
+                    `/v2/images/raw/${testImageUris.nonUtf8Characters}?source=test&format=auto`,
                     {
                         accept: accept,
                         'user-agent': userAgent,

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -24,7 +24,8 @@ const testImageUris = {
 	protocolRelative: '//origami-images.ft.com/ftsocial/v1/twitter.svg',
 	protocolRelativeftcms: '//im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	specialisttitle: 'specialisttitle:ned-logo',
-	nonUtf8Characters: 'http://s3-eu-west-1.amazonaws.com/fthtsi-assets-production/ez/images/0/9/3/2/1212390-1-eng-GB/Y+et+Beaute%CC%81+Tranquille.jpg'
+	nonUtf8Characters: 'http://s3-eu-west-1.amazonaws.com/fthtsi-assets-production/ez/images/0/9/3/2/1212390-1-eng-GB/Y+et+Beaute%CC%81+Tranquille.jpg',
+	jpeg: 'http://prod-upp-image-read.ft.com/3520df36-8c20-11e6-8cb7-e7ada1d123b1'
 };
 
 describe('GET /v2/images/raw…', function() {
@@ -302,7 +303,7 @@ describe('GET /v2/images/raw…', function() {
 			describe(`when the 'user-agent' header is ${userAgent} and the 'accepts' header is ${accept}`, function() {
 				setupRequest(
                     'GET',
-                    `/v2/images/raw/${testImageUris.nonUtf8Characters}?source=test&format=auto`,
+                    `/v2/images/raw/${testImageUris.jpeg}?source=test&format=auto`,
                     {
                         accept: accept,
                         'user-agent': userAgent,


### PR DESCRIPTION
Used the existing defined `.jpg` from S3 for lack of knowledge of alternatives.

Closes https://github.com/Financial-Times/origami-image-service/issues/173.