### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5138,9 +5138,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
           "dev": true
         },
         "yargs": {


### PR DESCRIPTION
### Updated (2)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [axios](https://npm.im/axios) | `0.20.0` → `0.20.0` | [github](https://github.com/axios/axios) | - |
| [y18n](https://npm.im/y18n) | `4.0.0` → `4.0.1` | [github](https://github.com/yargs/y18n) | **[High]** Prototype Pollution ([ref](https://npmjs.com/advisories/1654)) |

***

This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.11**.