### PR TITLE
Use Node.js 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Financial-Times/origami-image-service.git"
   },
   "engines": {
-    "node": "^11",
+    "node": "^10",
     "npm": "^6"
   },
   "main": "./lib/image-service.js",


### PR DESCRIPTION
Our general policy is to only use LTS releases in production, I know we've discussed in-person but should we maybe write it down somewhere? I'm reminded because of this tweet:

> Quick PSA...
> Please only use LTS releases of @nodejs in production.
> Once we end of life a release, stop using it!
> – https://twitter.com/MylesBorins/status/1110960442292256772