### PR TITLE
Add explanation for non transparent pngs converted to jpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Trouble-Shooting
 
 We've outlined some common issues that can occur in the running of the Image Service:
 
+### Requesting a PNG but being returned a JPG, why is that?
+
+When a png image is requested, and the requested image has no alpha channel (no transparency in the image), a jpg is instead returned because it will have a smaller filesize.
+
 ### I need to purge an image
 
 Please read the [purging documentation](https://www.ft.com/__origami/service/image/v2/docs/purge) on the website.

--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -160,6 +160,9 @@
 			<span class="o-forms-title__main">
 				Format
 			</span>
+			<span class="o-forms-title__prompt">
+				When a png image is requested, and the requested image has no alpha channel (no transparency in the image), a jpg is instead returned because it will have a smaller filesize.
+			</span>
 		</span>
 		<div class="o-forms-input o-forms-input--radio-round o-forms-input--inline">
 			<label>


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/origami-image-service/issues/653