### PR TITLE
fix: cache ftcms requests which 404 only for 5m instead of 1 year

### DIFF
--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -84,7 +84,7 @@ function getCmsUrl(config) {
 							if (!request.params.originalImageUrl) {
 								// If the v1 image can't be found, we error
 								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
-								error.cacheMaxAge = '1y';
+								error.cacheMaxAge = '5m';
 								error.skipSentry = true;
 								throw error;
 							}
@@ -103,7 +103,7 @@ function getCmsUrl(config) {
 								}
 								// If the v1 image can't be found, we error
 								const error = httpError(404, `Unable to get image ${cmsId} from Content API v1 or v2`);
-								error.cacheMaxAge = '1y';
+								error.cacheMaxAge = '5m';
 								error.skipSentry = true;
 								throw error;
 							});

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -159,7 +159,7 @@ describe('lib/middleware/get-cms-url', () => {
 					assert.instanceOf(responseError, Error);
 					assert.strictEqual(responseError.message, 'Unable to get image mock-id4 from Content API v1 or v2');
 					assert.strictEqual(responseError.status, 404);
-					assert.strictEqual(responseError.cacheMaxAge, '1y');
+					assert.strictEqual(responseError.cacheMaxAge, '5m');
 				});
 
 				it('logs that the CMS ID was found in neither API', () => {


### PR DESCRIPTION
Recently the content api had an issue where it was returning 404s by
accident for requests which should have returned a 200. We then cached
those invalid responses for 1 year, which was unfortunate for our users
as when the content api was fixed, we were still serving 404s.

This change will make it so that we cache content api 404s for only 5
minutes, which is long enough to stop our servers getting overloaded
and is short enough for our users to retry the requests in case the 404
was an accident