### PR TITLE
Fix URLs

### DIFF
--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -101,7 +101,7 @@ module.exports = app => {
 		const url = sanitizedData.url;
 		delete sanitizedData.url;
 		const query = querystring.stringify(sanitizedData);
-		return `/v2/images/raw/${url}?${query}`;
+		return `v2/images/raw/${url}?${query}`;
 	}
 
 	function buildDemoUrl(url) {

--- a/test/integration/v2/docs.test.js
+++ b/test/integration/v2/docs.test.js
@@ -14,6 +14,7 @@ describe('GET /v2/', function() {
 	it('has a <base> element with the expected path', function(done) {
 		this.request.expect(response => {
 			assert.isString(response.text);
+			assert.match(response.text, /<base\s+href="\/"\s*\/>/);
 		}).end(done);
 	});
 
@@ -30,6 +31,7 @@ describe('GET /v2/ with an FT-Origami-Service-Base-Path header', function() {
 	it('has a <base> element with the expected path', function(done) {
 		this.request.expect(response => {
 			assert.isString(response.text);
+			assert.match(response.text, /<base\s+href="\/foo\/bar\/"\s*\/>/);
 		}).end(done);
 	});
 

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -5,6 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title>{{title}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<base href="{{basePath}}"/>
 
 	<script>
 		var script = document.createElement('script');

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -13,7 +13,7 @@
 			<ul class="o-layout__primary-nav o-header-services__nav-list">
 				{{#navigation.items}}
 					<li class="o-header-services__nav-item">
-						<a class="o-header-services__nav-link {{#current}}o-header-services__nav-link--selected{{/current}}" href="{{@root.basePath}}{{href}}">
+						<a class="o-header-services__nav-link {{#current}}o-header-services__nav-link--selected{{/current}}" href="{{href}}">
 							{{name}}
 						</a>
 					</li>

--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -11,7 +11,7 @@
 
 <h2 id="url-settings">URL Settings</h2>
 
-	<form class="o-layout__main__full-span" action="{{@root.basePath}}v2/docs/url-builder" method="get">
+	<form class="o-layout__main__full-span" action="v2/docs/url-builder" method="get">
 		<div class="flex-container">
 			<div class="form" >
 				<div class="o-forms o-forms--wide">
@@ -56,11 +56,11 @@
 			<div class="url-builder-preview">
 				{{#if imagePreviewUrl}}
 					<a href="{{imagePreviewUrl}}" style="border: none;">
-						<img style="width:100%;"src="{{imagePreviewUrl}}" alt="Optimised Image"/>
+						<img style="width:100%;" src="{{imagePreviewUrl}}" alt="Optimised Image"/>
 					</a>
 					<div class="o-forms o-forms--wide">
 						<label for="builder-output" class="o-forms__label">URL for the optimised image</label>
-						<textarea class="url-builder-output" id="builder-output" class="o-forms__textarea" readonly>https://www.ft.com{{basePath}}{{imagePreviewUrl}}</textarea>
+						<textarea class="url-builder-output" id="builder-output" class="o-forms__textarea" readonly>https://www.ft.com/__origami/service/image/{{imagePreviewUrl}}</textarea>
 					</div>
 				{{/if}}
 			</div>


### PR DESCRIPTION
The `<base/>` element is required here, because we can't always
guarantee that the base URL of the service is `/` - it's different
depending on whether the service is accessed locally, via a Heroku
domain, or via the live service through Fastly.