### PR TITLE
Increase caching time of client misconfiguration errors

### DIFF
--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -78,7 +78,7 @@ function getCmsUrl(config) {
 							if (!request.params.originalImageUrl) {
 								// If the v1 image can't be found, we error
 								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
-								error.cacheMaxAge = '30s';
+								error.cacheMaxAge = '1y';
 								error.skipSentry = true;
 								throw error;
 							}
@@ -95,7 +95,7 @@ function getCmsUrl(config) {
 								}
 								// If the v1 image can't be found, we error
 								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
-								error.cacheMaxAge = '30s';
+								error.cacheMaxAge = '1y';
 								error.skipSentry = true;
 								throw error;
 							});

--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -35,7 +35,7 @@ function handleSvg() {
 				});
 			} catch (error) {
 				error.status = 400;
-				error.cacheMaxAge = '30s';
+				error.cacheMaxAge = '1y';
 				hasErrored = true;
 				return next(error);
 			}

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -32,7 +32,7 @@ function processImage(config) {
 			transform = new ImageTransform(request.query);
 		} catch (error) {
 			error.status = 400;
-			error.cacheMaxAge = '10m';
+			error.cacheMaxAge = '1y';
 			return next(error);
 		}
 

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -226,7 +226,7 @@ describe('lib/middleware/get-cms-url', () => {
 					assert.instanceOf(responseError, Error);
 					assert.strictEqual(responseError.message, 'Unable to get image mock-id4 from Content API v1 or v2');
 					assert.strictEqual(responseError.status, 404);
-					assert.strictEqual(responseError.cacheMaxAge, '30s');
+					assert.strictEqual(responseError.cacheMaxAge, '1y');
 				});
 
 				it('logs that the CMS ID was found in neither API', () => {

--- a/test/unit/lib/middleware/handle-svg.test.js
+++ b/test/unit/lib/middleware/handle-svg.test.js
@@ -370,7 +370,7 @@ describe('lib/middleware/handle-svg', function () {
 				it('calls next with the error and sets correct status code', () => {
 					assert.isTrue(next.calledOnce);
 					assert.equal(next.firstCall.firstArg.status, 400);
-					assert.equal(next.firstCall.firstArg.cacheMaxAge, '30s');
+					assert.equal(next.firstCall.firstArg.cacheMaxAge, '1y');
 				});
 
 			});


### PR DESCRIPTION
These errors are all triggered by creating an invalid Image Service URL which means that they would always be a client error and are safe to cache indefinitely.

To fix these errors the client would need to update their URL, which means it is a different object in our CDN cache.