### PR TITLE
Refactor handle-svg to use axios instead of request 

### DIFF
--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -2,7 +2,7 @@
 
 const createDOMPurify = require('dompurify');
 const httpError = require('http-errors');
-const httpRequest = require('request');
+const axios = require('axios').default;
 const {JSDOM} = require('jsdom');
 const SvgTintStream = require('svg-tint-stream');
 
@@ -42,30 +42,62 @@ function handleSvg() {
 		}
 
 		// Request the original SVG image
-		let imageRequest = httpRequest(uri, {
-			timeout: 25000 // 25 seconds
+		const imageRequest = axios(uri, {
+			method: 'get',
+			responseType: 'stream',
+			timeout: 25000,
+			validateStatus: function (status) {
+				return status >= 200 && status < 600;
+			}
 		});
 
-		imageRequest = imageRequest
+		imageRequest
 			// We listen for the response event so that we
 			// can error properly and *early* if the URI
 			// does not point to an SVG or it errors
-			.on('response', imageResponse => {
-				if (imageResponse.statusCode >= 400) {
-					const error = httpError(imageResponse.statusCode);
+			.then(imageResponse => {
+				if (imageResponse.status >= 400) {
+					const error = httpError(imageResponse.status);
 					error.cacheMaxAge = '30s';
-					return imageRequest.emit('error', error);
-				}
-				if (imageResponse.headers['content-type'].indexOf('image/svg+xml') === -1) {
+					throw error;
+				} else if (imageResponse.headers['content-type'].indexOf('image/svg+xml') === -1) {
 					const error = httpError(400, 'URI must point to an SVG image');
 					error.cacheMaxAge = '5m';
-					return imageRequest.emit('error', error);
+					throw error;
+				} else {
+					response.set('Content-Type', 'image/svg+xml; charset=utf-8');
+					let imageStream = imageResponse.data;
+					// Pipe the image request through the tint stream
+					if (tintStream) {
+						imageStream = imageResponse.data.pipe(tintStream);
+					}
+
+					// Temporary fix: load the entire SVG in and error if
+					// there are unsafe elements
+					let entireSvg = '';
+					imageStream.on('data', chunk => {
+						entireSvg += chunk.toString();
+					});
+					imageStream.on('end', () => {
+						if (!hasErrored) {
+							if (!window || !DOMPurify) {
+								window = (new JSDOM('')).window;
+								DOMPurify = createDOMPurify(window);
+							}
+
+							// Clean the SVG if required
+							if (isWhitelisted) {
+								response.send(entireSvg);
+							} else {
+								response.send(DOMPurify.sanitize(entireSvg));
+							}
+						}
+					});
 				}
-				response.set('Content-Type', 'image/svg+xml; charset=utf-8');
 			})
 			// If the request errors, report this using
 			// the standard error middleware
-			.on('error', error => {
+			.catch(error => {
 				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
 					error = new Error(`DNS lookup failed for "${uri}"`);
 				}
@@ -80,33 +112,5 @@ function handleSvg() {
 				hasErrored = true;
 				return next(error);
 			});
-
-		// Pipe the image request through the tint stream
-		if (tintStream) {
-			imageRequest = imageRequest.pipe(tintStream);
-		}
-
-		// Temporary fix: load the entire SVG in and error if
-		// there are unsafe elements
-		let entireSvg = '';
-		imageRequest.on('data', chunk => {
-			entireSvg += chunk.toString();
-		});
-		imageRequest.on('end', () => {
-			if (!hasErrored) {
-				if (!window || !DOMPurify) {
-					window = (new JSDOM('')).window;
-					DOMPurify = createDOMPurify(window);
-				}
-
-				// Clean the SVG if required
-				if (isWhitelisted) {
-					response.send(entireSvg);
-				} else {
-					response.send(DOMPurify.sanitize(entireSvg));
-				}
-			}
-		});
-
 	};
 }


### PR DESCRIPTION
Requires https://github.com/Financial-Times/origami-image-service/pull/623 first
This refactor fixes a bug which occurs when the requested SVG is a 404 and the handle-svg module throws an `Error: Parse Error: User callback error`
https://sentry.io/organizations/financial-times/issues/986368588/?project=97641&query=is%3Aunresolved&sort=freq&statsPeriod=14d