### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # Origami Image Service V2
 
 The Origami Image Service can be used to optimise and resize images. You can crop, tint, and convert images in JPEG, PNG, GIF and SVG formats quickly and easily.
+
+## Code
+
+origami-image-service-v2
 
 ## Service Tier
 
@@ -20,36 +28,19 @@ Heroku
 
 ## Contains Personal Data
 
-no
+No
 
 ## Contains Sensitive Data
 
-no
+No
 
-## Delivered By
+## Can Download Personal Data
 
-origami-team
+No
 
-## Supported By
+## Can Contact Individuals
 
-origami-team
-
-## Known About By
-
-* jake.champion
-* rowan.manning
-
-## Dependencies
-
-* ft-fastly
-* content-api
-* dyn-dns
-* heroku
-
-## Healthchecks
-
-* origami-image-service-us.herokuapp.com-https
-* origami-image-service-eu.herokuapp.com-https
+No
 
 ## Failover Architecture Type
 
@@ -79,48 +70,42 @@ PartiallyAutomated
 
 Manual
 
-
 ## Architecture
 
 This is mostly a Node.js application which acts as a proxy between the end user and a third-party service named Cloudinary.
 
-### Architecture Diagram
-
-https://docs.google.com/drawings/d/1By1z0mwDG8QlOAvCgPLq23rn_K2NDyYQ7FLh-gH-X-8">https://docs.google.com/drawings/d/1By1z0mwDG8QlOAvCgPLq23rn_K2NDyYQ7FLh-gH-X-8
-
 ### Fetching an image
 
-1. End user makes a request for an image
-2. Our Fastly service responds with a cached image if it exists [end], or forwards the request to this service
-3. Our service forwards the request to Cloudinary, converting our transformation config into a format that Cloudinary understands
-4. Cloudinary responds with a cached image if it exists [end], or fetches the image from its origin
-5. The origin service responds to Cloudinary with an image or 404
-
+1.  End user makes a request for an image
+2.  Our Fastly service responds with a cached image if it exists [end], or forwards the request to this service
+3.  Our service forwards the request to Cloudinary, converting our transformation config into a format that Cloudinary understands
+4.  Cloudinary responds with a cached image if it exists [end], or fetches the image from its origin
+5.  The origin service responds to Cloudinary with an image or 404
 
 ## More Information
 
-https://github.com/Financial-Times/origami-image-service#readme
+<https://github.com/Financial-Times/origami-image-service#readme>
 
 ## First Line Troubleshooting
 
 There are a few things you can try before contacting the Origami team:
 
-1. Verify that Cloudinary is up ([status page](https://status.cloudinary.com/)). This being down won't break old images, but it will prevent new images from being requested.
-2. Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/be91fac7-5b0e-40f5-abd1-b81b72ad1b97))
+1.  Verify that Cloudinary is up ([status page](https://status.cloudinary.com/)). This being down won't break old images, but it will prevent new images from being requested.
+2.  Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/be91fac7-5b0e-40f5-abd1-b81b72ad1b97))
 
 ## Second Line Troubleshooting
 
 If the application is failing entirely, you'll need to check a couple of things:
 
-1. Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
-2. Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/be91fac7-5b0e-40f5-abd1-b81b72ad1b97))
-2. Check the Splunk logs (see the monitoring section of this runbook for the link)
+1.  Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
+2.  Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/be91fac7-5b0e-40f5-abd1-b81b72ad1b97))
+3.  Check the Splunk logs (see the monitoring section of this runbook for the link)
 
 If only a few things aren't working, the Splunk logs (see monitoring) are the best place to start debugging. Always roll back a deploy if one happened just before the thing stopped working – this gives you the chance to debug in the relative calm of QA.
 
 ## Monitoring
 
-https://github.com/Financial-Times/origami-image-service#monitoring
+<https://github.com/Financial-Times/origami-image-service#monitoring>
 
 ## Failover Details
 
@@ -139,3 +124,11 @@ The application is deployed to production whenever a semver tag is added to this
 ## Key Management Details
 
 This service uses an API key for Cloudinary. The process for rotating these keys is manual, via the Cloudinary interface.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/origami-image-service/blob/runbook-no-relationships-2021-03-19/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **origami-image-service-v2** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **origami-image-service-v2** system in [Biz Ops](https://biz-ops.in.ft.com/System/origami-image-service-v2).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
