### PR TITLE
Update troubleshooting section for SVGs to mention it applies to all SVG requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ You'll need to provide an API key for change request logging. You can get this f
 make deploy
 ```
 
-### SVGs don't tint locally
+### SVGs don't work when running locally
 
-SVG tinting is done in a way that makes it near-impossible to run locally. When an SVG image is requested and a `tint` query parameter is provided, then we rewrite the URL to go route back through the Image Service. It looks something like this:
+When an SVG image is requested we rewrite the URL to go route back through the Image Service, this is to sanatize the SVG of any cross-site-scripting attack vectors and to tint the SVG if tinting has been requested. It looks something like this:
 
   * User requests:<br/>
   `http://imageservice/v2/images/raw/http://mysite/example.svg?tint=red`

--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -37,9 +37,9 @@ function processImage(config) {
 			return next(error);
 		}
 
-		// If the image is an SVG with a tint parameter then
-		// we need to route it through the /images/svgtint
-		// endpoint. This involves modifying the URI.
+		// If the image is an SVG then we need to route it through 
+		// the /images/svgtint endpoint to santize the SVG and
+		// tint it if required. This involves modifying the URI.
 		if (transform.format === 'svg' || /\.svg/i.test(transform.uri)) {
 			const hasQueryString = url.parse(transform.uri).search;
 			const encodedUri = encodeURIComponent(transform.uri);


### PR DESCRIPTION
At some point in the history of this project we made all SVGs go through svg endpoint to start sanitizing SVGs in order to protect against a cross-site-scripting attack but we forgot to update the troubleshooting section to mention that all SVGs would not work when running locally without supplying a valid `HOSTNAME` environment variable.

This pull-request updates the troubleshooting section and a code comment to mention that it applies to all SVGs now.