### PR TITLE
update to the latest version of cloudinary which uses correct signatures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -619,9 +619,9 @@
       }
     },
     "cloudinary": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.9.0.tgz",
-      "integrity": "sha1-RL/V2nm4ZQrGMBVgbwEi3fYByQk=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.9.1.tgz",
+      "integrity": "sha512-VfeDkEmamZ5R5BWpMs4rPLwaVDjONE2zxLOrqV+lKzLeqn2TTvEAy/CRQxUmcdxFLJ96gl62LUn+IoUMiYiuYw==",
       "requires": {
         "lodash": "3.10.1",
         "q": "1.4.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@financial-times/origami-service-makefile": "^6.0.1",
     "@financial-times/source-param-middleware": "^1.0.0",
     "base-64": "^0.1.0",
-    "cloudinary": "^1",
+    "cloudinary": "^1.9.1",
     "colornames": "^1",
     "date-fns": "^1.28.0",
     "dnscache": "^1.0.1",


### PR DESCRIPTION
Previous versions would use the encoded form of the url, which is not what the rest of cloudinary's system does.