### PR TITLE
If Content API does not have the image, try to use the original image url and see if it exists

### DIFF
--- a/lib/middleware/convert-to-cms-scheme.js
+++ b/lib/middleware/convert-to-cms-scheme.js
@@ -9,6 +9,7 @@ function convertToCmsScheme() {
 		let match = request.params.imageUrl.match(cmsRegExp);
 		if (match && match[3]) {
 			request.params.scheme = 'ftcms';
+			request.params.originalImageUrl = request.params.imageUrl;
 			request.params.imageUrl = `ftcms:${match[3]}`;
 			if (match[5]) {
 				request.params.imageUrl += match[5];
@@ -18,6 +19,7 @@ function convertToCmsScheme() {
 			match = request.params.imageUrl.match(sparkRegExp);
 			if (match && match[2]) {
 				request.params.scheme = 'ftcms';
+				request.params.originalImageUrl = request.params.imageUrl;
 				request.params.imageUrl = `ftcms:${match[2]}`;
 				if (match[4]) {
 					request.params.imageUrl += match[4];

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -68,29 +68,28 @@ function getCmsUrl(config) {
 								cmsVersionUsed = 'v1';
 								return v1Uri;
 							}
-							if (request.params.originalImageUrl) {
-								return requestPromise({
-									uri: request.params.originalImageUrl,
-									method: 'HEAD',
-									timeout: 10000 // 10 seconds
-								}).then(thirdResponse => {
-									// Cool, we've got an image from the original image url, which means the image has not yet been published to the Content API.
-									// This usually means the image is being used in an unpublished entry in the Spark CMS.
-									if (thirdResponse.statusCode <= 400) {
-										cmsVersionUsed = 'n/a';
-										return request.params.originalImageUrl;
-									}
-									// If the v1 image can't be found, we error
-									const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
-									error.cacheMaxAge = '30s';
-									throw error;
-								});
-							} else {
+							if (!request.params.originalImageUrl) {
 								// If the v1 image can't be found, we error
 								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
 								error.cacheMaxAge = '30s';
 								throw error;
 							}
+							return requestPromise({
+								uri: request.params.originalImageUrl,
+								method: 'HEAD',
+								timeout: 10000 // 10 seconds
+							}).then(thirdResponse => {
+								// Cool, we've got an image from the original image url, which means the image has not yet been published to the Content API.
+								// This usually means the image is being used in an unpublished entry in the Spark CMS.
+								if (thirdResponse.statusCode <= 400) {
+									cmsVersionUsed = 'n/a';
+									return request.params.originalImageUrl;
+								}
+								// If the v1 image can't be found, we error
+								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
+								error.cacheMaxAge = '30s';
+								throw error;
+							});
 						});
 					});
 			})

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -44,7 +44,7 @@ function getCmsUrl(config) {
 						return response.data.binaryUrl;
 					}
 				}
-				// Second try fetching from FT CMS v2
+				// Second try fetching from Content API v2
 				return requestPromise({
 						uri: v2Uri,
 						method: 'HEAD',
@@ -68,10 +68,29 @@ function getCmsUrl(config) {
 								cmsVersionUsed = 'v1';
 								return v1Uri;
 							}
-							// If the v1 image can't be found, we error
-							const error = httpError(404, `Unable to get image ${cmsId} from FT CMS v1 or v2`);
-							error.cacheMaxAge = '30s';
-							throw error;
+							if (request.params.originalImageUrl) {
+								return requestPromise({
+									uri: request.params.originalImageUrl,
+									method: 'HEAD',
+									timeout: 10000 // 10 seconds
+								}).then(thirdResponse => {
+									// Cool, we've got an image from the original image url, which means the image has not yet been published to the Content API.
+									// This usually means the image is being used in an unpublished entry in the Spark CMS.
+									if (thirdResponse.statusCode <= 400) {
+										cmsVersionUsed = 'n/a';
+										return request.params.originalImageUrl;
+									}
+									// If the v1 image can't be found, we error
+									const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
+									error.cacheMaxAge = '30s';
+									throw error;
+								});
+							} else {
+								// If the v1 image can't be found, we error
+								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
+								error.cacheMaxAge = '30s';
+								throw error;
+							}
 						});
 					});
 			})

