### PR TITLE
stop adding client errors to Sentry as these are not solvable by the application

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -50,6 +50,7 @@ function createProxy(errorHandler) {
 	proxy.on('error', (error, request, response) => {
 		if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
 			error = new Error(`Proxy DNS lookup failed for "${request.url}"`);
+			error.skipSentry = true;
 		}
 		if (error.code === 'ECONNRESET') {
 			const resetError = error;

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -79,6 +79,7 @@ function getCmsUrl(config) {
 								// If the v1 image can't be found, we error
 								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
 								error.cacheMaxAge = '30s';
+								error.skipSentry = true;
 								throw error;
 							}
 							return requestPromise({
@@ -95,6 +96,7 @@ function getCmsUrl(config) {
 								// If the v1 image can't be found, we error
 								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
 								error.cacheMaxAge = '30s';
+								error.skipSentry = true;
 								throw error;
 							});
 						});
@@ -110,6 +112,7 @@ function getCmsUrl(config) {
 				log.info(`ftcms-check cmsId=${cmsId} cmsVersionUsed=error source=${request.query.source}`);
 				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
 					error = new Error(`DNS lookup failed for "${lastRequestedUri}"`);
+					error.skipSentry = true;
 				}
 				if (error.code === 'ECONNRESET') {
 					const resetError = error;

--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -59,10 +59,12 @@ function handleSvg() {
 				if (imageResponse.status >= 400) {
 					const error = httpError(imageResponse.status);
 					error.cacheMaxAge = '30s';
+					error.skipSentry = true;
 					throw error;
 				} else if (imageResponse.headers['content-type'].indexOf('image/svg+xml') === -1) {
 					const error = httpError(400, 'URI must point to an SVG image');
 					error.cacheMaxAge = '5m';
+					error.skipSentry = true;
 					throw error;
 				} else {
 					response.set('Content-Type', 'image/svg+xml; charset=utf-8');
@@ -100,6 +102,7 @@ function handleSvg() {
 			.catch(error => {
 				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
 					error = new Error(`DNS lookup failed for "${uri}"`);
+					error.skipSentry = true;
 				}
 				if (error.code === 'ECONNRESET') {
 					const resetError = error;

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -75,10 +75,14 @@ function processImage(config) {
 				responseType: 'arraybuffer'
 			}).then(async imageResponse => {
 				if (imageResponse.status >= 400) {
-					throw httpError(imageResponse.status);
+					const error = httpError(imageResponse.status);
+					error.skipSentry = true;
+					throw error;
 				}
 				if (imageResponse.headers['content-type'].includes('text/html')) {
-					throw httpError(400);
+					const error = httpError(400);
+					error.skipSentry = true;
+					throw error;
 				}
 				const file = imageResponse.data;
 

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -96,6 +96,7 @@ module.exports = app => {
 		/^\/v2\/images\/(raw|debug|metadata|purge)\/$/i, function() {
 			const error = httpError(404, 'Image URI must be a string with a valid scheme');
 			error.cacheMaxAge = '1y';
+			error.skipSentry = true;
 			throw error;
 		}
 	);


### PR DESCRIPTION
This will make our Sentry alerts less noisy as we should only be receiving Sentry alerts for issues within the application rather than alerts for when a client provided image url is a 404/500/not-an-image.