### PR TITLE
only check content-type if it exists and is a string.

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -81,7 +81,7 @@ function processImage(config) {
 					error.skipSentry = true;
 					throw error;
 				}
-				if (imageResponse.headers['content-type'].includes('text/html')) {
+				if (typeof imageResponse.headers['content-type'] === 'string' && imageResponse.headers['content-type'].includes('text/html')) {
 					const error = httpError(400);
 					error.cacheMaxAge = '5m';
 					error.skipSentry = true;

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -261,7 +261,8 @@ describe('lib/middleware/process-image-request', () => {
 				});
 
 				it('does not error', () => {
-					assert.isFalse(next.calledOnce);
+					assert.isTrue(next.calledOnce);
+					assert.isUndefined(next.firstCall.firstArg); 
 				});
 			});
 

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -218,7 +218,7 @@ describe('lib/middleware/process-image-request', () => {
 
 			});
 
-			describe.only('when the request to the original image returns hmtl', () => {
+			describe('when the request to the original image returns hmtl', () => {
 				let scope;
 				beforeEach((done)=>{
 					scope = nock('https://ft.com').persist();
@@ -247,7 +247,7 @@ describe('lib/middleware/process-image-request', () => {
 				});
 			});
 
-			describe.only('when the request to the original image returns no content-type', () => {
+			describe('when the request to the original image returns no content-type', () => {
 				let scope;
 				beforeEach((done)=>{
 					scope = nock('https://ft.com').persist();


### PR DESCRIPTION
Fixes https://sentry.io/organizations/financial-times/issues/1907330565/?project=97641