### PR TITLE
Avoid passing stale content from Shield POP to Edge POP

### DIFF
--- a/fastly/vcl/image-service.vcl
+++ b/fastly/vcl/image-service.vcl
@@ -104,6 +104,11 @@ sub vcl_recv {
 	# If querystring is empty, remove the ? from the url.
 	set req.url = querystring.clean(querystring.sort(req.url));
 	call set_backend;
+
+	if (req.backend == ssl_shield_iad_va_us || req.backend == ssl_shield_london_city_uk) {
+		# avoid passing stale content from Shield POP to Edge POP
+		set req.max_stale_while_revalidate = 0s;
+	}
 }
 
 sub vcl_hash {


### PR DESCRIPTION
We set stale-while-revalidate cache-control directives on our responses from origin and those responses get forwarded from our shield POPs to the other POPs. When we issue a soft-purge in Fastly, Fastly marks the content as stale and serves the content in respect of the stale-while-revalidate directive. For requests which go direct from a browser to a shield POP, they get a stale response and eventually will get the newly updated response when the stale-while-revalidate time has expired. For requests which go to another POP, the request gets served a stale response and then the POP requests the same content from our shield POP, which may end up serving the stale content as well (including the cache-control directives), which the original POP will then cache for a very long time. 

The solution to this is to detect when a request has come from a Fastly POP to our shield POP and to make the request not honour the stale-while-revalidate directive and instead get served a fresh response immediately, thereby ensuring that a soft-purge of a resource works correctly across the entire Fastly network.

This can be achieved by adding to our vcl_recv subroutine:

```vcl
if (req.backend == ssl_shield_iad_va_us || req.backend == ssl_shield_london_city_uk) {
    # avoid passing stale content from Shield POP to Edge POP
    set req.max_stale_while_revalidate = 0s;
}
```