### PR TITLE
convert png to jpeg if it has no alpha channel (no transparency)

### DIFF
--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -32,6 +32,7 @@ function buildCloudinaryTransforms(transform) {
 		// Flags to improve image file sizes/compression
 		// http://cloudinary.com/documentation/image_transformation_reference#flags_parameter
 		flags: [
+			'lossy', // convery png to jpeg if it has no alpha channel (no transparency)
 			'any_format', // allow switching to PNG8 encoding
 			'force_strip', // always strip image meta-data
 			'progressive' // send progressive images

--- a/test/integration/v2/images-debug.test.js
+++ b/test/integration/v2/images-debug.test.js
@@ -51,7 +51,7 @@ describe('GET /v2/images/debug…', function () {
 					width: 123,
 					immutable: true
 				});
-				assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img$'));
+				assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img$'));
 			}).end(done);
 		});
 	});

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -97,13 +97,13 @@ describe('GET /v2/images/raw…', function() {
 	describe('/ftbrand:… (ftbrand scheme)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.ftbrand}?source=test`);
 		itRespondsWithStatus(200);
-		itRespondsWithContentType('image/png');
+		itRespondsWithContentType('image/jpeg');
 	});
 
 	describe('/ftbrand:… (ftbrand scheme with querystring)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.ftbrand}%3Ffoo%3Dbar?source=test`);
 		itRespondsWithStatus(200);
-		itRespondsWithContentType('image/png');
+		itRespondsWithContentType('image/jpeg');
 	});
 
 	describe('/ftcms:… (ftcms scheme)', function() {
@@ -193,7 +193,7 @@ describe('GET /v2/images/raw…', function() {
 	describe('/ftpodcast:… (ftpodcast scheme)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.ftpodcast}?source=test`);
 		itRespondsWithStatus(200);
-		itRespondsWithContentType('image/png');
+		itRespondsWithContentType('image/jpeg');
 	});
 
 	describe('/ftlogo:… (ftlogo scheme)', function() {
@@ -434,7 +434,7 @@ describe('GET /v2/images/raw…', function() {
 		describe('adds specific keys for image content types', function() {
 			describe('ftbrand', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.ftbrand}?source=test`);
-				itRespondsWithHeader('surrogate-key', /aW1hZ2UvcG5n/);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2UvanBlZw==/);
 			});
 
 			describe('ftcms', function() {
@@ -464,7 +464,7 @@ describe('GET /v2/images/raw…', function() {
 
 			describe('ftpodcast', function() {
 				setupRequest('GET', `/v2/images/raw/${testImageUris.ftpodcast}?source=test`);
-				itRespondsWithHeader('surrogate-key', /aW1hZ2UvcG5n/);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2UvanBlZw==/);
 			});
 
 			describe('ftsocial', function() {

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -33,7 +33,7 @@ describe('lib/transformers/cloudinary', () => {
 		});
 
 		it('returns a Cloudinary fetch URL', () => {
-			assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+			assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 		});
 
 		describe('when `transform` has a `width` property', () => {
@@ -44,7 +44,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72,w_123/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72,w_123/http://example.com/$'));
 			});
 
 		});
@@ -57,7 +57,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,h_123,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,h_123,q_72/http://example.com/$'));
 			});
 
 		});
@@ -70,7 +70,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,dpr_2,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,dpr_2,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -83,7 +83,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fit,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fit,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -96,7 +96,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -109,7 +109,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_scale,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_scale,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -122,7 +122,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_limit,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_limit,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -135,7 +135,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,g_auto:faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,g_auto:faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -148,7 +148,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,g_auto:no_faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,g_auto:no_faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -161,7 +161,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_png,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_png,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -174,7 +174,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive,q_30/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_30/http://example.com/$'));
 			});
 
 		});
@@ -187,7 +187,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -200,7 +200,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -213,7 +213,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -226,7 +226,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary fetch URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/fetch/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});


### PR DESCRIPTION
>25% of your bandwidth is being used to deliver PNG images. You can save considerable bandwidth by delivering non-transparent PNGs as JPGs. If you aren’t already doing so, consider using the ‘lossy’ flag to do this conversion automatically.

<img width="889" alt="image" src="https://user-images.githubusercontent.com/1569131/81003207-61eb0780-8e42-11ea-82f3-11c72937890b.png">
