### PR TITLE
deprecate mute_notifications as it is replaced by mute-notifications

### DIFF
--- a/image-sets/fticon/v1/deprecated.json
+++ b/image-sets/fticon/v1/deprecated.json
@@ -1,1 +1,3 @@
-[]
+[
+  "mute_notifications"
+]


### PR DESCRIPTION
Underscores are not allowed in our icon naming. mute_notifications has been replaced by mute-notifications
resolves https://github.com/Financial-Times/fticons/issues/74