--- a/test/unit/lib/middleware/convert-to-cms-scheme.test.js
+++ b/test/unit/lib/middleware/convert-to-cms-scheme.test.js
@@ -29,9 +29,9 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 		describe('middleware(request, response, next)', () => {
 
 			describe('when the `imageUrl` request param does not point to a known CMS image store', () => {
-
+				const originalImageUrl = 'http://foo.bar/image.jpg';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'http://foo.bar/image.jpg';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
@@ -42,61 +42,77 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 			});
 
 			describe('when the `imageUrl` request param points to an image in prod-upp-image-read.ft.com', () => {
-
+				const originalImageUrl = 'http://prod-upp-image-read.ft.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'http://prod-upp-image-read.ft.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});
 
 			describe('when the `imageUrl` request param points to an image in the imagepublish S3 bucket', () => {
-
+				const originalImageUrl = 'https://com.ft.imagepublish.prod.s3.amazonaws.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'https://com.ft.imagepublish.prod.s3.amazonaws.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});
 
 			describe('when the `imageUrl` request param points to an image in the imagepublish US S3 bucket', () => {
-
+				const originalImageUrl = 'https://com.ft.imagepublish.prod-us.s3.amazonaws.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'https://com.ft.imagepublish.prod-us.s3.amazonaws.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});
 
          describe('when the `imageUrl` request param points to an image in the imagepublish K8S EU S3 bucket', () => {
-
+			const originalImageUrl = 'http://com.ft.imagepublish.upp-prod-eu.s3.amazonaws.com/26a7951a-c3e4-11e7-b30e-a7c1c7c13aab';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'http://com.ft.imagepublish.upp-prod-eu.s3.amazonaws.com/26a7951a-c3e4-11e7-b30e-a7c1c7c13aab';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:26a7951a-c3e4-11e7-b30e-a7c1c7c13aab');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});
 
          describe('when the `imageUrl` request param points to an image in the imagepublish K8S US S3 bucket', () => {
-
+			const originalImageUrl = 'http://com.ft.imagepublish.upp-prod-us.s3.amazonaws.com/26a7951a-c3e4-11e7-b30e-a7c1c7c13aab';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'http://com.ft.imagepublish.upp-prod-us.s3.amazonaws.com/26a7951a-c3e4-11e7-b30e-a7c1c7c13aab';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
@@ -104,38 +120,50 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:26a7951a-c3e4-11e7-b30e-a7c1c7c13aab');
 				});
 
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
+				});
+
 			});
 
 			describe('when the `imageUrl` request param points to an image on im.ft-static.com', () => {
-
+				const originalImageUrl = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});
 			
 			describe('when the `imageUrl` request param points to an image on d1e00ek4ebabms.cloudfront.net', () => {
-
+				const originalImageUrl = 'http://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'http://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the image ID', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});
 			
 			describe('when the `imageUrl` request param points to an image on cct-images.ft.com', () => {
-
+				const originalImageUrl = 'http://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'http://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
@@ -143,12 +171,16 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b');
 				});
 
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
+				});
+
 			});
 
 			describe('when the `imageUrl` request param points to an image on im.ft-static.com with a "png" extension', () => {
-
+				const originalImageUrl = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.png';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.png';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
@@ -156,30 +188,42 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef');
 				});
 
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
+				});
+
 			});
 
 			describe('when the `imageUrl` request param has a querystring', () => {
-
+				const originalImageUrl = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img?foo=bar';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'https://im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img?foo=bar';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the query intact', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef?foo=bar');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});
 
 			describe('when the `imageUrl` request param is a protocol-relative URL', () => {
-
+				const originalImageUrl = '//im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img?foo=bar';
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = '//im.ft-static.com/content/images/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef.img?foo=bar';
+					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
 				});
 
 				it('sets the `imageUrl` request param to an `ftcms` URL with the query intact', () => {
 					assert.strictEqual(origamiService.mockRequest.params.imageUrl, 'ftcms:d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef?foo=bar');
+				});
+
+				it('sets the `originalImageUrl` request param to the original image url', () => {
+					assert.strictEqual(origamiService.mockRequest.params.originalImageUrl, originalImageUrl);
 				});
 
 			});


### PR DESCRIPTION
When working with unpublished content, the content API will not respond with the image but the original image url does in fact exist and work.

This change will make the image service attempt to use the original image url if it responds with a successful HTTP status code.

This change will make origami image service work for unpublished content being authored within Spark CMS.