### PR TITLE
increase the timeout for downloading the original image to 20 seconds

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -67,7 +67,7 @@ function processImage(config) {
 			transform.setName(imageName);
 		} else {
 			transformReady = axios.get(encodeURI(originalImageURI), {
-				timeout: 10000, // 10 seconds
+				timeout: 20000, // 20 seconds
 				validateStatus: function (status) {
 					return status >= 200 && status < 600;
 				},


### PR DESCRIPTION
we have 30 seconds to deal with a request in heroku, let's use at most 20 of those seconds downloading the original image. Hopefully this will reduce the amount of time-out errors we are throwing.

<img width="874" alt="screenshot of sentry which shows 2700 time-out errors in the last 6 days" src="https://user-images.githubusercontent.com/1569131/93227606-73d3a400-f76c-11ea-9354-35cf5da7a4f1.png">
