### PR TITLE
Add a "fill" option to the "fit" property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,6 @@ jobs:
           name: Run unit tests
           command: make test-unit-coverage
       - run:
-          name: Run whitesource
-          command: make whitesource
-      - run:
           name: Run integration tests
           command: make test-integration
 workflows:

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -16,7 +16,7 @@ module.exports = class ImageTransform {
 	 * @param {(String|Number)} [properties.width] - The width of the transformed image in pixels.
 	 * @param {(String|Number)} [properties.height] - The height of the transformed image in pixels.
 	 * @param {(String|Number)} [properties.dpr=1] - The device-pixel ratio of the transformed image.
-	 * @param {String} [properties.fit=cover] - The cropping strategy of the transformed image. One of contain, cover, or scale-down.
+	 * @param {String} [properties.fit=cover] - The cropping strategy of the transformed image. One of contain, cover, fill, or scale-down.
 	 * @param {String} [properties.quality=medium] - The compression quality of the transformed image. One of lowest, low, medium, high, highest, lossless.
 	 * @param {String} [properties.format=auto] - The file format of the transformed image. One of auto, jpg, png, svg.
 	 * @param {String} [properties.bgcolor] - A background color to apply to the transformed image (if transparent). Hex code or named color.
@@ -112,7 +112,7 @@ module.exports = class ImageTransform {
 
 	/**
 	 * Set the cropping strategy of the transformed image.
-	 * @param {String} [value=cover] - The cropping strategy. One of contain, cover, or scale-down.
+	 * @param {String} [value=cover] - The cropping strategy. One of contain, cover, fill, or scale-down.
 	 */
 	setFit(value = 'cover') {
 		const errorMessage = `Image fit must be one of ${ImageTransform.validFits.join(', ')}`;
@@ -471,6 +471,7 @@ module.exports = class ImageTransform {
 		return [
 			'contain',
 			'cover',
+			'fill',
 			'scale-down'
 		];
 	}

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -27,6 +27,7 @@ module.exports = app => {
 				value: request.query.fit,
 				isCover: !request.query.fit,
 				isContain: (request.query.fit === 'contain'),
+				isFill: (request.query.fit === 'fill'),
 				isScaleDown: (request.query.fit === 'scale-down')
 			},
 			gravity: {

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -63,6 +63,7 @@ function getCloudinaryCropStrategy(cropStrategy) {
 	const cropStrategyMap = {
 		contain: 'fit',
 		cover: 'fill',
+		fill: 'scale',
 		'scale-down': 'limit'
 	};
 	return cropStrategyMap[cropStrategy];

--- a/test/unit/lib/image-transform.test.js
+++ b/test/unit/lib/image-transform.test.js
@@ -1145,6 +1145,7 @@ describe('lib/image-transform', () => {
 		assert.deepEqual(ImageTransform.validFits, [
 			'contain',
 			'cover',
+			'fill',
 			'scale-down'
 		]);
 	});

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -101,6 +101,19 @@ describe('lib/transformers/cloudinary', () => {
 
 		});
 
+		describe('when `transform` has a `fit` property set to `fill`', () => {
+
+			beforeEach(() => {
+				transform.setFit('fill');
+				cloudinaryUrl = cloudinaryTransform(transform, options);
+			});
+
+			it('returns the expected Cloudinary fetch URL', () => {
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_scale,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+			});
+
+		});
+
 		describe('when `transform` has a `fit` property set to `scale-down`', () => {
 
 			beforeEach(() => {

--- a/views/api.html
+++ b/views/api.html
@@ -115,6 +115,8 @@
 					<dd>The image should be scaled to be as small as possible while ensuring both its dimensions are greater than or equal to the corresponding dimensions of the frame, and any cropping should be taken equally from both ends of the overflowing dimension.</dd>
 					<dt>contain</dt>
 					<dd>The image should be scaled to be as large as possible while ensuring both its dimensions are less than or equal to the corresponding dimensions of the frame. The frame should then be collapsed to match the aspect ratio of the image.</dd>
+					<dt>fill</dt>
+					<dd>The image width and height are set to the exact dimensions given in the <code>width</code> and <code>height</code> parameters, potentially stretching the image.</dd>
 					<dt>scale-down</dt>
 					<dd>Similarly to <code>contain</code>, the image dimensions are scaled down to be less than or equal to the corresponding dimensions of the frame, but the image is never enlarged.</dd>
 				</dl>

--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -11,7 +11,7 @@
 
 <h2 id="url-settings">URL Settings</h2>
 
-	<form class="o-layout__main__full-span" action="v2/docs/url-builder" method="get">
+	<form class="o-layout__main__full-span" action="{{@root.basePath}}v2/docs/url-builder" method="get">
 		<div class="flex-container">
 			<div class="form" >
 				<div class="o-forms o-forms--wide">
@@ -78,6 +78,8 @@
 				<label for="builder-fit-cover" class="o-forms__label">cover (default)</label>
 				<input type="radio" id="builder-fit-contain" name="fit" value="contain" class="o-forms__radio" {{#if form.fit.isContain}}checked{{/if}}/>
 				<label for="builder-fit-contain" class="o-forms__label">contain</label>
+				<input type="radio" id="builder-fit-fill" name="fit" value="fill" class="o-forms__radio" {{#if form.fit.isFill}}checked{{/if}}/>
+				<label for="builder-fit-fill" class="o-forms__label">fill</label>
 				<input type="radio" id="builder-fit-scale-down" name="fit" value="scale-down" class="o-forms__radio" {{#if form.fit.isScaleDown}}checked{{/if}}/>
 				<label for="builder-fit-scale-down" class="o-forms__label">scale-down</label>
 			</div>


### PR DESCRIPTION
This allows a user to opt into their image being stretched, which FT
labs needs for a project they're working on.

I opted for `fill` instead of `stretch` because the documentation
explicitly references the [CSS3 object-fit property](https://www.w3.org/TR/css3-images/#the-object-fit). In order to keep
following the same naming conventions, we need to go with `fill`.

Closes #340 - see issue for more information.

Note: this also fixes a broken link in the form action, which
hasn't made it to production yet.