### PR TITLE
Enable the width and height parameters to accept numeric strings ending in px

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -286,6 +286,9 @@ module.exports = class ImageTransform {
 	 * @static
 	 */
 	static sanitizeNumericValue(value, errorMessage = 'Expected a whole positive number') {
+		if (typeof value === 'string' && value.endsWith('px')) {
+			value = value.replace(/px$/, '');
+		}
 		if (value === undefined || value === '') {
 			return undefined;
 		}

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -286,8 +286,8 @@ module.exports = class ImageTransform {
 	 * @static
 	 */
 	static sanitizeNumericValue(value, errorMessage = 'Expected a whole positive number') {
-		if (typeof value === 'string' && value.endsWith('px')) {
-			value = value.replace(/px$/, '');
+		if (typeof value === 'string' && /px$/i.test(value)) {
+			value = value.replace(/px$/i, '');
 		}
 		if (value === undefined || value === '') {
 			return undefined;

--- a/test/unit/lib/image-transform.test.js
+++ b/test/unit/lib/image-transform.test.js
@@ -501,6 +501,14 @@ describe('lib/image-transform', () => {
 
 		});
 
+		describe('when `value` is a numeric string ending in px', () => {
+
+			it('strips the px and returns `value` converted into a number', () => {
+				assert.strictEqual(ImageTransform.sanitizeNumericValue('123px'), 123);
+			});
+
+		});
+
 		describe('when `value` is `undefined`', () => {
 
 			it('returns `undefined`', () => {

--- a/test/unit/lib/image-transform.test.js
+++ b/test/unit/lib/image-transform.test.js
@@ -507,6 +507,9 @@ describe('lib/image-transform', () => {
 				assert.strictEqual(ImageTransform.sanitizeNumericValue('123px'), 123);
 			});
 
+			it('strips the PX and returns `value` converted into a number', () => {
+				assert.strictEqual(ImageTransform.sanitizeNumericValue('123PX'), 123);
+			});
 		});
 
 		describe('when `value` is `undefined`', () => {


### PR DESCRIPTION
One of our more common set of client error requests are when the client has added `px` to the width and/or height parameters. 

E.G. `/v2/images/raw/ftsocial-v2:twitter?source=o-share&format=png&tint=%23FFFFFF,%23FFFFFF&width=26px`

This pull-request will turn this into a valid request by stripping the `px` before converting to a number.