### PR TITLE
 Add error handling for misformatted hostnames and no name-servers for a domain

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -48,7 +48,7 @@ function createProxy(errorHandler) {
 	proxy.on('proxyReq', proxyRequestHandler);
 	proxy.on('proxyRes', proxyResponseHandler);
 	proxy.on('error', (error, request, response) => {
-		if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
+		if (error.code === 'ENOTFOUND') {
 			error = new Error(`Proxy DNS lookup failed for "${request.url}"`);
 			error.skipSentry = true;
 		}

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -117,7 +117,7 @@ function getCmsUrl(config) {
 			})
 			.catch(error => {
 				log.info(`ftcms-check cmsId=${cmsId} cmsVersionUsed=error source=${request.query.source}`);
-				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
+				if (error.code === 'ENOTFOUND') {
 					error = new Error(`DNS lookup failed for "${lastRequestedUri}"`);
 					error.skipSentry = true;
 				}

--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -102,10 +102,22 @@ function handleSvg() {
 			// If the request errors, report this using
 			// the standard error middleware
 			.catch(error => {
+				// If the request errors, report this using
+				// the standard error middleware
 				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
 					error = new Error(`DNS lookup failed for "${uri}"`);
 					error.skipSentry = true;
 					error.cacheMaxAge = '5m';
+				}
+				if (error.code === 'ESERVFAIL') {
+					error = new Error(`"${uri}" has no DNS records`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '5m';
+				}
+				if (error.code === 'EAI_AGAIN') {
+					error = new Error(`DNS lookup timed out for "${uri}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '30s';
 				}
 				if (error.code === 'ECONNRESET') {
 					const resetError = error;
@@ -123,6 +135,36 @@ function handleSvg() {
 					error = new Error(`Request timed out when requesting "${uri}"`);
 					error.skipSentry = true;
 					error.cacheMaxAge = '30s';
+				}
+				if (error.code === 'CERT_HAS_EXPIRED') {
+					error = new Error(`Certificate has expired for "${uri}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '5m';
+				}
+				if (error.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
+					error = new Error(error.message);
+					error.skipSentry = true;
+					error.cacheMaxAge = '5m';
+				}
+				if (error.code === 'ENETUNREACH') {
+					error = new Error(error.message);
+					error.skipSentry = true;
+					error.cacheMaxAge = '30s';
+				}
+				if (error.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+					error = new Error(`Unable to verify the first certificate for "${uri}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '5m';
+				}
+				if (error.code === 'ERR_UNESCAPED_CHARACTERS') {
+					error = new Error(`Image url contains unescaped characters for "${uri}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '1y';
+				}
+				if (error.code === 'EBADNAME') {
+					error = new Error(`Misformatted host name "${uri}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '1y';
 				}
 				hasErrored = true;
 				return next(error);

--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -104,7 +104,7 @@ function handleSvg() {
 			.catch(error => {
 				// If the request errors, report this using
 				// the standard error middleware
-				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
+				if (error.code === 'ENOTFOUND') {
 					error = new Error(`DNS lookup failed for "${uri}"`);
 					error.skipSentry = true;
 					error.cacheMaxAge = '5m';

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -128,6 +128,11 @@ function processImage(config) {
 					error.skipSentry = true;
 					error.cacheMaxAge = '5m';
 				}
+				if (error.code === 'ESERVFAIL') {
+					error = new Error(`"${encodeURI(originalImageURI)}" has no DNS records`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '5m';
+				}
 				if (error.code === 'EAI_AGAIN') {
 					error = new Error(`DNS lookup timed out for "${encodeURI(originalImageURI)}"`);
 					error.skipSentry = true;
@@ -172,6 +177,11 @@ function processImage(config) {
 				}
 				if (error.code === 'ERR_UNESCAPED_CHARACTERS') {
 					error = new Error(`Image url contains unescaped characters for "${encodeURI(originalImageURI)}"`);
+					error.skipSentry = true;
+					error.cacheMaxAge = '1y';
+				}
+				if (error.code === 'EBADNAME') {
+					error = new Error(`Misformatted host name "${encodeURI(originalImageURI)}"`);
 					error.skipSentry = true;
 					error.cacheMaxAge = '1y';
 				}

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -123,7 +123,7 @@ function processImage(config) {
 			}, error => {
 				// If the request errors, report this using
 				// the standard error middleware
-				if (error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo') {
+				if (error.code === 'ENOTFOUND') {
 					error = new Error(`DNS lookup failed for "${encodeURI(originalImageURI)}"`);
 					error.skipSentry = true;
 					error.cacheMaxAge = '5m';

--- a/test/unit/lib/image-service.test.js
+++ b/test/unit/lib/image-service.test.js
@@ -533,7 +533,6 @@ describe('lib/image-service', () => {
 				beforeEach(() => {
 					serviceErrorHandler.resetHistory();
 					proxyError.code = 'ENOTFOUND';
-					proxyError.syscall = 'getaddrinfo';
 					handler(proxyError, origamiService.mockRequest, origamiService.mockResponse);
 				});
 

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -237,7 +237,6 @@ describe('lib/middleware/get-cms-url', () => {
 					// V2 errors
 					dnsError = new Error('mock error');
 					dnsError.code = 'ENOTFOUND';
-					dnsError.syscall = 'getaddrinfo';
 					scope = nock('http://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id7').replyWithError(dnsError);
 

--- a/test/unit/lib/middleware/handle-svg.test.js
+++ b/test/unit/lib/middleware/handle-svg.test.js
@@ -32,7 +32,6 @@ describe('lib/middleware/handle-svg', function () {
 		});
 		scope.get('/twitter.svg-ENOTFOUND').replyWithError({
 			message: 'uh oh the domain has no dns record',
-			syscall: 'getaddrinfo',
 			code: 'ENOTFOUND',
 		});
 		scope.get('/twitter.svg-ETIMEDOUT').replyWithError({
@@ -147,7 +146,7 @@ describe('lib/middleware/handle-svg', function () {
 					proclaim.equal(origamiService.mockResponse.send.firstCall.firstArg, twitterSVGWithOnClickHandler);
 				});
 			});
-			
+
 			describe('when the image URL is from origami-images.ft.com', () => {
 				let next;
 				beforeEach((done) => {
@@ -316,7 +315,7 @@ describe('lib/middleware/handle-svg', function () {
 					proclaim.include(origamiService.mockResponse.send.firstCall.firstArg, '<style>*{fill:#FFC0CB!important;}</style>');
 				});
 			});
-			
+
 			describe('when `request.query.color` is not set', () => {
 				let next;
 				beforeEach((done) => {

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -249,8 +249,8 @@ describe('lib/middleware/process-image-request', () => {
 						code: 'EAI_AGAIN',
 					});
 					scope.get('/twitter.svg-ESERVFAIL').replyWithError({
-						message: 'The domain has no DNS records',
-						code: 'EAI_AGAIN',
+						message: 'The domain has no name server',
+						code: 'ESERVFAIL',
 					});
 					scope.get('/twitter.svg-EBADNAME').replyWithError({
 						message: 'The hostname is incorrect formatting',

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -258,7 +258,6 @@ describe('lib/middleware/process-image-request', () => {
 					});
 					scope.get('/twitter.svg-ENOTFOUND').replyWithError({
 						message: 'uh oh the domain has no dns record',
-						syscall: 'getaddrinfo',
 						code: 'ENOTFOUND',
 					});
 					scope.get('/twitter.svg-ETIMEDOUT').replyWithError({


### PR DESCRIPTION
- Misformatted hostnames can be cached for a long time because it is a client issue in the hostname and the hostname is part of the cache-key we use in Fastly, the only waay the client can fix the issue is to change their hostname, which would mean a new cache-key is used.

- Domains which have no name-server configured can be fixed by the client without changing anything which modifies our cache-key, so we need to use a short cache time.

- I've removed the check for ENOTFOUND errors to have been thrown by a system call because we no longer use the system dns implementation. Our new implementation does not add a `syscall : 'getaddrinfo'` property to the errors.