### PR TITLE
Extract the axios error handling into it's own module for reuse

### DIFF
--- a/lib/create-error-from-axios-error.js
+++ b/lib/create-error-from-axios-error.js
@@ -1,0 +1,76 @@
+'use strict';
+
+module.exports = function createErrorFromAxiosError(error, address) {
+	let newError;
+	switch (error.code) {
+		case 'ENETUNREACH':
+			newError = new Error(error.message);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '30s';
+			break;
+		case 'EAI_AGAIN':
+			newError = new Error(`DNS lookup timed out for "${address}"`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '30s';
+			break;
+		case 'ECONNRESET':
+			newError = new Error(`Connection reset when requesting "${address}"`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '30s';
+			break;
+		case 'ETIMEDOUT':
+			newError = new Error(`Request timed out when requesting "${address}"`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '30s';
+			break;
+		case 'ECONNABORTED':
+			newError = new Error(`Request timed out when requesting "${address}"`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '30s';
+			break;
+		case 'ENOTFOUND':
+			newError = new Error(`DNS lookup failed for "${address}"`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '5m';
+			break;
+		case 'ESERVFAIL':
+			newError = new Error(`"${address}" has no DNS records`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '5m';
+			break;
+		case 'CERT_HAS_EXPIRED':
+			newError = new Error(`Certificate has expired for "${address}"`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '5m';
+			break;
+		case 'ERR_TLS_CERT_ALTNAME_INVALID':
+			newError = new Error(error.message);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '5m';
+			break;
+		case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE':
+			newError = new Error(
+				`Unable to verify the first certificate for "${address}"`
+			);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '5m';
+			break;
+		case 'ERR_UNESCAPED_CHARACTERS':
+			newError = new Error(
+				`Image url contains unescaped characters for "${address}"`
+			);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '1y';
+			break;
+		case 'EBADNAME':
+			newError = new Error(`Misformatted host name "${address}"`);
+			newError.skipSentry = true;
+			newError.cacheMaxAge = '1y';
+			break;
+		default:
+			newError = error;
+			break;
+	}
+
+	return newError;
+};

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -3,6 +3,7 @@
 const httpError = require('http-errors');
 const axios = require('axios').default;
 const dnsLookup = require('lookup-dns-cache').lookup;
+const createErrorFromAxiosError = require('../create-error-from-axios-error');
 
 module.exports = getCmsUrl;
 
@@ -117,35 +118,8 @@ function getCmsUrl(config) {
 			})
 			.catch(error => {
 				log.info(`ftcms-check cmsId=${cmsId} cmsVersionUsed=error source=${request.query.source}`);
-				if (error.code === 'ENOTFOUND') {
-					error = new Error(`DNS lookup failed for "${lastRequestedUri}"`);
-					error.skipSentry = true;
-				}
-				if (error.code === 'ECONNRESET') {
-					const resetError = error;
-					error = new Error(`Connection reset when requesting "${lastRequestedUri}" (${resetError.syscall})`);
-					error.skipSentry = true;
-				}
-				// ETIMEDOUT is when no bytes are received at all
-				// in the given timeout
-				if (error.code === 'ETIMEDOUT') {
-					const timeoutError = error;
-					error = new Error(`Request timed out when requesting "${lastRequestedUri}" (${timeoutError.syscall})`);
-					error.skipSentry = true;
-				}
-				if (error.code === 'ECONNABORTED') {
-					error = new Error(`Request timed out when requesting "${lastRequestedUri}"`);
-					error.skipSentry = true;
-				}
-				// ESOCKETTIMEOUT is when the request receives bytes
-				// initially but then has a pause between bytes equal
-				// to or greater than the given timeout
-				if (error.code === 'ESOCKETTIMEOUT') {
-					const timeoutError = error;
-					error = new Error(`Request socket timed out when requesting "${lastRequestedUri}" (${timeoutError.syscall})`);
-					error.skipSentry = true;
-				}
-				next(error);
+				const newError = createErrorFromAxiosError(error, lastRequestedUri);
+				next(newError);
 			});
 		}
 	};

--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -6,6 +6,7 @@ const axios = require('axios').default;
 const dnsLookup = require('lookup-dns-cache').lookup;
 const {JSDOM} = require('jsdom');
 const SvgTintStream = require('svg-tint-stream');
+const createErrorFromAxiosError = require('../create-error-from-axios-error');
 
 let window;
 let DOMPurify;
@@ -104,70 +105,9 @@ function handleSvg() {
 			.catch(error => {
 				// If the request errors, report this using
 				// the standard error middleware
-				if (error.code === 'ENOTFOUND') {
-					error = new Error(`DNS lookup failed for "${uri}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ESERVFAIL') {
-					error = new Error(`"${uri}" has no DNS records`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'EAI_AGAIN') {
-					error = new Error(`DNS lookup timed out for "${uri}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'ECONNRESET') {
-					const resetError = error;
-					error = new Error(`Connection reset when requesting "${uri}" (${resetError.syscall})`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'ETIMEDOUT') {
-					const timeoutError = error;
-					error = new Error(`Request timed out when requesting "${uri}" (${timeoutError.syscall})`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'ECONNABORTED') {
-					error = new Error(`Request timed out when requesting "${uri}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'CERT_HAS_EXPIRED') {
-					error = new Error(`Certificate has expired for "${uri}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
-					error = new Error(error.message);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ENETUNREACH') {
-					error = new Error(error.message);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
-					error = new Error(`Unable to verify the first certificate for "${uri}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ERR_UNESCAPED_CHARACTERS') {
-					error = new Error(`Image url contains unescaped characters for "${uri}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '1y';
-				}
-				if (error.code === 'EBADNAME') {
-					error = new Error(`Misformatted host name "${uri}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '1y';
-				}
 				hasErrored = true;
-				return next(error);
+				const newError = createErrorFromAxiosError(error, uri);
+				return next(newError);
 			});
 	};
 }

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -9,6 +9,7 @@ const dnsLookup = require('lookup-dns-cache').lookup;
 const crypto = require('crypto');
 const cloudinary = require('cloudinary').v2;
 const promisify = require('util').promisify;
+const createErrorFromAxiosError = require('../create-error-from-axios-error');
 
 module.exports = processImage;
 
@@ -121,71 +122,8 @@ function processImage(config) {
 				}
 
 			}, error => {
-				// If the request errors, report this using
-				// the standard error middleware
-				if (error.code === 'ENOTFOUND') {
-					error = new Error(`DNS lookup failed for "${encodeURI(originalImageURI)}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ESERVFAIL') {
-					error = new Error(`"${encodeURI(originalImageURI)}" has no DNS records`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'EAI_AGAIN') {
-					error = new Error(`DNS lookup timed out for "${encodeURI(originalImageURI)}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'ECONNRESET') {
-					const resetError = error;
-					error = new Error(`Connection reset when requesting "${encodeURI(originalImageURI)}" (${resetError.syscall})`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'ETIMEDOUT') {
-					const timeoutError = error;
-					error = new Error(`Request timed out when requesting "${encodeURI(originalImageURI)}" (${timeoutError.syscall})`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'ECONNABORTED') {
-					error = new Error(`Request timed out when requesting "${encodeURI(originalImageURI)}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'CERT_HAS_EXPIRED') {
-					error = new Error(`Certificate has expired for "${encodeURI(originalImageURI)}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
-					error = new Error(error.message);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ENETUNREACH') {
-					error = new Error(error.message);
-					error.skipSentry = true;
-					error.cacheMaxAge = '30s';
-				}
-				if (error.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
-					error = new Error(`Unable to verify the first certificate for "${encodeURI(originalImageURI)}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '5m';
-				}
-				if (error.code === 'ERR_UNESCAPED_CHARACTERS') {
-					error = new Error(`Image url contains unescaped characters for "${encodeURI(originalImageURI)}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '1y';
-				}
-				if (error.code === 'EBADNAME') {
-					error = new Error(`Misformatted host name "${encodeURI(originalImageURI)}"`);
-					error.skipSentry = true;
-					error.cacheMaxAge = '1y';
-				}
-				throw error;
+				const newError = createErrorFromAxiosError(error, encodeURI(originalImageURI));
+				throw newError;
 			});
 		}
 

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -265,7 +265,6 @@ describe('lib/middleware/get-cms-url', () => {
 					// V2 errors
 					resetError = new Error('mock error');
 					resetError.code = 'ECONNRESET';
-					resetError.syscall = 'mock-syscall';
 					scope = nock('http://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id8').replyWithError(resetError);
 
@@ -277,7 +276,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Connection reset when requesting "http://prod-upp-image-read.ft.com/mock-id8" (mock-syscall)');
+					assert.strictEqual(responseError.message, 'Connection reset when requesting "http://prod-upp-image-read.ft.com/mock-id8"');
 				});
 
 			});
@@ -294,7 +293,6 @@ describe('lib/middleware/get-cms-url', () => {
 					// V2 errors
 					timeoutError = new Error('mock error');
 					timeoutError.code = 'ETIMEDOUT';
-					timeoutError.syscall = 'mock-syscall';
 					scope = nock('http://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id9').replyWithError(timeoutError);
 
@@ -306,42 +304,9 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Request timed out when requesting "http://prod-upp-image-read.ft.com/mock-id9" (mock-syscall)');
+					assert.strictEqual(responseError.message, 'Request timed out when requesting "http://prod-upp-image-read.ft.com/mock-id9"');
 				});
-
 			});
-
-			describe('when the request socket times out', () => {
-				let responseError;
-				let timeoutError;
-				let scope;
-
-				beforeEach(done => {
-					origamiService.mockRequest.url = 'mock-url';
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id10';
-
-					// V2 errors
-					timeoutError = new Error('mock error');
-					timeoutError.code = 'ESOCKETTIMEOUT';
-					timeoutError.syscall = 'mock-syscall';
-					scope = nock('http://prod-upp-image-read.ft.com').persist();
-					scope.head('/mock-id10').replyWithError(timeoutError);
-
-					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
-						responseError = error;
-						done();
-					});
-				});
-
-				it('calls `next` with a descriptive error', () => {
-					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Request socket timed out when requesting "http://prod-upp-image-read.ft.com/mock-id10" (mock-syscall)');
-				});
-
-			});
-
 		});
-
 	});
-
 });

--- a/test/unit/lib/middleware/handle-svg.test.js
+++ b/test/unit/lib/middleware/handle-svg.test.js
@@ -27,7 +27,6 @@ describe('lib/middleware/handle-svg', function () {
 
 		scope.get('/twitter.svg-ECONNRESET').replyWithError({
 			message: 'uh oh the connection reset',
-			syscall: 'syscall',
 			code: 'ECONNRESET',
 		});
 		scope.get('/twitter.svg-ENOTFOUND').replyWithError({
@@ -36,7 +35,6 @@ describe('lib/middleware/handle-svg', function () {
 		});
 		scope.get('/twitter.svg-ETIMEDOUT').replyWithError({
 			message: 'uh oh the connection timed out',
-			syscall: 'syscall',
 			code: 'ETIMEDOUT',
 		});
 	});
@@ -75,7 +73,7 @@ describe('lib/middleware/handle-svg', function () {
 				it('calls `next` with a descriptive error', () => {
 					assert.isTrue(next.calledOnce);
 					assert.isInstanceOf(next.firstCall.args[0], Error);
-					assert.strictEqual(next.firstCall.args[0].message, 'Connection reset when requesting "https://ft.com/twitter.svg-ECONNRESET" (syscall)');
+					assert.strictEqual(next.firstCall.args[0].message, 'Connection reset when requesting "https://ft.com/twitter.svg-ECONNRESET"');
 				});
 			});
 
@@ -112,7 +110,7 @@ describe('lib/middleware/handle-svg', function () {
 				it('calls `next` with a descriptive error', () => {
 					assert.isTrue(next.calledOnce);
 					assert.isInstanceOf(next.firstCall.args[0], Error);
-					assert.strictEqual(next.firstCall.args[0].message, 'Request timed out when requesting "https://ft.com/twitter.svg-ETIMEDOUT" (syscall)');
+					assert.strictEqual(next.firstCall.args[0].message, 'Request timed out when requesting "https://ft.com/twitter.svg-ETIMEDOUT"');
 				});
 
 			});

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -262,7 +262,7 @@ describe('lib/middleware/process-image-request', () => {
 
 				it('does not error', () => {
 					assert.isTrue(next.calledOnce);
-					assert.isUndefined(next.firstCall.firstArg); 
+					assert.isUndefined(next.firstCall.firstArg);
 				});
 			});
 
@@ -276,7 +276,6 @@ describe('lib/middleware/process-image-request', () => {
 					});
 					scope.get('/twitter.svg-ECONNRESET').replyWithError({
 						message: 'uh oh the connection reset',
-						syscall: 'syscall',
 						code: 'ECONNRESET',
 					});
 					scope.get('/twitter.svg-UNABLE_TO_VERIFY_LEAF_SIGNATURE').replyWithError({
@@ -289,7 +288,6 @@ describe('lib/middleware/process-image-request', () => {
 					});
 					scope.get('/twitter.svg-ENETUNREACH').replyWithError({
 						message: 'uh oh the network is unreachable',
-						syscall: 'syscall',
 						code: 'ENETUNREACH',
 					});
 					scope.get('/twitter.svg-EAI_AGAIN').replyWithError({
@@ -310,7 +308,6 @@ describe('lib/middleware/process-image-request', () => {
 					});
 					scope.get('/twitter.svg-ETIMEDOUT').replyWithError({
 						message: 'uh oh the connection timed out',
-						syscall: 'syscall',
 						code: 'ETIMEDOUT',
 					});
 					scope.get('/twitter.svg-CERT_HAS_EXPIRED').replyWithError({


### PR DESCRIPTION
These errors are thrown and handled in at least three different parts of the codebase:
- The part which handles tinting SVGs.
- The part which converts ftcms images to their http url
- The part which download the image and then uploads it to cloudinary.

They all handle these errors in the same way, instead of copying and pasting the error handing code between them, let's put it in a module to reuse it.