### PR TITLE
Enable the integration tests to run against a live server

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -9,3 +9,28 @@ jobs:
       - run: git fetch --prune --unshallow
       - name: Deploy to Heroku
         run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-image-service-dev.git HEAD:refs/heads/master --force
+  
+  create-change-log:
+    needs: [deploy-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Financial-Times/change-api-action@v1
+        name: Create new change log
+        with:
+          change-api-key: ${{ secrets.CHANGE_API_KEY }}
+          system-code: "origami-image-service-v2"
+          environment: dev
+          slack-channels: "ft-changes,origami-deploys"
+
+  integration-tests:
+    needs: [deploy-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: 14.x
+      - run: npm install -g "npm@^7"
+      - run: npm ci
+      - run: HOST="https://origami-image-service-dev.herokuapp.com" make test-integration

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -24,3 +24,15 @@ jobs:
           system-code: "origami-image-service-v2"
           environment: test
           slack-channels: "ft-changes,origami-deploys"
+
+  integration-tests:
+    needs: [deploy-to-staging]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: 14.x
+      - run: npm install -g "npm@^7"
+      - run: npm ci
+      - run: HOST="https://origami-image-service-qa.herokuapp.com" make test-integration

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ make verify
 
 We run the tests and linter on CI, you can view [results on CI][ci]. `make test` and `make lint` must pass before we merge a pull request.
 
+You can run the integration tests against a URL by setting a `HOST` environment variable to the URL you want to test. This is useful for testing a Heroku application after it is deployed, which we do on CI.
+
+```sh
+HOST="https://www.example.com" make test-integration
+```
+
 
 Deployment
 ----------

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -3,6 +3,8 @@
 const imageService = require('../..');
 const supertest = require('supertest');
 
+const HOST = process.env.HOST;
+
 const noop = () => {};
 const mockLog = {
 	info: noop,
@@ -11,27 +13,40 @@ const mockLog = {
 };
 
 before(function() {
-	return imageService({
-		contentApiKey: process.env.CONTENT_API_KEY,
-		cloudinaryAccountName: 'financial-times', // TODO set up a test account for this?
-		cloudinaryApiKey: process.env.CLOUDINARY_API_KEY,
-		cloudinaryApiSecret: process.env.CLOUDINARY_API_SECRET,
-		customSchemeCacheBust: process.env.CUSTOM_SCHEME_CACHE_BUST || '',
-		customSchemeStore: process.env.CUSTOM_SCHEME_STORE || 'https://origami-images.ft.com',
-		hostname: 'origami-image-service-qa.herokuapp.com',
-		defaultLayout: 'main',
-		environment: 'test',
-		log: mockLog,
-		port: 0,
-		requestLogFormat: null
-	})
-	.listen()
-	.then(app => {
-		this.agent = supertest.agent(app);
-		this.app = app;
-	});
+	// If HOST is defined, we are wanting to test a real server and not the local express app in this project.
+	if (HOST) {
+		return new Promise(resolve => {
+			this.app = HOST;
+			this.basepath = new URL(HOST).pathname;
+			this.agent = supertest.agent(this.app);
+			resolve();
+		});
+	} else {
+		return imageService({
+			contentApiKey: process.env.CONTENT_API_KEY,
+			cloudinaryAccountName: 'financial-times', // TODO set up a test account for this?
+			cloudinaryApiKey: process.env.CLOUDINARY_API_KEY,
+			cloudinaryApiSecret: process.env.CLOUDINARY_API_SECRET,
+			customSchemeCacheBust: process.env.CUSTOM_SCHEME_CACHE_BUST || '',
+			customSchemeStore: process.env.CUSTOM_SCHEME_STORE || 'https://origami-images.ft.com',
+			hostname: 'origami-image-service-qa.herokuapp.com',
+			defaultLayout: 'main',
+			environment: 'test',
+			log: mockLog,
+			port: 0,
+			requestLogFormat: null
+		})
+		.listen()
+		.then(app => {
+			this.agent = supertest.agent(app);
+			this.app = app;
+		});
+	}
 });
 
 after(function() {
-	this.app.ft.server.close();
+	// If HOST is not defined, we are testing the local express app in this project and need to stop the server to let the process exit.
+	if (!HOST) {
+		this.app.ft.server.close();
+	}
 });


### PR DESCRIPTION
We need this functionality to have tests written for the new way of serving image-sets (#763)

As the image-sets will be served from the application instead of a separate domain, the integration tests for image-sets will only work when the integration test server is on a domain which cloudinary can access (not localhost)

This setup is the same as the setup we have in the origami build service (https://github.com/Financial-Times/origami-build-service/pull/411)