### PR TITLE
Remove sentence about requesting an purging API key

### DIFF
--- a/views/purge.html
+++ b/views/purge.html
@@ -12,7 +12,7 @@
 			</h1>
 
 			<p>
-				To use these endpoints you need to set the header <code>FT-Origami-Api-Key</code> with your API key. If you would like an API key, please request one by emailing <code>origami.support@ft.com</code> and explaining what you are wanting the API key for.
+				To use these endpoints you need to set the header <code>FT-Origami-Api-Key</code> with your API key.
 			</p>
 
 			<h3>GET /v2/images/purge/<var>:uri</var></h3>


### PR DESCRIPTION
We do not want to give users the ability to purge images themselves as it can be abused. Ideally they have an image publishing workflow that doesn't involve purging images. If an image needs to be purged, users can email or Slack the Origami team with a request to purge.