### PR TITLE
use https on links which support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,13 @@ The Financial Times has published this software under the [MIT license][license]
 
 
 
-[grafana]: http://grafana.ft.com/dashboard/db/origami-image-service
+[grafana]: https://grafana.ft.com/dashboard/db/origami-image-service
 [heroku-pipeline]: https://dashboard.heroku.com/pipelines/9cd9033e-fa9d-42af-bfe9-b9d0aa6f4a50
 [heroku-production-eu]: https://dashboard.heroku.com/apps/origami-image-service-eu
 [heroku-production-us]: https://dashboard.heroku.com/apps/origami-image-service-us
 [heroku-qa]: https://dashboard.heroku.com/apps/origami-image-service-qa
 [heroku]: https://heroku.com/
-[license]: http://opensource.org/licenses/MIT
+[license]: https://opensource.org/licenses/MIT
 [node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/
 [pingdom-eu]: https://my.pingdom.com/newchecks/checks#check=2301115

--- a/about.json
+++ b/about.json
@@ -56,7 +56,7 @@
 			"description": "Heroku dashboard (QA > Production pipeline)"
 		},
 		{
-			"url": "http://grafana.ft.com/dashboard/db/origami-image-service",
+			"url": "https://grafana.ft.com/dashboard/db/origami-image-service",
 			"category": "monitoring",
 			"description": "Grafana dashboard"
 		},

