### PR TITLE
Remove superfluous expires header

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -138,7 +138,6 @@ function createProxy(errorHandler) {
 			'Content-Length': originalHeaders['content-length'],
 			'Connection': 'keep-alive',
 			'Etag': originalHeaders['etag'],
-			'Expires': new Date(Date.now() + (oneWeek * 1000)).toGMTString(),
 			'Last-Modified': originalHeaders['last-modified']
 		};
 

--- a/test/unit/lib/image-service.js
+++ b/test/unit/lib/image-service.js
@@ -226,7 +226,6 @@ describe('lib/image-service', () => {
 					'Content-Length': '1234',
 					'Connection': 'keep-alive',
 					'Etag': '123',
-					'Expires': 'Thu, 08 Jan 1970 00:00:10 GMT',
 					'FT-Image-Format': 'default',
 					'Last-Modified': 'some time',
 					'Surrogate-Control': 'public, max-age=604800, stale-while-revalidate=604800, stale-if-error=604800',


### PR DESCRIPTION
Cache-Control: max-age is already set.

Closes https://github.com/Financial-Times/origami-image-service/issues/144.