### PR TITLE
Do not use `request.hostname` for url builder output

### DIFF
--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -65,7 +65,7 @@ module.exports = app => {
 		// Build the image preview URL
 		let imagePreviewUrl;
 		if (formData.url) {
-			imagePreviewUrl = buildUrl(formData, request.basePath, request.hostname);
+			imagePreviewUrl = buildUrl(formData, request.basePath);
 		}
 
 		// Remove the preview source once we've used it
@@ -101,12 +101,12 @@ module.exports = app => {
 		});
 	});
 
-	function buildUrl(data, basePath, requestHostname) {
+	function buildUrl(data, basePath) {
 		const sanitizedData = sanitizeData(data);
 		const url = sanitizedData.url;
 		delete sanitizedData.url;
 		const query = querystring.stringify(sanitizedData);
-		const hostname = app.ft.options.hostname || requestHostname;
+		const hostname = app.ft.options.hostname || 'www.ft.com';
 		const protocol = hostname === 'localhost' ? 'http' : 'https';
 		return new URL(`${basePath}v2/images/raw/${url}?${query}`, `${protocol}://${hostname}`);
 	}


### PR DESCRIPTION
this is set to the heroku hostname by fastly
![Screenshot 2021-11-05 at 13 50 06](https://user-images.githubusercontent.com/10405691/140520737-0390b02d-b2aa-458d-b1ce-c5d3ee72c212.png)
