### PR TITLE
Improve handling of images which are too large to upload to Cloudinary

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -96,13 +96,22 @@ function processImage(config) {
 				cache[originalImageURI] = imageName;
 				
 				// 3. upload the image to cloudinary - this will not error if the image has already been uploaded to cloudinary
-				await upload(originalImageURI, {
-					public_id: imageName,
-					unique_filename: false,
-					use_filename: false,
-					resource_type: 'image',
-					overwrite: false
-				});
+				try {
+					await upload(originalImageURI, {
+						public_id: imageName,
+						unique_filename: false,
+						use_filename: false,
+						resource_type: 'image',
+						overwrite: false
+					});
+				} catch (error) {
+					console.error('uploading the image failed:', error);
+					if (error.message.includes('File size too large.')) {
+						error.skipSentry = true;
+						error.cacheMaxAge = '5m';
+					}
+					throw error;
+				}
 
 			}, error => {
 				// If the request errors, report this using
@@ -152,7 +161,7 @@ function processImage(config) {
 			request.appliedTransform = appliedTransform;
 			next();
 		}).catch(error => {
-			console.error(error);
+			console.error({error});
 			next(error);
 			return;
 		});

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -161,7 +161,7 @@ function processImage(config) {
 			request.appliedTransform = appliedTransform;
 			next();
 		}).catch(error => {
-			console.error({error});
+			console.error(error);
 			next(error);
 			return;
 		});


### PR DESCRIPTION
if the image is too large to upload, let's cache the error response for 5 minutes to help avoid load on the Heroku applications and let's not capture the error in Sentry because it is a client error.