### PR TITLE
Cache more errors in fastly and do not record them in sentry

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -123,6 +123,11 @@ function processImage(config) {
 					error.skipSentry = true;
 					error.cacheMaxAge = '5m';
 				}
+				if (error.code === 'EAI_AGAIN') {
+					error = new Error(`DNS lookup timed out for "${encodeURI(originalImageURI)}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '30s';
+				}
 				if (error.code === 'ECONNRESET') {
 					const resetError = error;
 					error = new Error(`Connection reset when requesting "${encodeURI(originalImageURI)}" (${resetError.syscall})`);

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -155,6 +155,11 @@ function processImage(config) {
 					error.skipSentry = true;
 					error.cacheMaxAge = '5m';
 				}
+				if (error.code === 'ENETUNREACH') {
+					error = new Error(error.message);
+					error.skipSentry = true;
+					error.cacheMaxAge = '30s';
+				}
 				throw error;
 			});
 		}

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -160,6 +160,11 @@ function processImage(config) {
 					error.skipSentry = true;
 					error.cacheMaxAge = '30s';
 				}
+				if (error.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+					error = new Error(`Unable to verify the first certificate for "${encodeURI(originalImageURI)}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '5m';
+				}
 				throw error;
 			});
 		}

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -165,6 +165,11 @@ function processImage(config) {
 					error.skipSentry = true;
 					error.cacheMaxAge = '5m';
 				}
+				if (error.code === 'ERR_UNESCAPED_CHARACTERS') {
+					error = new Error(`Image url contains unescaped characters for "${encodeURI(originalImageURI)}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '1y';
+				}
 				throw error;
 			});
 		}

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const httpMock = require('node-mocks-http');
 const nock = require('nock');
 
-describe('lib/middleware/process-image-request', () => {
+describe.only('lib/middleware/process-image-request', () => {
 	let cloudinaryTransform;
 	let cloudinary;
 	let ImageTransform;
@@ -233,9 +233,11 @@ describe('lib/middleware/process-image-request', () => {
 					});
 					scope.get('/twitter.svg-UNABLE_TO_VERIFY_LEAF_SIGNATURE').replyWithError({
 						message: 'Unable to verify the certificate',
+						code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
 					});
 					scope.get('/twitter.svg-ERR_UNESCAPED_CHARACTERS').replyWithError({
 						message: 'URL contains unescaped characters',
+						code: 'ERR_UNESCAPED_CHARACTERS',
 					});
 					scope.get('/twitter.svg-ENETUNREACH').replyWithError({
 						message: 'uh oh the network is unreachable',
@@ -243,7 +245,8 @@ describe('lib/middleware/process-image-request', () => {
 						code: 'ENETUNREACH',
 					});
 					scope.get('/twitter.svg-EAI_AGAIN').replyWithError({
-						message: 'uh oh the DNS lookup timed out'
+						message: 'uh oh the DNS lookup timed out',
+						code: 'EAI_AGAIN',
 					});
 					scope.get('/twitter.svg-ENOTFOUND').replyWithError({
 						message: 'uh oh the domain has no dns record',

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -336,8 +336,8 @@ describe.only('lib/middleware/process-image-request', () => {
 						assert.isTrue(next.firstCall.firstArg.skipSentry);
 					});
 
-					it('sets the error `cacheMaxAge` property to "30s"', () => {
-						assert.strictEqual(next.firstCall.firstArg.cacheMaxAge, '30s');
+					it('sets the error `cacheMaxAge` property to "5m"', () => {
+						assert.strictEqual(next.firstCall.firstArg.cacheMaxAge, '5m');
 					});
 				});
 


### PR DESCRIPTION
Handling errors for:
- dns timeouts - cached for 30 seconds because this is recoverable based on traffic load to origin.

- unreachable networks - cached for 30 seconds because the network should come back online.

- invalid certificates which causes the request to fail - cached for a shortish duration because the certificate could get updated and the request would then work again.

- invalid characters in a url -- these can be cached for a very long time because it will always return an error.