### PR TITLE
do not record error in sentry if the original file is an invalid image file because this is a client error and not an app error

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -108,6 +108,8 @@ function processImage(config) {
 					});
 				} catch (error) {
 					console.error('uploading the image failed:', error);
+					// Cloudinary unfortunately do not use an Error instance
+					// they throw an object with a message property instead
 					if (error.message.includes('File size too large.')) {
 						error.skipSentry = true;
 						error.cacheMaxAge = '5m';

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -111,6 +111,9 @@ function processImage(config) {
 					if (error.message.includes('File size too large.')) {
 						error.skipSentry = true;
 						error.cacheMaxAge = '5m';
+					} else if (error.message.includes('Invalid image file')) {
+						error.skipSentry = true;
+						error.cacheMaxAge = '5m';
 					}
 					throw error;
 				}


### PR DESCRIPTION
Recently a few files have been uploaded into the universal-publishing (UPP) image buckets which are invalid images and Cloudinary correctly throws an error when we try to upload and optimise them.

Let's cache these errors in Fastly to avoid lots of requests hitting the origin and mark the errors to not be entered into sentry because they are not something we can resolve.

We still have splunk logs for the errors so we can see if we get an increase in these types of errors though 👍 