--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -58,14 +58,14 @@ function healthChecks(options) {
 			// It will fail on a non-200 response
 			{
 				type: 'ping-url',
-				url: 'http://prod-upp-image-read.ft.com/__gtg',
+				url: 'https://prod-upp-image-read.ft.com/__gtg',
 				interval: 60000,
 				id: 'upp-images',
 				name: 'Images can be retrieved from the Universal Publishing Platform',
 				severity: 2,
 				businessImpact: 'Users may not be able to view images served by Universal Publishing Platform',
 				technicalSummary: 'Hits the given url and checks that it responds successfully',
-				panicGuide: 'Check that the UPP endpoint http://prod-upp-image-read.ft.com/__gtg is responding with a 200 status and that the AWS Region is up'
+				panicGuide: 'Check that the UPP endpoint https://prod-upp-image-read.ft.com/__gtg is responding with a 200 status and that the AWS Region is up'
 			},
 
 			// This check monitors the process memory usage

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -22,7 +22,7 @@ function getCmsUrl(config) {
 		const cmsId = uriParts.shift();
 		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
 		const v1Uri = `https://im.ft-static.com/content/images/${cmsId}.img${query}`;
-		const v2Uri = `http://prod-upp-image-read.ft.com/${cmsId}${query}`;
+		const v2Uri = `https://prod-upp-image-read.ft.com/${cmsId}${query}`;
 		const capi = `https://api.ft.com/enrichedcontent/${cmsId}${query}`;
 		request.params.schemeUrl = `ftcms:${cmsId}`;
 

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -21,7 +21,7 @@ function getCmsUrl(config) {
 		const uriParts = request.params.imageUrl.split(':').pop().split('?');
 		const cmsId = uriParts.shift();
 		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
-		const v1Uri = `http://im.ft-static.com/content/images/${cmsId}.img${query}`;
+		const v1Uri = `https://im.ft-static.com/content/images/${cmsId}.img${query}`;
 		const v2Uri = `http://prod-upp-image-read.ft.com/${cmsId}${query}`;
 		const capi = `https://api.ft.com/enrichedcontent/${cmsId}${query}`;
 		request.params.schemeUrl = `ftcms:${cmsId}`;

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -11,7 +11,7 @@ module.exports = app => {
 		// If there's no URL, trip into preview mode
 		let url = request.query.url;
 		if (!url) {
-			url = 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img';
+			url = 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img';
 			request.query.preview = true;
 		}
 
@@ -54,7 +54,7 @@ module.exports = app => {
 				isLossless: (request.query.quality === 'lossless')
 			}
 		};
-		
+
 		const defaultSource = 'image-url-builder';
 
 		// Make the preview source work
@@ -75,7 +75,7 @@ module.exports = app => {
 
 		// Build the demo URLs
 		const demo = {
-			url: buildDemoUrl('http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'),
+			url: buildDemoUrl('https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'),
 			cms: buildDemoUrl('ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1'),
 			flag: buildDemoUrl('ftflag-v1:eu'),
 			icon: buildDemoUrl('fticon-v1:book'),

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -27,7 +27,7 @@ function buildCloudinaryTransforms(transform) {
 		sign_url: true,
 
 		// Flags to improve image file sizes/compression
-		// http://cloudinary.com/documentation/image_transformation_reference#flags_parameter
+		// https://cloudinary.com/documentation/image_transformation_reference#flags_parameter
 		flags: [
 			'lossy', // convery png to jpeg if it has no alpha channel (no transparency)
 			'any_format', // allow switching to PNG8 encoding

--- a/test/integration/v2/images-debug.test.js
+++ b/test/integration/v2/images-debug.test.js
@@ -19,7 +19,7 @@ const testImageUris = {
 	ftpodcast: 'ftpodcast:arts',
 	ftsocial: 'ftsocial:whatsapp',
 	httpsspark: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
-	httpftcms: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+	httpftcms: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	httpsftcms: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	httpftcmsmalformed: 'http:/im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
 	httpsftcmsmalformed: 'https:im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
@@ -61,11 +61,11 @@ describe('GET /v2/images/debug…', function () {
 	const imagesWithSchemes = {
 		ftcms: {
 			requestedUrl: 'ftcms:6c5a2f8c-18ca-4afa-80ff-7d56e41172b1',
-			resolvedUrl: new RegExp('http://im.ft-static.com/content/images/6c5a2f8c-18ca-4afa-80ff-7d56e41172b1.img')
+			resolvedUrl: 'https://im.ft-static.com/content/images/6c5a2f8c-18ca-4afa-80ff-7d56e41172b1.img'
 		},
 		capiv1: {
 			requestedUrl: 'ftcms:be875529-7675-43d8-b461-b304410398c2',
-			resolvedUrl: new RegExp('http://im.ft-static.com/content/images/be875529-7675-43d8-b461-b304410398c2.img')
+			resolvedUrl: 'https://im.ft-static.com/content/images/be875529-7675-43d8-b461-b304410398c2.img'
 		},
 		capiv2: {
 			requestedUrl: 'ftcms:03b59122-a148-11e9-a282-2df48f366f7d',
@@ -73,43 +73,43 @@ describe('GET /v2/images/debug…', function () {
 		},
 		spark: {
 			requestedUrl: 'ftcms:c3fec7fb-aba9-42ee-a745-a62c872850d0',
-			resolvedUrl: new RegExp('https://d1e00ek4ebabms.cloudfront.net/production/c3fec7fb-aba9-42ee-a745-a62c872850d0.jpg')
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/c3fec7fb-aba9-42ee-a745-a62c872850d0.jpg'
 		},
 		sparkMasterImage: {
 			requestedUrl: 'ftcms:817dd37c-b808-4b32-9db2-d50bdd92372b',
-			resolvedUrl: new RegExp('https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg')
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg'
 		},
 		httpsspark: {
 			requestedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
-			resolvedUrl: new RegExp('https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg')
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg'
 		},
 		httpspark: {
 			requestedUrl: 'http://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
-			resolvedUrl: new RegExp('https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg')
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg'
 		},
 		httpssparkcustomdomain: {
 			requestedUrl: 'https://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
-			resolvedUrl: new RegExp('https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg')
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg'
 		},
 		httpsparkcustomdomain: {
 			requestedUrl: 'http://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg',
-			resolvedUrl: new RegExp('https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg')
+			resolvedUrl: 'https://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg'
 		},
 		httpftcms: {
-			requestedUrl: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
-			resolvedUrl: new RegExp('http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img')
+			requestedUrl: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
+			resolvedUrl: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
 		},
 		httpsftcms: {
 			requestedUrl: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
-			resolvedUrl: new RegExp('http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img')
+			resolvedUrl: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
 		},
 		httpftcmsmalformed: {
 			requestedUrl: 'http:/im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
-			resolvedUrl: new RegExp('http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img')
+			resolvedUrl: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
 		},
 		httpsftcmsmalformed: {
 			requestedUrl: 'https:im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img',
-			resolvedUrl: new RegExp('http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img')
+			resolvedUrl: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
 		},
 	};
 
@@ -125,7 +125,11 @@ describe('GET /v2/images/debug…', function () {
 			it('responds with the correct location of the original image', function (done) {
 				this.request.expect(response => {
 					const actual = response.body.transform.uri;
-					assert.match(actual, resolvedUrl, `Expected ${requestedUrl} to match to ${resolvedUrl} but it actually resolved to ${actual}`);
+					if (typeof resolvedUrl === 'string') {
+						assert.deepEqual(actual, resolvedUrl, `Expected ${requestedUrl} to match ${resolvedUrl} but it actually resolved to ${actual}`);
+					} else {
+						assert.match(actual, resolvedUrl, `Expected ${requestedUrl} to match to ${resolvedUrl} but it actually resolved to ${actual}`);
+					}
 				}).end(done);
 			});
 		});

--- a/test/integration/v2/images-metadata.test.js
+++ b/test/integration/v2/images-metadata.test.js
@@ -6,7 +6,7 @@ const itRespondsWithStatus = require('../helpers/it-responds-with-status');
 const setupRequest = require('../helpers/setup-request');
 
 const testImageUris = {
-	http: 'http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
+	http: 'https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'
 };
 
 describe('GET /v2/images/metadata…', function() {

--- a/test/unit/lib/middleware/convert-to-cms-scheme.test.js
+++ b/test/unit/lib/middleware/convert-to-cms-scheme.test.js
@@ -42,7 +42,7 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 			});
 
 			describe('when the `imageUrl` request param points to an image in prod-upp-image-read.ft.com', () => {
-				const originalImageUrl = 'http://prod-upp-image-read.ft.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
+				const originalImageUrl = 'https://prod-upp-image-read.ft.com/d4e0c8c7-adb0-4171-bc98-e01a7d07d7ef';
 				beforeEach(done => {
 					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
@@ -109,8 +109,8 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 
 			});
 
-         describe('when the `imageUrl` request param points to an image in the imagepublish K8S US S3 bucket', () => {
-			const originalImageUrl = 'http://com.ft.imagepublish.upp-prod-us.s3.amazonaws.com/26a7951a-c3e4-11e7-b30e-a7c1c7c13aab';
+		describe('when the `imageUrl` request param points to an image in the imagepublish K8S US S3 bucket', () => {
+			const originalImageUrl = 'https://com.ft.imagepublish.upp-prod-us.s3.amazonaws.com/26a7951a-c3e4-11e7-b30e-a7c1c7c13aab';
 				beforeEach(done => {
 					origamiService.mockRequest.params.imageUrl = originalImageUrl;
 					middleware(origamiService.mockRequest, origamiService.mockResponse, done);
@@ -142,7 +142,7 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 				});
 
 			});
-			
+
 			describe('when the `imageUrl` request param points to an image on d1e00ek4ebabms.cloudfront.net', () => {
 				const originalImageUrl = 'http://d1e00ek4ebabms.cloudfront.net/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
 				beforeEach(done => {
@@ -159,7 +159,7 @@ describe('lib/middleware/convert-to-cms-scheme', () => {
 				});
 
 			});
-			
+
 			describe('when the `imageUrl` request param points to an image on cct-images.ft.com', () => {
 				const originalImageUrl = 'http://cct-images.ft.com/production/817dd37c-b808-4b32-9db2-d50bdd92372b.jpg';
 				beforeEach(done => {

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -64,7 +64,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the v2 API cannot find the image', () => {
-				const v1Uri = 'http://im.ft-static.com/content/images/mock-id2.img';
+				const v1Uri = 'https://im.ft-static.com/content/images/mock-id2.img';
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
 
@@ -72,7 +72,7 @@ describe('lib/middleware/get-cms-url', () => {
 					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id2';
 					log.info.resetHistory();
 
-					nockScopeForV1Images = nock('http://im.ft-static.com').persist();
+					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
 					nockScopeForV1Images.head('/content/images/mock-id2.img').reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
@@ -109,7 +109,7 @@ describe('lib/middleware/get-cms-url', () => {
 					nockScopeForFallback.head('/image.jpg').reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
-					nockScopeForV1Images = nock('http://im.ft-static.com').persist();
+					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
 					nockScopeForV1Images.head('/content/images/mock-id3.img').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
@@ -140,7 +140,7 @@ describe('lib/middleware/get-cms-url', () => {
 					nockScopeForFallback.head('/image.jpg').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
-					nockScopeForV1Images = nock('http://im.ft-static.com').persist();
+					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
 					nockScopeForV1Images.head('/content/images/mock-id4.img').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -39,13 +39,13 @@ describe('lib/middleware/get-cms-url', () => {
 
 		describe('middleware(request, response, next)', () => {
 			let scope;
-			const v2Uri = 'http://prod-upp-image-read.ft.com/mock-id1';
+			const v2Uri = 'https://prod-upp-image-read.ft.com/mock-id1';
 
 			beforeEach(done => {
 				origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id1';
 				origamiService.mockRequest.query.source = 'mock-source';
 				origamiService.mockRequest.params.originalImageUrl = 'http://test.example/image.jpg';
-				scope = nock('http://prod-upp-image-read.ft.com').persist();
+				scope = nock('https://prod-upp-image-read.ft.com').persist();
 				scope.head('/mock-id1').reply(200, 'I am an svg file', {
 					'Content-Type': 'image/svg+xml; charset=utf-8',
 				});
@@ -76,7 +76,7 @@ describe('lib/middleware/get-cms-url', () => {
 					nockScopeForV1Images.head('/content/images/mock-id2.img').reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
-					nockScopeForV2Images = nock('http://prod-upp-image-read.ft.com').persist();
+					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
 					nockScopeForV2Images.head('/mock-id2').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
@@ -113,7 +113,7 @@ describe('lib/middleware/get-cms-url', () => {
 					nockScopeForV1Images.head('/content/images/mock-id3.img').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
-					nockScopeForV2Images = nock('http://prod-upp-image-read.ft.com').persist();
+					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
 					nockScopeForV2Images.head('/mock-id3').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
@@ -144,7 +144,7 @@ describe('lib/middleware/get-cms-url', () => {
 					nockScopeForV1Images.head('/content/images/mock-id4.img').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
-					nockScopeForV2Images = nock('http://prod-upp-image-read.ft.com').persist();
+					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
 					nockScopeForV2Images.head('/mock-id4').reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
@@ -171,12 +171,12 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the ftcms URL has a querystring', () => {
-				const v2Uri = 'http://prod-upp-image-read.ft.com/mock-id5?foo=bar';
+				const v2Uri = 'https://prod-upp-image-read.ft.com/mock-id5?foo=bar';
 				let scope;
 
 				beforeEach(done => {
 					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id5?foo=bar';
-					scope = nock('http://prod-upp-image-read.ft.com').persist();
+					scope = nock('https://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id5?foo=bar').reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
@@ -210,7 +210,7 @@ describe('lib/middleware/get-cms-url', () => {
 				beforeEach(done => {
 					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id6';
 
-					scope = nock('http://prod-upp-image-read.ft.com').persist();
+					scope = nock('https://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id6').replyWithError(new Error('mock error'));
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
@@ -237,7 +237,7 @@ describe('lib/middleware/get-cms-url', () => {
 					// V2 errors
 					dnsError = new Error('mock error');
 					dnsError.code = 'ENOTFOUND';
-					scope = nock('http://prod-upp-image-read.ft.com').persist();
+					scope = nock('https://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id7').replyWithError(dnsError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
@@ -248,7 +248,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'DNS lookup failed for "http://prod-upp-image-read.ft.com/mock-id7"');
+					assert.strictEqual(responseError.message, 'DNS lookup failed for "https://prod-upp-image-read.ft.com/mock-id7"');
 				});
 
 			});
@@ -265,7 +265,7 @@ describe('lib/middleware/get-cms-url', () => {
 					// V2 errors
 					resetError = new Error('mock error');
 					resetError.code = 'ECONNRESET';
-					scope = nock('http://prod-upp-image-read.ft.com').persist();
+					scope = nock('https://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id8').replyWithError(resetError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
@@ -276,7 +276,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Connection reset when requesting "http://prod-upp-image-read.ft.com/mock-id8"');
+					assert.strictEqual(responseError.message, 'Connection reset when requesting "https://prod-upp-image-read.ft.com/mock-id8"');
 				});
 
 			});
@@ -293,7 +293,7 @@ describe('lib/middleware/get-cms-url', () => {
 					// V2 errors
 					timeoutError = new Error('mock error');
 					timeoutError.code = 'ETIMEDOUT';
-					scope = nock('http://prod-upp-image-read.ft.com').persist();
+					scope = nock('https://prod-upp-image-read.ft.com').persist();
 					scope.head('/mock-id9').replyWithError(timeoutError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
@@ -304,7 +304,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Request timed out when requesting "http://prod-upp-image-read.ft.com/mock-id9"');
+					assert.strictEqual(responseError.message, 'Request timed out when requesting "https://prod-upp-image-read.ft.com/mock-id9"');
 				});
 			});
 		});

--- a/test/unit/lib/middleware/purge-url.test.js
+++ b/test/unit/lib/middleware/purge-url.test.js
@@ -72,7 +72,7 @@ describe('lib/middleware/purge-url', () => {
 		});
 
 		describe('middleware(request, response, next)', () => {
-			const url = 'http://im.ft-static.com/content/images/mock-id.img';
+			const url = 'https://im.ft-static.com/content/images/mock-id.img';
 
 			describe('when the request does not specify a url to purge', () => {
 				it('calls `next` with a 400 error', () => {

--- a/views/index.html
+++ b/views/index.html
@@ -27,7 +27,7 @@
 	<tbody>
 		<tr>
 			<td>
-				<img src="http://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img" alt="Source Image"/>
+				<img src="https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img" alt="Source Image"/>
 			</td>
 			<td>
 				<img src="v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=docs" alt="Optimised Image"/>


### PR DESCRIPTION
This will remove the mixed content warning we get on the origami-image-service homepage.
This will also use https for more of our image backends such as prod-upp-image-read.ft.com and im.ft-static.com 👍 