### PR TITLE
fix: url builder output in production where the hostname env is not set

### DIFF
--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -65,7 +65,7 @@ module.exports = app => {
 		// Build the image preview URL
 		let imagePreviewUrl;
 		if (formData.url) {
-			imagePreviewUrl = buildUrl(formData, request.basePath);
+			imagePreviewUrl = buildUrl(formData, request.basePath, request.hostname);
 		}
 
 		// Remove the preview source once we've used it
@@ -101,12 +101,14 @@ module.exports = app => {
 		});
 	});
 
-	function buildUrl(data, basePath) {
+	function buildUrl(data, basePath, requestHostname) {
 		const sanitizedData = sanitizeData(data);
 		const url = sanitizedData.url;
 		delete sanitizedData.url;
 		const query = querystring.stringify(sanitizedData);
-		return new URL(`${basePath}v2/images/raw/${url}?${query}`, `https://${app.ft.options.hostname}`);
+		const hostname = app.ft.options.hostname || requestHostname;
+		const protocol = hostname === 'localhost' ? 'http' : 'https';
+		return new URL(`${basePath}v2/images/raw/${url}?${query}`, `${protocol}://${hostname}`);
 	}
 
 	function buildDemoUrl(url, basePath) {


### PR DESCRIPTION
Express gets `request.hostname` from the Host HTTP header, I think it's safe to use in this way