### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ workflows:
       - change-api/release-log:
           requires:
             - deploy_dev
-          systemCode: 'origami-image-service'
+          systemCode: 'origami-image-service-v2'
           environment: 'dev'
           slackChannels: 'origami-deploys'
           filters:
@@ -154,7 +154,7 @@ workflows:
       - change-api/release-log:
           requires:
             - deploy_staging
-          systemCode: 'origami-image-service'
+          systemCode: 'origami-image-service-v2'
           environment: 'test'
           slackChannels: 'origami-deploys'
           filters:
@@ -181,7 +181,7 @@ workflows:
       - change-api/release-log:
           requires:
             - deploy_service_production
-          systemCode: 'origami-image-service'
+          systemCode: 'origami-image-service-v2'
           environment: 'prod'
           slackChannels: 'origami-deploys'
           filters:


### PR DESCRIPTION
## What 

Update system code to the correct value since `origami-image-service` doesnt exist in Biz-Ops.

## Why 

Change API has been unable to create a Salesforce entry for releases being made to this system because the `systemcode` being provided doesnt seem to exist in Biz-Ops. I did find an entry for [Origami Image Service 2](https://biz-ops.in.ft.com/System/origami-image-service-v2) which I believe was the intention?

Apologies, we are working on exposing these errors to the users. Currently, it is very manual and has to be tracked on [Splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/change_api_test?earliest=-24h%40h&latest=now&form.env_index=aws_cloudwatch&form.systemCode=*)