### PR TITLE
Increase cache hit ratio by removing parts of cache key which are not needed

### DIFF
--- a/fastly/vcl/image-service.vcl
+++ b/fastly/vcl/image-service.vcl
@@ -1,3 +1,5 @@
+import querystring;
+
 sub set_backend {
 	# The Fastly macro is inserted before the backend is selected because the
 	# macro has the code which defines the values avaiable for req.http.Host
@@ -109,8 +111,12 @@ sub vcl_hash {
 		call breadcrumb_hash;
 	}
 
-	set req.hash += req.http.host;
-	set req.hash += req.url;
+	# Do not add the host header because it can have 1 of 3 values: origami-image-service.in.ft.com, origami-image-service-eu.herokuapp.com , origami-image-service-us.herokuapp.com
+	# set req.hash += req.http.host;
+	
+	# Do include the source query parameter in the url when adding the url to the hash
+	set req.hash += querystring.filter(req.url, "source");
+
 	# We include return(hash) to stop the function falling through to the default VCL built into varnish, which for vcl_hash will add req.url and req.http.Host to the hash.
 	return(hash);
 }

--- a/fastly/vcl/image-service.vcl
+++ b/fastly/vcl/image-service.vcl
@@ -114,8 +114,13 @@ sub vcl_hash {
 	# Do not add the host header because it can have 1 of 3 values: origami-image-service.in.ft.com, origami-image-service-eu.herokuapp.com , origami-image-service-us.herokuapp.com
 	# set req.hash += req.http.host;
 	
-	# Do include the source query parameter in the url when adding the url to the hash
+	# Do include the source query parameter in the url when adding the url to the hash but do include whether the url did have a source parameter at all
 	set req.hash += querystring.filter(req.url, "source");
+	if (std.strlen(subfield(req.url.qs, "source", "&")) > 0) {
+		set req.hash += "has source parameter";
+	} else {
+		set req.hash += "does not have source parameter";
+	}
 
 	# We include return(hash) to stop the function falling through to the default VCL built into varnish, which for vcl_hash will add req.url and req.http.Host to the hash.
 	return(hash);

--- a/fastly/vcl/image-service.vcl
+++ b/fastly/vcl/image-service.vcl
@@ -114,7 +114,7 @@ sub vcl_hash {
 	# Do not add the host header because it can have 1 of 3 values: origami-image-service.in.ft.com, origami-image-service-eu.herokuapp.com , origami-image-service-us.herokuapp.com
 	# set req.hash += req.http.host;
 	
-	# Do include the source query parameter in the url when adding the url to the hash but do include whether the url did have a source parameter at all
+	# Do not include the source query parameter in the url when adding the url to the hash but do include whether the url did have a source parameter at all
 	set req.hash += querystring.filter(req.url, "source");
 	if (std.strlen(subfield(req.url.qs, "source", "&")) > 0) {
 		set req.hash += "has source parameter";

--- a/test/fastly/origami-image-service.test.js
+++ b/test/fastly/origami-image-service.test.js
@@ -64,7 +64,7 @@ describe('Origami-image-service', function () {
                             .get(`${path}?source=${Math.random()}`)
                             .set('Fastly-Debug', 'true')
                             .expect('Fastly-Debug-Digest', digest)
-                            .expect('X-Cache', '\bHIT\b')
+                            .expect('X-Cache', /\bHIT\b/)
                             .expect(200);
                     });
             });

--- a/test/fastly/origami-image-service.test.js
+++ b/test/fastly/origami-image-service.test.js
@@ -49,5 +49,24 @@ describe('Origami-image-service', function () {
                     .expect('vary', /FT-image-format/i);
             });
         });
+
+        describe('cache key logic', () => {
+            it('does not include the source query parameter in the cache key', () => {
+                const path = '/__origami/service/image/v2/images/raw/http://www.elblogdelinfo.com/wp-content/uploads/alb_elias.jpg';
+                return request(host)
+                    .get(`${path}?source=vcl-test`)
+                    .set('Fastly-Debug', 'true')
+                    .expect(200)
+                    .then((response) => {
+                        const digest = response.headers['fastly-debug-digest'];
+                        return request(host)
+                            .get(`${path}?source=${Math.random()}`)
+                            .set('Fastly-Debug', 'true')
+                            .expect('Fastly-Debug-Digest', digest)
+                            .expect('X-Cache', 'HIT')
+                            .expect(200);
+                    });
+            });
+        });
     });
 });

--- a/test/fastly/origami-image-service.test.js
+++ b/test/fastly/origami-image-service.test.js
@@ -64,7 +64,7 @@ describe('Origami-image-service', function () {
                             .get(`${path}?source=${Math.random()}`)
                             .set('Fastly-Debug', 'true')
                             .expect('Fastly-Debug-Digest', digest)
-                            .expect('X-Cache', 'HIT')
+                            .expect('X-Cache', '\bHIT\b')
                             .expect(200);
                     });
             });


### PR DESCRIPTION
don't include the host header or the source query parameter in the cache key to increase the cache hit ratio (host can be 3 different values, source can be any value :| )

header and source values are not used in the generation of an image and so can be removed from the cache key. 

We store in the cache key whether a source parameter did exist because we serve an error page if the source parameter is missing.

This should make FTCMS images have a much better cache hit ratio because they are requested with source parameters of `next`, `app`, `fruitcake` etc.