### PR TITLE
Make the cloudinary upload process faster by avoiding the resource api call

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -18,7 +18,6 @@ function processImage(config) {
 		api_key: config.cloudinaryApiKey,
 		api_secret: config.cloudinaryApiSecret
 	});
-	const resource = promisify(cloudinary.api.resource.bind(cloudinary.api));
 	const upload = promisify(cloudinary.uploader.upload.bind(cloudinary.uploader));
 	return (request, response, next) => {
 		let transform;

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -94,25 +94,15 @@ function processImage(config) {
 				transform.setName(imageName);
 				cache[originalImageURI] = imageName;
 				
-				// 3. check cloudinary to see if image with name exists
-				let imageAlreadyUploadedToCloudinary = false;
-				try {
-					imageAlreadyUploadedToCloudinary = await resource(imageName);
-				} catch (imageAlreadyUploadedToCloudinaryError) {
-					// errors will be thrown if either the resource does not exist or if the cloudinary api rate-limit has been reached.
-					// both of those errors are safe to ignore because the upload call below does not have a rate-limit.
-				}
+				// 3. upload the image to cloudinary - this will not error if the image has already been uploaded to cloudinary
+				await upload(originalImageURI, {
+					public_id: imageName,
+					unique_filename: false,
+					use_filename: false,
+					resource_type: 'image',
+					overwrite: false
+				});
 
-				// 4. upload image to cloudinary if it is not already uploaded.
-				if (!imageAlreadyUploadedToCloudinary) {
-					await upload(originalImageURI, {
-						public_id: imageName,
-						unique_filename: false,
-						overwrite: true,
-						use_filename: false,
-						resource_type: 'image'
-					});
-				}
 			});
 		}
 


### PR DESCRIPTION
We made a call to the Cloudinary Resource API to check if the image was already uploaded. It turns out that API call is not required as the Upload API call does not upload the image if it already exists in Cloudinary.

Using the Upload API with `overwrite` set to `false` will upload the image to cloudinary if it does not already exist. If it does already exist it returns an object which has the metadata for the already uploaded image.

This has a side-benefit of not using an API call which is rate-limited to 5000 calls per hour, which we regularly were hitting