### PR TITLE
Whitelist SVGs from ft.com/__assets

### DIFF
--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -17,7 +17,10 @@ function handleSvg() {
 		// Grab the params we need for tinting
 		const color = request.query.color || null;
 		const uri = request.params[0];
-		const isWhitelisted = /^https:\/\/origami-images\.ft\.com\//.test(uri);
+		const isWhitelisted = (
+			uri.startsWith('https://origami-images.ft.com/') ||
+			uri.startsWith('https://www.ft.com/__assets/')
+		);
 		let hasErrored = false;
 
 		// Create a tint stream with the colour found in


### PR DESCRIPTION
Some SVGs in the FT.com assets use features that are stripped by our DOM
purification. As this is a trusted source, I'm whitelisting alongside
our own image-sets.