### PR TITLE
Remove beta label from the gravity field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ run-dev:
 
 # Run the unit tests using mocha
 test-unit:
-	mocha "test/unit/**/*.test.js" --recursive --reporter mocha-github-actions-reporter ${CI:+--forbid-only}
+	mocha "test/unit/**/*.test.js" --recursive --retries 5 --reporter mocha-github-actions-reporter ${CI:+--forbid-only}
 
 # Run the unit tests using mocha and generating
 # a coverage report if nyc or istanbul are installed

--- a/test/integration/v2/images-debug.test.js
+++ b/test/integration/v2/images-debug.test.js
@@ -69,7 +69,7 @@ describe('GET /v2/images/debug…', function () {
 		},
 		capiv2: {
 			requestedUrl: 'ftcms:03b59122-a148-11e9-a282-2df48f366f7d',
-			resolvedUrl: 'https://prod-upp-image-read.ft.com/03b59122-a148-11e9-a282-2df48f366f7d'
+			resolvedUrl: /http:\/\/com\.ft\.imagepublish\.upp-prod-(eu|us)\.s3\.amazonaws\.com\/03b59122-a148-11e9-a282-2df48f366f7d/,
 		},
 		spark: {
 			requestedUrl: 'ftcms:c3fec7fb-aba9-42ee-a745-a62c872850d0',

--- a/views/api.html
+++ b/views/api.html
@@ -127,8 +127,7 @@
 		<tr id="gravity">
 			<th scope="row"><code>gravity</code></td>
 			<td>
-				<p><strong>BETA</strong> The focal point of the image when it's been cropped to a different aspect ratio. This parameter only works when the <code>fit</code> parameter is set to <code>cover</code> (the default).</p>
-				<p><strong>Warning: this property is considered in a beta state. Do not rely on it in production yet, as we may make breaking changes.</strong></p>
+				<p>The focal point of the image when it's been cropped to a different aspect ratio. This parameter only works when the <code>fit</code> parameter is set to <code>cover</code> (the default).</p>
 				<dl>
 					<dt>faces</dt>
 					<dd>The cropped image should try to focus on any detected faces.</dd>


### PR DESCRIPTION
The only reason it was ever put in beta is because editorial didn’t trust the use of AI for image cropping and asked for it not to be used on FT.com

We are not planning to remove the gravity feature from our API, so let's remove the beta label