### PR TITLE
Whitelist the Origami image sets

### DIFF
--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -17,6 +17,7 @@ function handleSvg() {
 		// Grab the params we need for tinting
 		const color = request.query.color || null;
 		const uri = request.params[0];
+		const isWhitelisted = /^https:\/\/origami-images\.ft\.com\//.test(uri);
 		let hasErrored = false;
 
 		// Create a tint stream with the colour found in
@@ -89,15 +90,18 @@ function handleSvg() {
 			entireSvg += chunk.toString();
 		});
 		imageRequest.on('end', () => {
-
 			if (!hasErrored) {
 				if (!window || !DOMPurify) {
 					window = (new JSDOM('')).window;
 					DOMPurify = createDOMPurify(window);
 				}
 
-				// Clean the SVG
-				response.send(DOMPurify.sanitize(entireSvg));
+				// Clean the SVG if required
+				if (isWhitelisted) {
+					response.send(entireSvg);
+				} else {
+					response.send(DOMPurify.sanitize(entireSvg));
+				}
 			}
 		});
 


### PR DESCRIPTION
We currently use xlink:href in flags to repeat the same path multiple
times. This now gets stripped, and it'd be a lot of work to update each
flag image. I've whitelisted all of the images in our image sets, which
means we should be vigilant when accepting new SVGs into our sets.