### PR TITLE
reduce load on origin servers by increasing the cache for bad responses

### DIFF
--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -58,7 +58,7 @@ function handleSvg() {
 			.then(imageResponse => {
 				if (imageResponse.status >= 400) {
 					const error = httpError(imageResponse.status);
-					error.cacheMaxAge = '30s';
+					error.cacheMaxAge = '5m';
 					error.skipSentry = true;
 					throw error;
 				} else if (imageResponse.headers['content-type'].indexOf('image/svg+xml') === -1) {

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -75,11 +75,13 @@ function processImage(config) {
 			}).then(async imageResponse => {
 				if (imageResponse.status >= 400) {
 					const error = httpError(imageResponse.status);
+					error.cacheMaxAge = '5m';
 					error.skipSentry = true;
 					throw error;
 				}
 				if (imageResponse.headers['content-type'].includes('text/html')) {
 					const error = httpError(400);
+					error.cacheMaxAge = '5m';
 					error.skipSentry = true;
 					throw error;
 				}

--- a/test/unit/lib/middleware/handle-svg.test.js
+++ b/test/unit/lib/middleware/handle-svg.test.js
@@ -229,7 +229,7 @@ describe('lib/middleware/handle-svg', function () {
 				it('calls next with an error and sets correct status code', () => {
 					assert.isTrue(next.calledOnce);
 					assert.equal(next.firstCall.firstArg.status, 404);
-					assert.equal(next.firstCall.firstArg.cacheMaxAge, '30s');
+					assert.equal(next.firstCall.firstArg.cacheMaxAge, '5m');
 				});
 			});
 
@@ -257,7 +257,7 @@ describe('lib/middleware/handle-svg', function () {
 				it('calls next with an error and sets correct status code', () => {
 					assert.isTrue(next.calledOnce);
 					assert.equal(next.firstCall.firstArg.status, 500);
-					assert.equal(next.firstCall.firstArg.cacheMaxAge, '30s');
+					assert.equal(next.firstCall.firstArg.cacheMaxAge, '5m');
 				});
 			});
 


### PR DESCRIPTION
When the original image returns a 4xx or higher, let's cache the response for 5 minutes to avoid being overloaded by loads of requests for that image.