### PR TITLE
Use Content API to locate the url of an image if it exists in the Content API otherwise fallback to original logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ We configure Origami Image Service using environment variables. In development, 
 
 ### Required everywhere
 
+  * `CONTENT_API_KEY`: The API key for the FT UPP Content API.
   * `CLOUDINARY_ACCOUNT_NAME`: The name of the Cloudinary account to use in image transforms.
   * `CLOUDINARY_API_KEY`: The Cloudinary API key corresponding to `CLOUDINARY_ACCOUNT_NAME`.
   * `CLOUDINARY_API_SECRET`: The Cloudinary API secret corresponding to `CLOUDINARY_ACCOUNT_NAME`.

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ dotenv.config({
 	silent: true
 });
 const options = {
+	contentApiKey: process.env.CONTENT_API_KEY,
 	cloudinaryAccountName: process.env.CLOUDINARY_ACCOUNT_NAME,
 	cloudinaryApiKey: process.env.CLOUDINARY_API_KEY,
 	cloudinaryApiSecret: process.env.CLOUDINARY_API_SECRET,

--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -65,7 +65,7 @@ function healthChecks(options) {
 				severity: 2,
 				businessImpact: 'Users may not be able to view images served by Universal Publishing Platform',
 				technicalSummary: 'Hits the given url and checks that it responds successfully',
-				panicGuide: `Check that the UPP endpoint http://prod-upp-image-read.ft.com/__gtg is responding with a 200 status and that the AWS Region is up`
+				panicGuide: 'Check that the UPP endpoint http://prod-upp-image-read.ft.com/__gtg is responding with a 200 status and that the AWS Region is up'
 			},
 
 			// This check monitors the process memory usage

--- a/lib/middleware/convert-to-cms-scheme.js
+++ b/lib/middleware/convert-to-cms-scheme.js
@@ -4,15 +4,28 @@ module.exports = convertToCmsScheme;
 
 function convertToCmsScheme() {
 	const cmsRegExp = /^(https?:)?\/*(?:prod-upp-image-read\.ft\.com|com\.ft\.imagepublish\.(prod|prod-us|upp-prod-eu|upp-prod-us)\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.(img|png|jpg|jpeg|gif))?(\?.+)?$/i;
+	const sparkRegExp = /^(https?:)?\/*(?:d1e00ek4ebabms\.cloudfront\.net\/production|cct-images\.ft\.com\/production)\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).*(\?.+)?$/i;
 	return (request, response, next) => {
-		const match = request.params.imageUrl.match(cmsRegExp);
+		let match = request.params.imageUrl.match(cmsRegExp);
 		if (match && match[3]) {
 			request.params.scheme = 'ftcms';
 			request.params.imageUrl = `ftcms:${match[3]}`;
 			if (match[5]) {
 				request.params.imageUrl += match[5];
 			}
+			next();
+		} else {
+			match = request.params.imageUrl.match(sparkRegExp);
+			if (match && match[2]) {
+				request.params.scheme = 'ftcms';
+				request.params.imageUrl = `ftcms:${match[2]}`;
+				if (match[4]) {
+					request.params.imageUrl += match[4];
+				}
+				next();
+			} else {
+				next();
+			}
 		}
-		next();
 	};
 }

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -43,7 +43,7 @@ function getCmsUrl(config) {
 						return response.data.binaryUrl;
 					}
 				}
-				// First try fetching the v2 image
+				// Second try fetching from FT CMS v2
 				return requestPromise({
 						uri: v2Uri,
 						method: 'HEAD',

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const httpError = require('http-errors');
+const axios = require('axios');
 const requestPromise = require('../request-promise');
 
 module.exports = getCmsUrl;
 
-function getCmsUrl() {
+function getCmsUrl(config) {
 	return (request, response, next) => {
 
 		if (!request.params.imageUrl.startsWith('ftcms')) {
@@ -20,41 +21,58 @@ function getCmsUrl() {
 		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
 		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img${query}`;
 		const v2Uri = `http://prod-upp-image-read.ft.com/${cmsId}${query}`;
+		const capi = `https://api.ft.com/enrichedcontent/${cmsId}${query}`;
 		request.params.schemeUrl = `ftcms:${cmsId}`;
 
 		// Keep track of which API we last checked
 		let lastRequestedUri = v2Uri;
 		let cmsVersionUsed = null;
 
-		// First try fetching the v2 image
-		requestPromise({
-			uri: v2Uri,
-			method: 'HEAD',
-			timeout: 10000 // 10 seconds
-		})
-			.then(firstResponse => {
-				// Cool, we've got an image from v2
-				if (firstResponse.statusCode <= 400) {
-					cmsVersionUsed = 'v2';
-					return v2Uri;
-				}
-				// If the v2 image can't be found, try v1
-				lastRequestedUri = v1Uri;
-				return requestPromise({
-					uri: v1Uri,
-					method: 'HEAD',
-					timeout: 10000 // 10 seconds
-				}).then(secondResponse => {
-					// Cool, we've got an image from v1
-					if (secondResponse.statusCode <= 400) {
-						cmsVersionUsed = 'v1';
-						return v1Uri;
+		axios.get(capi, {
+				headers: {
+					'x-api-key': config.contentApiKey
+				},
+				timeout: 10000, // 10 seconds
+				validateStatus: function (status) {
+					return status >= 200 && status < 600;
+				},
+			})
+			.then(response => {
+				if (response.status <= 400) {
+					if (response.data.binaryUrl.length > 0) {
+						return response.data.binaryUrl;
 					}
-					// If the v1 image can't be found, we error
-					const error = httpError(404, `Unable to get image ${cmsId} from FT CMS v1 or v2`);
-					error.cacheMaxAge = '30s';
-					throw error;
-				});
+				}
+				// First try fetching the v2 image
+				return requestPromise({
+						uri: v2Uri,
+						method: 'HEAD',
+						timeout: 10000 // 10 seconds
+					})
+					.then(firstResponse => {
+						// Cool, we've got an image from v2
+						if (firstResponse.statusCode <= 400) {
+							cmsVersionUsed = 'v2';
+							return v2Uri;
+						}
+						// If the v2 image can't be found, try v1
+						lastRequestedUri = v1Uri;
+						return requestPromise({
+							uri: v1Uri,
+							method: 'HEAD',
+							timeout: 10000 // 10 seconds
+						}).then(secondResponse => {
+							// Cool, we've got an image from v1
+							if (secondResponse.statusCode <= 400) {
+								cmsVersionUsed = 'v1';
+								return v1Uri;
+							}
+							// If the v1 image can't be found, we error
+							const error = httpError(404, `Unable to get image ${cmsId} from FT CMS v1 or v2`);
+							error.cacheMaxAge = '30s';
+							throw error;
+						});
+					});
 			})
 			.then(resolvedUrl => {
 				log.info(`ftcms-check cmsId=${cmsId} cmsVersionUsed=${cmsVersionUsed} source=${request.query.source}`);

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -28,6 +28,7 @@ function getCmsUrl(config) {
 		let lastRequestedUri = v2Uri;
 		let cmsVersionUsed = null;
 
+		// First try fetching from Content API
 		axios.get(capi, {
 				headers: {
 					'x-api-key': config.contentApiKey

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -119,7 +119,7 @@ module.exports = app => {
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com).+)$/i,
+		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com|d1e00ek4ebabms\.cloudfront\.net|cct-images\.ft\.com).+)$/i,
 		mapParams,
 		mapScheme,
 		markImageAsImmutable,

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -119,7 +119,7 @@ module.exports = app => {
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com|d1e00ek4ebabms\.cloudfront\.net|cct-images\.ft\.com).+)$/i,
+		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com|d1e00ek4ebabms\.cloudfront\.net\/production|cct-images\.ft\.com\/production).+)$/i,
 		mapParams,
 		mapScheme,
 		markImageAsImmutable,

--- a/package-lock.json
+++ b/package-lock.json
@@ -442,6 +442,38 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@financial-times/podcast-logos": "1.1.4",
     "@financial-times/social-images": "2.2.2",
     "@financial-times/source-param-middleware": "1.0.6",
+    "axios": "^0.19.0",
     "base-64": "0.1.0",
     "cloudinary": "1.14.0",
     "colornames": "1.1.1",

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -12,6 +12,7 @@ const mockLog = {
 
 before(function() {
 	return imageService({
+		contentApiKey: process.env.CONTENT_API_KEY,
 		cloudinaryAccountName: 'financial-times', // TODO set up a test account for this?
 		customSchemeStore: process.env.CUSTOM_SCHEME_STORE || 'https://origami-images.ft.com',
 		hostname: 'origami-image-service-qa.herokuapp.com',

--- a/test/integration/v2/images-debug.test.js
+++ b/test/integration/v2/images-debug.test.js
@@ -6,29 +6,127 @@ const itRespondsWithStatus = require('../helpers/it-responds-with-status');
 const setupRequest = require('../helpers/setup-request');
 
 const testImageUris = {
-	http: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
+	ftbrand: 'ftbrand:brussels-blog',
+	ftcms: 'ftcms:6c5a2f8c-18ca-4afa-80ff-7d56e41172b1',
+	capiv1: 'ftcms:be875529-7675-43d8-b461-b304410398c2',
+	capiv2: 'ftcms:03b59122-a148-11e9-a282-2df48f366f7d',
+	spark: 'ftcms:c3fec7fb-aba9-42ee-a745-a62c872850d0',
+	sparkMasterImage: 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b',
+	ftflag: 'ftflag:jp',
+	fthead: 'fthead:martin-wolf',
+	fticon: 'fticon:cross',
+	ftlogo: 'ftlogo:brand-ft',
+	ftpodcast: 'ftpodcast:arts',
+	ftsocial: 'ftsocial:whatsapp',
+	httpsspark: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+	httpftcms: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	httpsftcms: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	httpftcmsmalformed: 'http:/im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	httpsftcmsmalformed: 'https:im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	http: 'http://origami-images.ft.com/ftsocial/v1/twitter.svg',
+	https: 'https://origami-images.ft.com/ftsocial/v1/twitter.svg',
+	protocolRelative: '//origami-images.ft.com/ftsocial/v1/twitter.svg',
+	protocolRelativeftcms: '//im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	specialisttitle: 'specialisttitle:ned-logo',
+	nonUtf8Characters: 'http://s3-eu-west-1.amazonaws.com/fthtsi-assets-production/ez/images/0/9/3/2/1212390-1-eng-GB/Y+et+Beaute%CC%81+Tranquille.jpg'
 };
 
-describe('GET /v2/images/debug…', function() {
 
-	setupRequest('GET', `/v2/images/debug/${testImageUris.http}?source=test&width=123&height=456&echo`);
-	itRespondsWithStatus(200);
-	itRespondsWithContentType('application/json');
+describe('GET /v2/images/debug…', function () {
 
-	it('responds with JSON representing the transforms in the image request', function(done) {
-		this.request.expect(response => {
-			assert.isObject(response.body);
-			assert.deepEqual(response.body.transform, {
-				fit: 'cover',
-				format: 'auto',
-				height: 456,
-				quality: 72,
-				uri: testImageUris.http,
-				width: 123,
-				immutable: true
-			});
-			assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img$'));
-		}).end(done);
+	describe('http', function () {
+		setupRequest('GET', `/v2/images/debug/${testImageUris.httpftcms}?source=test&width=123&height=456&echo`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('application/json');
+
+		it('responds with JSON representing the transforms in the image request', function (done) {
+			this.request.expect(response => {
+				assert.isObject(response.body);
+				assert.deepEqual(response.body.transform, {
+					fit: 'cover',
+					format: 'auto',
+					height: 456,
+					quality: 72,
+					uri: testImageUris.httpftcms,
+					width: 123,
+					immutable: true
+				});
+				assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img$'));
+			}).end(done);
+		});
 	});
 
+
+	const imagesWithSchemes = {
+		ftcms: {
+			requestedUrl: 'ftcms:6c5a2f8c-18ca-4afa-80ff-7d56e41172b1',
+			resolvedUrl: 'http://im.ft-static.com/content/images/6c5a2f8c-18ca-4afa-80ff-7d56e41172b1.img'
+		},
+		capiv1: {
+			requestedUrl: 'ftcms:be875529-7675-43d8-b461-b304410398c2',
+			resolvedUrl: 'http://im.ft-static.com/content/images/be875529-7675-43d8-b461-b304410398c2.img'
+		},
+		capiv2: {
+			requestedUrl: 'ftcms:03b59122-a148-11e9-a282-2df48f366f7d',
+			resolvedUrl: 'http://com.ft.imagepublish.upp-prod-us.s3.amazonaws.com/03b59122-a148-11e9-a282-2df48f366f7d'
+		},
+		spark: {
+			requestedUrl: 'ftcms:c3fec7fb-aba9-42ee-a745-a62c872850d0',
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/c3fec7fb-aba9-42ee-a745-a62c872850d0.jpg'
+		},
+		sparkMasterImage: {
+			requestedUrl: 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b',
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg'
+		},
+		httpsspark: {
+			requestedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+		},
+		httpspark: {
+			requestedUrl: 'http://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+		},
+		httpssparkcustomdomain: {
+			requestedUrl: 'https://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+		},
+		httpsparkcustomdomain: {
+			requestedUrl: 'http://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
+		},
+		httpftcms: {
+			requestedUrl: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+			resolvedUrl: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+		},
+		httpsftcms: {
+			requestedUrl: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+			resolvedUrl: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+		},
+		httpftcmsmalformed: {
+			requestedUrl: 'http:/im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+			resolvedUrl: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+		},
+		httpsftcmsmalformed: {
+			requestedUrl: 'https:im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+			resolvedUrl: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+		},
+	};
+
+	for (const [test, {
+			requestedUrl,
+			resolvedUrl
+		}] of Object.entries(imagesWithSchemes)) {
+		describe(`resolving urls which have custom schemes: ${test} -- ${requestedUrl} should resolve to ${resolvedUrl}`, function () {
+			setupRequest('GET', `/v2/images/debug/${requestedUrl}?source=test&width=123&height=456`);
+			itRespondsWithStatus(200);
+			itRespondsWithContentType('application/json');
+
+			it('responds with the correct location of the original image', function (done) {
+				this.request.expect(response => {
+					const actual = response.body.transform.uri;
+					assert.deepEqual(actual, resolvedUrl, `Expected ${requestedUrl} to resolve to ${resolvedUrl} but it actually resolved to ${actual}`);
+				}).end(done);
+			});
+		});
+	}
 });

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -9,12 +9,17 @@ const setupRequest = require('../helpers/setup-request');
 const testImageUris = {
 	ftbrand: 'ftbrand:brussels-blog',
 	ftcms: 'ftcms:6c5a2f8c-18ca-4afa-80ff-7d56e41172b1',
+	capiv1: 'ftcms:be875529-7675-43d8-b461-b304410398c2',
+	capiv2: 'ftcms:03b59122-a148-11e9-a282-2df48f366f7d',
+	spark: 'ftcms:c3fec7fb-aba9-42ee-a745-a62c872850d0',
+	sparkMasterImage: 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b',
 	ftflag: 'ftflag:jp',
 	fthead: 'fthead:martin-wolf',
 	fticon: 'fticon:cross',
 	ftlogo: 'ftlogo:brand-ft',
 	ftpodcast: 'ftpodcast:arts',
 	ftsocial: 'ftsocial:whatsapp',
+	httpsspark: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
 	httpftcms: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	httpsftcms: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	httpftcmsmalformed: 'http:/im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
@@ -103,6 +108,36 @@ describe('GET /v2/images/raw…', function() {
 
 	describe('/ftcms:… (ftcms scheme)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.ftcms}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+
+	describe('/ftcms:… (capiv1 scheme)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.capiv1}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+	
+	describe('/ftcms:… (capiv2 scheme)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.capiv2}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+	
+	describe('/ftcms:… (spark scheme)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.spark}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+	
+	describe('/ftcms:… (sparkMasterImage scheme)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.sparkMasterImage}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+	});
+	
+	describe('/https:… (httpsspark scheme)', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.httpsspark}?source=test`);
 		itRespondsWithStatus(200);
 		itRespondsWithContentType('image/jpeg');
 	});

--- a/test/unit/lib/middleware/convert-to-cms-scheme.test.js
+++ b/test/unit/lib/middleware/convert-to-cms-scheme.test.js
@@ -118,6 +118,32 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 				});
 
 			});
+			
+			describe('when the `imageUrl` request param points to an image on d1e00ek4ebabms.cloudfront.net', () => {
+
+				beforeEach(done => {
+					origamiService.mockRequest.params.imageUrl = 'http://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
+					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
+				});
+
+				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
+					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b');
+				});
+
+			});
+			
+			describe('when the `imageUrl` request param points to an image on cct-images.ft.com', () => {
+
+				beforeEach(done => {
+					origamiService.mockRequest.params.imageUrl = 'http://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
+					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
+				});
+
+				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
+					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b');
+				});
+
+			});
 
 			describe('when the `imageUrl` request param points to an image on im.ft-static.com with a "png" extension', () => {
 

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -9,6 +9,7 @@ describe('lib/middleware/get-cms-url', () => {
 	let getCmsUrl;
 	let log;
 	let requestPromise;
+	let config;
 
 	beforeEach(() => {
 		origamiService = require('../../mock/origami-service.mock');
@@ -16,6 +17,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 		requestPromise = require('../../mock/request-promise.mock');
 		mockery.registerMock('../request-promise', requestPromise);
+		config = {contentApiKey: 'test'};
 
 		getCmsUrl = require('../../../../lib/middleware/get-cms-url');
 	});
@@ -28,7 +30,7 @@ describe('lib/middleware/get-cms-url', () => {
 		let middleware;
 
 		beforeEach(() => {
-			middleware = getCmsUrl();
+			middleware = getCmsUrl(config);
 		});
 
 		it('returns a middleware function', () => {


### PR DESCRIPTION
This ensures we still work for old Content API v1 images and work for the images coming from the new CMS called Spark