### PR TITLE
Redirect old blogs domain images to the new blogs domain

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    timeout-minutes: 120
     steps:
       - name: 'Wait for status checks'
         id: waitforstatuschecks

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ include node_modules/@financial-times/origami-service-makefile/index.mk
 # [edit below this line]
 # ------------------------
 
+# Set up the npm binary path
+NPM_BIN = ./node_modules/.bin
+export PATH := $(PATH):$(NPM_BIN)
 
 # Configuration
 # -------------
@@ -24,3 +27,16 @@ HEROKU_APP_US = origami-image-service-us
 GRAFANA_DASHBOARD = origami-image-service
 
 export GITHUB_RELEASE_REPO := Financial-Times/origami-image-service
+
+# Run the unit tests using mocha
+test-unit:
+	mocha "test/unit/**/*.test.js" --recursive --reporter mocha-github-actions-reporter ${CI:+--forbid-only}
+
+# Run the unit tests using mocha and generating
+# a coverage report if nyc or istanbul are installed
+test-unit-coverage:
+	nyc --reporter=text --reporter=html mocha "test/unit/**/*.test.js" -- --recursive --reporter mocha-github-actions-reporter ${CI:+--forbid-only}
+
+# Run the integration tests using mocha
+test-integration:
+	mocha "test/integration/**/*.test.js" --recursive --reporter mocha-github-actions-reporter ${CI:+--forbid-only} --timeout $(INTEGRATION_TIMEOUT) --slow $(INTEGRATION_SLOW) $(INTEGRATION_FLAGS)

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -27,6 +27,9 @@ module.exports = app => {
 		next();
 	}
 
+	// Redirect the old now deleted domain to the correct domain for Live Blogs Images.
+	// Conversation in Slack about this -- https://financialtimes.slack.com/archives/CPEETMY49/p1600188171025000
+	// System in Biz-Ops -- https://biz-ops.in.ft.com/System/blogs
 	function updateOldBlogsLinks(request, response, next) {
 		if (request.params.schemeUrl.startsWith('https://blogs.r.ftdata.co.uk/')) {
 			request.params.schemeUrl = request.params.schemeUrl.replace('https://blogs.r.ftdata.co.uk', 'https://blogs.ft.com');

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -27,6 +27,17 @@ module.exports = app => {
 		next();
 	}
 
+	function updateOldBlogsLinks(request, response, next) {
+		if (request.params.schemeUrl.startsWith('https://blogs.r.ftdata.co.uk')) {
+			request.params.schemeUrl = request.params.schemeUrl.replace('https://blogs.r.ftdata.co.uk', 'https://blogs.ft.com');
+			request.params.imageUrl = request.params.schemeUrl;
+		} else if (request.params.schemeUrl.startsWith('http://blogs.r.ftdata.co.uk')) {
+			request.params.schemeUrl = request.params.schemeUrl.replace('http://blogs.r.ftdata.co.uk', 'https://blogs.ft.com');
+			request.params.imageUrl = request.params.schemeUrl;
+		}
+		next();
+	}
+
 	function mapScheme(request, response, next) {
 		request.params.scheme = request.params[2] || 'http'; // We make protocol-relative links use http.
 		next();
@@ -155,6 +166,7 @@ module.exports = app => {
 	app.get(
 		/^\/v2\/images\/(raw|debug|metadata|purge)\/((https?(:|%3A))?(\/|%2F)*.*)$/i,
 		mapParams,
+		updateOldBlogsLinks,
 		mapScheme,
 		requireValidSourceParam,
 		processImageRequest(app.ft.options),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
+      "integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -4462,6 +4468,15 @@
             }
           }
         }
+      }
+    },
+    "mocha-github-actions-reporter": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/mocha-github-actions-reporter/-/mocha-github-actions-reporter-0.2.1.tgz",
+      "integrity": "sha512-/r7mLNSr9a994PTB5D/l9ev4QtOyoiZNxGZanh66tn2OmePlE8EG6acD5Y8Aja3jqdHOAQ3rQBdAzotA3zuLDQ==",
+      "dev": true,
+      "requires": {
+        "@actions/core": "1.2.3"
       }
     },
     "mockery": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "denodeify": "1.2.1",
     "eslint": "7.9.0",
     "mocha": "8.1.3",
+    "mocha-github-actions-reporter": "^0.2.1",
     "mockery": "2.1.0",
     "nock": "^13.0.4",
     "node-mocks-http": "^1.9.0",

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -41,13 +41,13 @@ describe('GET /v2/images/raw…', function() {
 	describe('/http://blogs.r.ftdata.co.uk', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.oldLiveBlogsDomainHttp}?source=test`);
 		itRespondsWithStatus(200);
-		itRespondsWithContentType('image/png');
+		itRespondsWithContentType('image/jpeg');
 	});
 
 	describe('/https://blogs.r.ftdata.co.uk', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.oldLiveBlogsDomainHttps}?source=test`);
 		itRespondsWithStatus(200);
-		itRespondsWithContentType('image/png');
+		itRespondsWithContentType('image/jpeg');
 	});
 
 	describe('/http://… (HTTP scheme unencoded)', function() {

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -31,10 +31,24 @@ const testImageUris = {
 	protocolRelative: '//origami-images.ft.com/ftsocial/v1/twitter.svg',
 	protocolRelativeftcms: '//im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	specialisttitle: 'specialisttitle:ned-logo',
-	nonUtf8Characters: 'https://origami-image-service-integration-tests.s3-eu-west-1.amazonaws.com/Beaute%CC%81.jpg'
+	nonUtf8Characters: 'https://origami-image-service-integration-tests.s3-eu-west-1.amazonaws.com/Beaute%CC%81.jpg',
+	oldLiveBlogsDomainHttp: 'http://blogs.ft.com/tech-blog/files/2012/03/Screen-Shot-2012-03-01-at-11.25.02-PM-391x270.png',
+	oldLiveBlogsDomainHttps: 'https://blogs.ft.com/tech-blog/files/2012/03/Screen-Shot-2012-03-01-at-11.25.02-PM-391x270.png',
 };
 
 describe('GET /v2/images/raw…', function() {
+
+	describe('/http://blogs.r.ftdata.co.uk', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.oldLiveBlogsDomainHttp}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/png');
+	});
+
+	describe('/https://blogs.r.ftdata.co.uk', function() {
+		setupRequest('GET', `/v2/images/raw/${testImageUris.oldLiveBlogsDomainHttps}?source=test`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/png');
+	});
 
 	describe('/http://… (HTTP scheme unencoded)', function() {
 		setupRequest('GET', `/v2/images/raw/${testImageUris.httpftcms}?source=test`);

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const httpMock = require('node-mocks-http');
 const nock = require('nock');
 
-describe.only('lib/middleware/process-image-request', () => {
+describe('lib/middleware/process-image-request', () => {
 	let cloudinaryTransform;
 	let cloudinary;
 	let ImageTransform;


### PR DESCRIPTION
The old blogs domain is still being used for images and the domain no longer exists. We should replace the old domain with the new domain to make these images still work.

Currently we get roughly 4 thousand image requests for the old domain each day.