### PR TITLE
attach all route handlers under the path prefix /__origami/service/image/

### DIFF
--- a/data/navigation.json
+++ b/data/navigation.json
@@ -2,32 +2,32 @@
 	"items": [
 		{
 			"name": "Overview",
-			"href": "v2",
+			"href": "/__origami/service/image/v2",
 			"current": false
 		},
 		{
 			"name": "URL Builder",
-			"href": "v2/docs/url-builder",
+			"href": "/__origami/service/image/v2/docs/url-builder",
 			"current": false
 		},
 		{
 			"name": "API Reference",
-			"href": "v2/docs/api",
+			"href": "/__origami/service/image/v2/docs/api",
 			"current": false
 		},
 		{
 			"name": "Image Sets",
-			"href": "v2/docs/image-sets",
+			"href": "/__origami/service/image/v2/docs/image-sets",
 			"current": false
 		},
 		{
 			"name": "Migration",
-			"href": "v2/docs/migration",
+			"href": "/__origami/service/image/v2/docs/migration",
 			"current": false
 		},
 		{
 			"name": "Purging Guide",
-			"href": "v2/docs/purge",
+			"href": "/__origami/service/image/v2/docs/purge",
 			"current": false
 		}
 	]

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -29,7 +29,6 @@ function imageService(options) {
 	const app = origamiService(options);
 	app.proxy = createProxy(origamiService.middleware.errorHandler());
 
-	app.use(origamiService.middleware.getBasePath());
 	app.use(origamiImageServiceSurrogateKey());
 	mountRoutes(app);
 	app.use(origamiService.middleware.notFound());

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -2,7 +2,7 @@
 
 module.exports = app => {
 	// Service home page
-	app.get('/', (request, response) => {
-		response.redirect(301, `${request.basePath}v2/`);
+	app.get(['/', '/__origami/service/image/'], (request, response) => {
+		response.redirect(301, `/__origami/service/image/v2/`);
 	});
 };

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -3,6 +3,6 @@
 module.exports = app => {
 	// Service home page
 	app.get(['/', '/__origami/service/image/'], (request, response) => {
-		response.redirect(301, `/__origami/service/image/v2/`);
+		response.redirect(301, '/__origami/service/image/v2/');
 	});
 };

--- a/lib/routes/purge.js
+++ b/lib/routes/purge.js
@@ -20,11 +20,11 @@ module.exports = app => {
 		'/v2/docs/purge',
 		'/v2/docs/purge/',
 		'/v2/docs/url-builder',
-		'/v2/docs/url-builder/'
+		'/v2/docs/url-builder/',
 	];
 
 	// Purge page
-	app.post('/purge', purgeUrls({
+	app.post(['/purge', '/__origami/service/image/purge'], purgeUrls({
 		urls: paths.map(path => `https://www.ft.com/__origami/service/image${path}`)
 	}));
 };

--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -6,7 +6,7 @@ module.exports = app => {
 	app.use([
 		'/v1',
 		'/__origami/service/image/v1',
-	 ], (request, response) => {
+	], (request, response) => {
 		response.redirect(301, `/v2${request.url}`);
 	});
 

--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -7,7 +7,7 @@ module.exports = app => {
 		'/v1',
 		'/__origami/service/image/v1',
 	], (request, response) => {
-		response.redirect(301, `/v2${request.url}`);
+		response.redirect(301, `/__origami/service/image/v2${request.url}`);
 	});
 
 };

--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -3,7 +3,10 @@
 module.exports = app => {
 
 	// v1 endpoint redirect
-	app.use('/v1', (request, response) => {
+	app.use([
+		'/v1',
+		'/__origami/service/image/v1',
+	 ], (request, response) => {
 		response.redirect(301, `/v2${request.url}`);
 	});
 

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -2,6 +2,7 @@
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
 const navigation = require('../../../../data/navigation.json');
+const path = require('path');
 
 module.exports = app => {
 
@@ -11,7 +12,7 @@ module.exports = app => {
 		'/__origami/service/image/v2/docs/api',
 	], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
-			if (item.href === request.path) {
+			if (item.href === request.path || item.href === path.join('/__origami/service/image', request.path)) {
 				item.current = true;
 			} else {
 				item.current = false;

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -9,7 +9,7 @@ module.exports = app => {
 	app.get([
 		'/v2/docs/api',
 		'/__origami/service/image/v2/docs/api',
-	 ], cacheControl({maxAge: '7d'}), (request, response) => {
+	], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -6,7 +6,10 @@ const navigation = require('../../../../data/navigation.json');
 module.exports = app => {
 
 	// v2 api documentation page
-	app.get('/v2/docs/api', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+		'/v2/docs/api',
+		'/__origami/service/image/v2/docs/api',
+	 ], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;

--- a/lib/routes/v2/docs/compare.js
+++ b/lib/routes/v2/docs/compare.js
@@ -6,7 +6,7 @@ module.exports = app => {
 	app.get([
 		'/v2/docs/compare',
 		'/__origami/service/image/v2/docs/compare',
-	 ], (request, response, next) => {
+	], (request, response, next) => {
 		next(httpError(410, 'The comparison page is no longer available, as Image Service V1 has been decommissioned.'));
 	});
 };

--- a/lib/routes/v2/docs/compare.js
+++ b/lib/routes/v2/docs/compare.js
@@ -3,7 +3,10 @@
 const httpError = require('http-errors');
 
 module.exports = app => {
-	app.get('/v2/docs/compare', (request, response, next) => {
+	app.get([
+		'/v2/docs/compare',
+		'/__origami/service/image/v2/docs/compare',
+	 ], (request, response, next) => {
 		next(httpError(410, 'The comparison page is no longer available, as Image Service V1 has been decommissioned.'));
 	});
 };

--- a/lib/routes/v2/docs/image-sets.js
+++ b/lib/routes/v2/docs/image-sets.js
@@ -2,6 +2,7 @@
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
 const navigation = require('../../../../data/navigation.json');
+const path = require('path');
 
 // We do not want to show deprecated image-sets on the website,
 // which is why fticon and ftsocial are not imported.
@@ -23,7 +24,7 @@ module.exports = app => {
 		'/__origami/service/image/v2/docs/image-sets',
 	], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
-			if (item.href === request.path) {
+			if (item.href === request.path || item.href === path.join('/__origami/service/image', request.path)) {
 				item.current = true;
 			} else {
 				item.current = false;

--- a/lib/routes/v2/docs/image-sets.js
+++ b/lib/routes/v2/docs/image-sets.js
@@ -21,7 +21,7 @@ module.exports = app => {
 	app.get([
 		'/v2/docs/image-sets',
 		'/__origami/service/image/v2/docs/image-sets',
-	 ], cacheControl({maxAge: '7d'}), (request, response) => {
+	], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;

--- a/lib/routes/v2/docs/image-sets.js
+++ b/lib/routes/v2/docs/image-sets.js
@@ -18,7 +18,10 @@ const {
 module.exports = app => {
 
 	// v2 url-builder page
-	app.get('/v2/docs/image-sets', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+		'/v2/docs/image-sets',
+		'/__origami/service/image/v2/docs/image-sets',
+	 ], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -2,6 +2,7 @@
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
 const navigation = require('../../../../data/navigation.json');
+const path = require('path');
 
 module.exports = app => {
 	// v2 migration page
@@ -10,7 +11,7 @@ module.exports = app => {
 		'/__origami/service/image/v2/docs/migration',
 	], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
-			if (item.href === request.path) {
+			if (item.href === request.path || item.href === path.join('/__origami/service/image', request.path)) {
 				item.current = true;
 			} else {
 				item.current = false;

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -5,7 +5,10 @@ const navigation = require('../../../../data/navigation.json');
 
 module.exports = app => {
 	// v2 migration page
-	app.get('/v2/docs/migration', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+		'/v2/docs/migration',
+		'/__origami/service/image/v2/docs/migration',
+	 ], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;
@@ -13,7 +16,7 @@ module.exports = app => {
 				item.current = false;
 			}
 		}
-		
+
 		response.render('migration', {
 			title: 'Migration Guide - Origami Image Service',
 			navigation

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -8,7 +8,7 @@ module.exports = app => {
 	app.get([
 		'/v2/docs/migration',
 		'/__origami/service/image/v2/docs/migration',
-	 ], cacheControl({maxAge: '7d'}), (request, response) => {
+	], cacheControl({maxAge: '7d'}), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;

--- a/lib/routes/v2/docs/purge.js
+++ b/lib/routes/v2/docs/purge.js
@@ -5,7 +5,10 @@ const navigation = require('../../../../data/navigation.json');
 
 module.exports = app => {
 	// v2 purge page
-	app.get('/v2/docs/purge', cacheControl({ maxAge: '1y' }), (request, response) => {
+	app.get([
+		'/v2/docs/purge',
+		'/__origami/service/image/v2/docs/purge',
+	 ], cacheControl({ maxAge: '1y' }), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;

--- a/lib/routes/v2/docs/purge.js
+++ b/lib/routes/v2/docs/purge.js
@@ -8,7 +8,7 @@ module.exports = app => {
 	app.get([
 		'/v2/docs/purge',
 		'/__origami/service/image/v2/docs/purge',
-	 ], cacheControl({ maxAge: '1y' }), (request, response) => {
+	], cacheControl({ maxAge: '1y' }), (request, response) => {
 		for (const item of navigation.items) {
 			if (item.href === request.path) {
 				item.current = true;

--- a/lib/routes/v2/docs/purge.js
+++ b/lib/routes/v2/docs/purge.js
@@ -2,6 +2,7 @@
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
 const navigation = require('../../../../data/navigation.json');
+const path = require('path');
 
 module.exports = app => {
 	// v2 purge page
@@ -10,7 +11,7 @@ module.exports = app => {
 		'/__origami/service/image/v2/docs/purge',
 	], cacheControl({ maxAge: '1y' }), (request, response) => {
 		for (const item of navigation.items) {
-			if (item.href === request.path) {
+			if (item.href === request.path || item.href === path.join('/__origami/service/image', request.path)) {
 				item.current = true;
 			} else {
 				item.current = false;

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -10,7 +10,7 @@ module.exports = app => {
 	app.get([
 		'/v2/docs/url-builder',
 		'/__origami/service/image/v2/docs/url-builder',
-	 ], cacheControl({maxAge: '7d'}), (request, response) => {
+	], cacheControl({maxAge: '7d'}), (request, response) => {
 		// If there's no URL, trip into preview mode
 		let url = request.query.url;
 		if (!url) {

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -68,7 +68,7 @@ module.exports = app => {
 		// Build the image preview URL
 		let imagePreviewUrl;
 		if (formData.url) {
-			imagePreviewUrl = buildUrl(formData, request.basePath);
+			imagePreviewUrl = buildUrl(formData);
 		}
 
 		// Remove the preview source once we've used it
@@ -78,12 +78,12 @@ module.exports = app => {
 
 		// Build the demo URLs
 		const demo = {
-			url: buildDemoUrl('https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img', request.basePath),
-			cms: buildDemoUrl('ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1', request.basePath),
-			flag: buildDemoUrl('ftflag-v1:eu', request.basePath),
-			icon: buildDemoUrl('fticon-v1:book', request.basePath),
-			social: buildDemoUrl('ftsocial-v2:twitter', request.basePath),
-			logo: buildDemoUrl('ftlogo-v1:brand-ft-masthead', request.basePath)
+			url: buildDemoUrl('https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img'),
+			cms: buildDemoUrl('ftcms:3520df36-8c20-11e6-8cb7-e7ada1d123b1'),
+			flag: buildDemoUrl('ftflag-v1:eu'),
+			icon: buildDemoUrl('fticon-v1:book'),
+			social: buildDemoUrl('ftsocial-v2:twitter'),
+			logo: buildDemoUrl('ftlogo-v1:brand-ft-masthead')
 		};
 
 		for (const item of navigation.items) {
@@ -104,18 +104,18 @@ module.exports = app => {
 		});
 	});
 
-	function buildUrl(data, basePath) {
+	function buildUrl(data) {
 		const sanitizedData = sanitizeData(data);
 		const url = sanitizedData.url;
 		delete sanitizedData.url;
 		const query = querystring.stringify(sanitizedData);
 		const hostname = app.ft.options.hostname || 'www.ft.com';
 		const protocol = hostname === 'localhost' ? 'http' : 'https';
-		return new URL(`${basePath}v2/images/raw/${url}?${query}`, `${protocol}://${hostname}`);
+		return new URL(`/__origami/service/image/v2/images/raw/${url}?${query}`, `${protocol}://${hostname}`);
 	}
 
-	function buildDemoUrl(url, basePath) {
-		return `${basePath}v2/docs/url-builder?url=${encodeURIComponent(url)}&preview=true`;
+	function buildDemoUrl(url) {
+		return `/__origami/service/image/v2/docs/url-builder?url=${encodeURIComponent(url)}&preview=true`;
 	}
 
 	function sanitizeData(data) {

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
+const path = require('path');
 const querystring = require('querystring');
 const navigation = require('../../../../data/navigation.json');
 
@@ -87,7 +88,7 @@ module.exports = app => {
 		};
 
 		for (const item of navigation.items) {
-			if (item.href === request.path) {
+			if (item.href === request.path || item.href === path.join('/__origami/service/image', request.path)) {
 				item.current = true;
 			} else {
 				item.current = false;

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -7,7 +7,10 @@ const navigation = require('../../../../data/navigation.json');
 module.exports = app => {
 
 	// v2 url-builder page
-	app.get('/v2/docs/url-builder', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+		'/v2/docs/url-builder',
+		'/__origami/service/image/v2/docs/url-builder',
+	 ], cacheControl({maxAge: '7d'}), (request, response) => {
 		// If there's no URL, trip into preview mode
 		let url = request.query.url;
 		if (!url) {

--- a/lib/routes/v2/images-svgtint.js
+++ b/lib/routes/v2/images-svgtint.js
@@ -8,7 +8,10 @@ module.exports = app => {
 	// /v2/images/svgtint/https://...
 	// /v2/images/svgtint/http://...
 	app.get(
-		/\/v2\/images\/svgtint\/(https?(:|%3A).*)$/,
+		[
+			/\/v2\/images\/svgtint\/(https?(:|%3A).*)$/,
+			/\/__origami\/service\/image\/v2\/images\/svgtint\/(https?(:|%3A).*)$/,
+		],
 		handleSvg(options)
 	);
 

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -84,7 +84,7 @@ module.exports = app => {
 				getImageMeta(request, response, next);
 				break;
 			case 'purge':
-				response.redirect(`${request.basePath}v2/purge/url/?url=${encodeURIComponent(request.params.imageUrl)}`);
+				response.redirect(`/__origami/service/image/v2/purge/url/?url=${encodeURIComponent(request.params.imageUrl)}`);
 				break;
 			default:
 				next();

--- a/lib/routes/v2/images.js
+++ b/lib/routes/v2/images.js
@@ -171,7 +171,10 @@ module.exports = app => {
 
 	// Request with no scheme at all
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/$/i,
+		[
+			/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/$/i,
+			/^\/__origami\/service\/image\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/$/i,
+		],
 		mapParams,
 		rejectMissingScheme,
 		mapScheme,
@@ -185,7 +188,10 @@ module.exports = app => {
 	// /v2/images/raw/fticon:...
 	// /v2/images/debug/ftlogo:...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((ftflag|fticon|ftsocial|ftlogo|ftbrand|ftpodcast|specialisttitle)(-v\d+)?(:|%3A).*)$/i,
+		[
+			/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((ftflag|fticon|ftsocial|ftlogo|ftbrand|ftpodcast|specialisttitle)(-v\d+)?(:|%3A).*)$/i,
+			/^\/__origami\/service\/image\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((ftflag|fticon|ftsocial|ftlogo|ftbrand|ftpodcast|specialisttitle)(-v\d+)?(:|%3A).*)$/i,
+		],
 		mapParams,
 		mapScheme,
 		mapCustomScheme(app.ft.options),
@@ -198,7 +204,10 @@ module.exports = app => {
 	// /v2/images/raw/fthead:...
 	// /v2/images/debug/fthead:...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((fthead(-v1)?)(:|%3A).*)$/i,
+		[
+			/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((fthead(-v1)?)(:|%3A).*)$/i,
+			/^\/__origami\/service\/image\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((fthead(-v1)?)(:|%3A).*)$/i,
+		],
 		mapParams,
 		mapScheme,
 		getHeadshotUrl(app.ft.options),
@@ -212,7 +221,10 @@ module.exports = app => {
 	// /v2/images/raw/https://im.ft-static.com/...
 	// /v2/images/debug/http://im.ft-static.com/...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com|d1e00ek4ebabms\.cloudfront\.net\/production|cct-images\.ft\.com\/production).+)$/i,
+		[
+			/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com|d1e00ek4ebabms\.cloudfront\.net\/production|cct-images\.ft\.com\/production).+)$/i,
+			/^\/__origami\/service\/image\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((https?(:|%3A))?(\/|%2F)*(prod-upp-image-read\.ft\.com|com\.ft\.imagepublish|im\.ft-static\.com|d1e00ek4ebabms\.cloudfront\.net\/production|cct-images\.ft\.com\/production).+)$/i,
+		],
 		mapParams,
 		mapScheme,
 		markImageAsImmutable,
@@ -227,7 +239,10 @@ module.exports = app => {
 	// /v2/images/raw/ftcms:...
 	// /v2/images/debug/ftcms:...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((ftcms)(:|%3A).*)$/i,
+		[
+			/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((ftcms)(:|%3A).*)$/i,
+			/^\/__origami\/service\/image\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((ftcms)(:|%3A).*)$/i,
+		],
 		mapParams,
 		mapScheme,
 		markImageAsImmutable,
@@ -242,7 +257,10 @@ module.exports = app => {
 	// /v2/images/raw/http://...
 	// /v2/images/debug/http://...
 	app.get(
-		/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((https?(:|%3A))?(\/|%2F)*.*)$/i,
+		[
+			/^\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((https?(:|%3A))?(\/|%2F)*.*)$/i,
+			/^\/__origami\/service\/image\/v2\/images\/(raw|debug|metadata|purge|placeholder)\/((https?(:|%3A))?(\/|%2F)*.*)$/i,
+		],
 		mapParams,
 		updateOldBlogsLinks,
 		mapScheme,
@@ -252,12 +270,18 @@ module.exports = app => {
 	);
 
 	app.get(
-		'/internal-images/*.(gif|png|svg)',
+		[
+			'/internal-images/*.(gif|png|svg)',
+			'/__origami/service/image/internal-images/*.(gif|png|svg)',
+		],
 		st({ path: path.join(__dirname, '../../../image-sets/'), url: '/internal-images/' })
 	);
 
 	app.get(
-		'/v2/imagesets/:scheme(ftbrand|ftbrand-v1|ftflag|ftflag-v1|fticon|fticon-v1|ftlogo|ftlogo-v1|ftpodcast|ftpodcast-v1|ftsocial|ftsocial-v1|ftsocial-v2|specialisttitle|specialisttitle-v1)',
+		[
+			'/v2/imagesets/:scheme(ftbrand|ftbrand-v1|ftflag|ftflag-v1|fticon|fticon-v1|ftlogo|ftlogo-v1|ftpodcast|ftpodcast-v1|ftsocial|ftsocial-v1|ftsocial-v2|specialisttitle|specialisttitle-v1)',
+			'/__origami/service/image/v2/imagesets/:scheme(ftbrand|ftbrand-v1|ftflag|ftflag-v1|fticon|fticon-v1|ftlogo|ftlogo-v1|ftpodcast|ftpodcast-v1|ftsocial|ftsocial-v1|ftsocial-v2|specialisttitle|specialisttitle-v1)',
+		],
 		(request, response) => {
 			switch (request.params.scheme) {
 				case 'ftbrand':

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -4,7 +4,10 @@ const cacheControl = require('@financial-times/origami-service').middleware.cach
 const navigation = require('../../../data/navigation');
 module.exports = app => {
 	// v2 home page
-	app.get('/v2', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+		'/v2',
+		'/__origami/service/image/v2',
+	 ], cacheControl({maxAge: '7d'}), (request, response) => {
 		navigation.items.map(item => item.current = false);
 		navigation.items[0].current = true;
 		response.render('index', {

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -7,7 +7,7 @@ module.exports = app => {
 	app.get([
 		'/v2',
 		'/__origami/service/image/v2',
-	 ], cacheControl({maxAge: '7d'}), (request, response) => {
+	], cacheControl({maxAge: '7d'}), (request, response) => {
 		navigation.items.map(item => item.current = false);
 		navigation.items[0].current = true;
 		response.render('index', {

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -2,14 +2,21 @@
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
 const navigation = require('../../../data/navigation');
+const path = require('path');
+
 module.exports = app => {
 	// v2 home page
 	app.get([
 		'/v2',
 		'/__origami/service/image/v2',
 	], cacheControl({maxAge: '7d'}), (request, response) => {
-		navigation.items.map(item => item.current = false);
-		navigation.items[0].current = true;
+		for (const item of navigation.items) {
+			if (item.href === request.path || item.href === path.join('/__origami/service/image', request.path)) {
+				item.current = true;
+			} else {
+				item.current = false;
+			}
+		}
 		response.render('index', {
 			title: 'Origami Image Service',
 			navigation

--- a/lib/routes/v2/purge.js
+++ b/lib/routes/v2/purge.js
@@ -13,7 +13,10 @@ module.exports = app => {
 		// Purge a specific URL
 		// /v2/purge/url/?url=
 		app.get(
-			'/v2/purge/url',
+			[
+				'/v2/purge/url',
+				'/__origami/service/image/v2/purge/url',
+			],
 			noCache(),
 			apiKey(options),
 			purgeUrl(options)
@@ -22,7 +25,10 @@ module.exports = app => {
 		// Purge a specific key
 		// /v2/purge/key/?key=
 		app.get(
-			'/v2/purge/key',
+			[
+				'/v2/purge/key',
+				'/__origami/service/image/v2/purge/key',
+			],
 			noCache(),
 			apiKey(options),
 			purgeKey(options)

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -17,7 +17,6 @@ before(function() {
 	if (HOST) {
 		return new Promise(resolve => {
 			this.app = HOST;
-			this.basepath = new URL(HOST).pathname;
 			this.agent = supertest.agent(this.app);
 			resolve();
 		});

--- a/test/integration/v1/docs.test.js
+++ b/test/integration/v1/docs.test.js
@@ -7,11 +7,23 @@ const setupRequest = require('../helpers/setup-request');
 describe('GET /v1/', function() {
 	setupRequest('GET', '/v1/');
 	itRespondsWithStatus(301);
-	itRespondsWithHeader('Location', '/v2/');
+	itRespondsWithHeader('Location', '/__origami/service/image/v2/');
 });
 
 describe('GET /v1/images/raw/fticon:cross?source=origami-image-service', function() {
 	setupRequest('GET', '/v1/images/raw/fticon:cross?source=origami-image-service');
 	itRespondsWithStatus(301);
-	itRespondsWithHeader('Location', '/v2/images/raw/fticon:cross?source=origami-image-service');
+	itRespondsWithHeader('Location', '/__origami/service/image/v2/images/raw/fticon:cross?source=origami-image-service');
+});
+
+describe('GET /__origami/service/image/v1/', function() {
+	setupRequest('GET', '/__origami/service/image/v1/');
+	itRespondsWithStatus(301);
+	itRespondsWithHeader('Location', '/__origami/service/image/v2/');
+});
+
+describe('GET /__origami/service/image/v1/images/raw/fticon:cross?source=origami-image-service', function() {
+	setupRequest('GET', '/__origami/service/image/v1/images/raw/fticon:cross?source=origami-image-service');
+	itRespondsWithStatus(301);
+	itRespondsWithHeader('Location', '/__origami/service/image/v2/images/raw/fticon:cross?source=origami-image-service');
 });

--- a/test/integration/v2/docs.test.js
+++ b/test/integration/v2/docs.test.js
@@ -10,3 +10,10 @@ describe('GET /v2/', function() {
 	itRespondsWithStatus(200);
 	itRespondsWithContentType('text/html');
 });
+
+describe('GET /__origami/service/image/v2/', function() {
+
+	setupRequest('GET', '/__origami/service/image/v2/');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('text/html');
+});

--- a/test/integration/v2/images-debug.test.js
+++ b/test/integration/v2/images-debug.test.js
@@ -63,6 +63,29 @@ describe('GET /v2/images/debug…', function () {
 		});
 	});
 
+	describe('http', function () {
+		setupRequest('GET', `/__origami/service/image/v2/images/debug/${testImageUris.httpftcms}?source=origami-image-service&width=123&height=456&echo`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('application/json');
+
+		it('responds with JSON representing the transforms in the image request', function (done) {
+			this.request.expect(response => {
+				assert.isObject(response.body);
+				assert.deepEqual(response.body.transform, {
+					fit: 'cover',
+					format: 'auto',
+					height: 456,
+					quality: 72,
+					uri: testImageUris.httpftcms,
+					width: 123,
+					immutable: true,
+					name: '15a8ed456065fe9f8193405a81d4ee3d1531876634177efe359a662496d62793'
+				});
+				assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/15a8ed456065fe9f8193405a81d4ee3d1531876634177efe359a662496d62793$'));
+			}).end(done);
+		});
+	});
+
 
 	const imagesWithSchemes = {
 		ftcms: {
@@ -125,6 +148,22 @@ describe('GET /v2/images/debug…', function () {
 		}] of Object.entries(imagesWithSchemes)) {
 		describe(`resolving urls which have custom schemes: ${test} -- ${requestedUrl} should resolve to ${resolvedUrl}`, function () {
 			setupRequest('GET', `/v2/images/debug/${requestedUrl}?source=origami-image-service&width=123&height=456`);
+			itRespondsWithStatus(200);
+			itRespondsWithContentType('application/json');
+
+			it('responds with the correct location of the original image', function (done) {
+				this.request.expect(response => {
+					const actual = response.body.transform.uri;
+					if (typeof resolvedUrl === 'string') {
+						assert.deepEqual(actual, resolvedUrl, `Expected ${requestedUrl} to match ${resolvedUrl} but it actually resolved to ${actual}`);
+					} else {
+						assert.match(actual, resolvedUrl, `Expected ${requestedUrl} to match to ${resolvedUrl} but it actually resolved to ${actual}`);
+					}
+				}).end(done);
+			});
+		});
+		describe(`resolving urls which have custom schemes: ${test} -- ${requestedUrl} should resolve to ${resolvedUrl}`, function () {
+			setupRequest('GET', `/__origami/service/image/v2/images/debug/${requestedUrl}?source=origami-image-service&width=123&height=456`);
 			itRespondsWithStatus(200);
 			itRespondsWithContentType('application/json');
 

--- a/test/integration/v2/images-metadata.test.js
+++ b/test/integration/v2/images-metadata.test.js
@@ -31,3 +31,25 @@ describe('GET /v2/images/metadata…', function() {
 	});
 
 });
+
+describe('GET /__origami/service/image/v2/images/metadata…', function() {
+
+	setupRequest('GET', `/__origami/service/image/v2/images/metadata/${testImageUris.http}?source=origami-image-service&width=123&height=456&echo`);
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+	it('responds with JSON representing the metadata of the requested image', function(done) {
+		this.request.expect(response => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.dpr, 1);
+			assert.strictEqual(response.body.type, 'image/jpeg');
+			assert.strictEqual(response.body.width, 123);
+			assert.strictEqual(response.body.height, 456);
+			assert.greaterThan(response.body.filesize, 5000);
+			assert.lessThan(response.body.filesize, 12000);
+		}).end(done);
+	});
+
+});

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -724,3 +724,682 @@ describe('GET /v2/images/raw…', function() {
 		});
 	});
 });
+
+describe('GET /__origami/service/image/v2/images/raw…', function() {
+
+	describe('/http://blogs.r.ftdata.co.uk', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.oldLiveBlogsDomainHttp}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/https://blogs.r.ftdata.co.uk', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.oldLiveBlogsDomainHttps}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/http://… (HTTP scheme unencoded)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/https://… (HTTPS scheme unencoded)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.nonUtf8Characters}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/http%3A%2F%2F… (HTTP scheme encoded)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${encodeURIComponent(testImageUris.httpftcms)}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/https%3A%2F%2F… (HTTPS scheme encoded)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${encodeURIComponent(testImageUris.httpsftcms)}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/http:/… (HTTP scheme url unencoded malformed)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpmalformed}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/png');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/https:… (HTTPS scheme url unencoded malformed)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsmalformed}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/png');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/http:/… (HTTP scheme with ftcms url unencoded malformed)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcmsmalformed}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/https:… (HTTPS scheme with ftcms url unencoded malformed)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsftcmsmalformed}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/http%3A%2F… (HTTP scheme encoded malformed)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${encodeURIComponent(testImageUris.httpftcmsmalformed)}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/https%3A… (HTTPS scheme encoded malformed)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${encodeURIComponent(testImageUris.httpsftcmsmalformed)}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('///… (protocol-relative unencoded)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.protocolRelativeftcms}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/2F%2F… (protocol-relative encoded)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${encodeURIComponent(testImageUris.protocolRelativeftcms)}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/ftbrand:… (ftbrand scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftbrand}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/ftbrand:… (ftbrand scheme with querystring)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftbrand}%3Ffoo%3Dbar?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/ftcms:… (ftcms scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftcms}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/ftcms:… (capiv1 scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.capiv1}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/ftcms:… (capiv2 scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.capiv2}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/ftcms:… (spark scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.spark}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/ftcms:… (sparkMasterImage scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.sparkMasterImage}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/https:… (httpsspark scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsspark}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('/ftcms:… (ftcms scheme with querystring)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftcms}%3Ffoo%3Dbar?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/ftflag:… (ftflag scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftflag}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/ftflag:… (ftflag scheme with querystring)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftflag}%3Ffoo%3Dbar?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/fticon:… (fticon scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.fticon}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/fticon:… (fticon scheme with querystring)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.fticon}%3Ffoo%3Dbar?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/ftsocial:… (ftsocial scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftsocial}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/ftlogo:… (ftlogo scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftlogo}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/specialisttitle:… (specialisttitle scheme)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.specialisttitle}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('/specialisttitle:… (specialisttitle scheme with querystring)', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.specialisttitle}%3Ffoo%3Dbar?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('without a `source` query parameter', function() {
+
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}`);
+		itRespondsWithStatus(400);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+		it('responds with a descriptive error message', function(done) {
+			this.timeout(30000);
+			this.request.expect(/the source parameter is required/i).end(done);
+		});
+
+	});
+
+	describe('when a transform query parameter is invalid', function() {
+
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service&bgcolor=f0`);
+		itRespondsWithStatus(400);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+		it('responds with a descriptive error message', function(done) {
+			this.request.expect(/image bgcolor must be a valid hex code or color name/i).end(done);
+		});
+
+	});
+
+	describe('when a dpr is set', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service&dpr=2`);
+		itRespondsWithHeader('content-Dpr', '2');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('when a dpr is not set', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service`);
+		itDoesNotRespondWithHeader('content-Dpr');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	onlyRunOnExternalServer('when a custom scheme image is not found', function() {
+		setupRequest('GET', '/__origami/service/image/v2/images/raw/ftbrand-v1:notabrand?source=origami-image-service');
+		itRespondsWithStatus(400);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+	});
+
+	describe('when a CMS image is not found', function() {
+		setupRequest('GET', '/__origami/service/image/v2/images/raw/ftcms:notanid?source=origami-image-service');
+		itRespondsWithStatus(404);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+	});
+
+	describe('when an HTTP image is not found', function() {
+		setupRequest('GET', '/__origami/service/image/v2/images/raw/https://www.ft.com/notapage?source=origami-image-service');
+		itRespondsWithStatus(404);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+	});
+
+	describe('when an image responds with HTML', function() {
+		setupRequest('GET', '/__origami/service/image/v2/images/raw/https://www.ft.com/?source=origami-image-service');
+		itRespondsWithStatus(400);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+	});
+
+	describe('when a request has no image specified', function() {
+		setupRequest('GET', '/__origami/service/image/v2/images/raw/?source=origami-image-service');
+		itRespondsWithStatus(400);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+
+	});
+
+	describe('when an image starts with a spaces', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/%20%20%20%20${testImageUris.httpsftcms}?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('when an image ends with spaces', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsftcms}%20%20%20?source=origami-image-service`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/jpeg');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('when the \'format\' query parameter is \'auto\'', () => {
+
+		const firefoxUA = 'Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0';
+		const chromeUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.75 Safari/537.36';
+		const ieUA = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
+
+		[
+			{
+				accept: '*/*',
+				userAgent: firefoxUA,
+				expectedContentType: 'image/jpeg',
+				expectedFtImageFormat: 'default'
+			},
+			{
+				accept: 'image/webp',
+				userAgent: firefoxUA,
+				expectedContentType: 'image/webp',
+				expectedFtImageFormat: 'webp'
+			},
+			{
+				accept: 'image/jxr',
+				userAgent: firefoxUA,
+				expectedContentType: 'image/vnd.ms-photo',
+				expectedFtImageFormat: 'jpegxr'
+			},
+			{
+				accept: '*/*',
+				userAgent: chromeUA,
+				expectedContentType: 'image/jpeg',
+				expectedFtImageFormat: 'default'
+			},
+			{
+				accept: 'image/webp',
+				userAgent: chromeUA,
+				expectedContentType: 'image/webp',
+				expectedFtImageFormat: 'webp'
+			},
+			{
+				accept: 'image/jxr',
+				userAgent: chromeUA,
+				expectedContentType: 'image/vnd.ms-photo',
+				expectedFtImageFormat: 'jpegxr'
+			},
+			{
+				accept: '*/*',
+				userAgent: ieUA,
+				expectedContentType: 'image/jpeg',
+				expectedFtImageFormat: 'default'
+			},
+			{
+				accept: 'image/webp',
+				userAgent: ieUA,
+				expectedContentType: 'image/webp',
+				expectedFtImageFormat: 'webp'
+			},
+			{
+				accept: 'image/jxr',
+				userAgent: ieUA,
+				expectedContentType: 'image/vnd.ms-photo',
+				expectedFtImageFormat: 'jpegxr'
+			},
+		].forEach(({accept, userAgent, expectedContentType, expectedFtImageFormat}) => {
+			describe(`when the 'user-agent' header is ${userAgent} and the 'accepts' header is ${accept}`, function() {
+				setupRequest(
+                    'GET',
+                    `/__origami/service/image/v2/images/raw/${testImageUris.httpsftcms}?source=origami-image-service&format=auto`,
+                    {
+                        accept: accept,
+                        'user-agent': userAgent,
+                    }
+                );
+				itRespondsWithHeader('Content-Type', expectedContentType);
+				itRespondsWithHeader('FT-Image-Format', expectedFtImageFormat);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+		});
+	});
+
+	context('when an image is returned, surrogate keys are added', function() {
+		describe('adds generic key for all image requests:', function() {
+			onlyRunOnExternalServer('ftbrand', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftbrand}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('ftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftflag', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftflag}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('fticon', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.fticon}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftlogo', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftlogo}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftsocial', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftsocial}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('http', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('https', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('protocolRelative', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.protocolRelativeftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('specialisttitle', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.specialisttitle}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+		});
+
+		describe('adds specific keys for image content types', function() {
+			onlyRunOnExternalServer('ftbrand', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftbrand}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2Uvc3ZnK3htbA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('ftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2UvanBlZw==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftflag', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftflag}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2Uvc3ZnK3htbA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('fticon', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.fticon}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2Uvc3ZnK3htbA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftlogo', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftlogo}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2Uvc3ZnK3htbA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftsocial', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftsocial}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2Uvc3ZnK3htbA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('http', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2UvanBlZw==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('https', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2UvanBlZw==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('protocolRelative', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.protocolRelativeftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2UvanBlZw==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('specialisttitle', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.specialisttitle}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aW1hZ2Uvc3ZnK3htbA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+		});
+
+		describe('adds specific keys for image schemes', function() {
+			onlyRunOnExternalServer('ftbrand', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftbrand}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRicmFuZA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('ftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM=/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftflag', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftflag}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRmbGFn/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('fticon', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.fticon}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRpY29u/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftlogo', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftlogo}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRsb2dv/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftsocial', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftsocial}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRzb2NpYWw=/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('httpftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM=/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('httpsftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM=/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('http', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.http}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aHR0cDo=/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('https', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.https}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aHR0cHM6Ly9vcmlnYW1pL/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('protocolRelativeftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.protocolRelativeftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM=/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('protocolRelative', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.protocolRelative}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aHR0cA==/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('specialisttitle', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.specialisttitle}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /c3BlY2lhbGlzdHRpdGxl/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+		});
+
+		describe('adds key for specific image requested', function() {
+			onlyRunOnExternalServer('ftbrand', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftbrand}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRicmFuZC12MTpicmFuZC1mdC1tb25leQ/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('ftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM6NmM1YTJmOGMtMThjYS00YWZhLTgwZmYtN2Q1NmU0MTE3MmIx/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftflag', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftflag}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRmbGFnOmpw/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('fthead', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.fthead}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRoZWFkLXYx/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('fticon', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.fticon}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRpY29uOmNyb3Nz/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftlogo', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftlogo}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRsb2dvOmJyYW5kLWZ0/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('ftsocial', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.ftsocial}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRzb2NpYWw6d2hhdHNhcHA=/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('httpftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM6YTYwYWUyNGItYjg3Zi00MzljLWJmMWItNmU1NDk0NmI0Y2Yy/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('httpsftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.httpsftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM6YTYwYWUyNGItYjg3Zi00MzljLWJmMWItNmU1NDk0NmI0Y2Yy/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('http', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.http}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aHR0cDovL29yaWdhbWkta/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('https', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.https}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aHR0cHM6Ly9vcmlnYW1pL/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('protocolRelativeftcms', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.protocolRelativeftcms}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /ZnRjbXM6YTYwYWUyNGItYjg3Zi00MzljLWJmMWItNmU1NDk0NmI0Y2Yy/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('protocolRelative', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.protocolRelative}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /Ly9vcmlnYW1pLWltYWdl/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			onlyRunOnExternalServer('specialisttitle', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.specialisttitle}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /c3BlY2lhbGlzdHRpdGxlOm5lZC1sb2dv/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+
+			describe('nonUtf8Characters', function() {
+				setupRequest('GET', `/__origami/service/image/v2/images/raw/${testImageUris.nonUtf8Characters}?source=origami-image-service`);
+				itRespondsWithHeader('surrogate-key', /aHR0cHM6Ly9vcmlnYW1pLWltYWdlLXNlcnZpY2UtaW50ZWdyYXRpb24tdGVzdHMuczMtZXUtd2VzdC0xLmFtYXpvbmF3cy5jb20vQmVhdXRlzIEuanBn/);
+				itRespondsWithHeader('surrogate-key', /origami-image-service/);
+			});
+		});
+	});
+});

--- a/test/integration/v2/images-svgtint.test.js
+++ b/test/integration/v2/images-svgtint.test.js
@@ -52,3 +52,45 @@ describe('GET /v2/images/svgtint…', function() {
 	});
 
 });
+
+describe('GET /__origami/service/image/v2/images/svgtint…', function() {
+
+	describe('with a valid URI', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/svgtint/${testImageUris.valid}`);
+		itRespondsWithStatus(200);
+		itRespondsWithContentType('image/svg+xml');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('with a URI that 404s', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/svgtint/${testImageUris.notFound}`);
+		itRespondsWithStatus(404);
+		itRespondsWithContentType('text/html');
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('with a URI that does not point to an SVG', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/svgtint/${testImageUris.nonSvg}`);
+		itRespondsWithStatus(400);
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+		it('responds with a descriptive error message', function(done) {
+			this.request.expect(/uri must point to an svg image/i).end(done);
+		});
+	});
+
+	describe('with a valid `color` query parameter', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/svgtint/${testImageUris.valid}?color=f00`);
+		itRespondsWithStatus(200);
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+	});
+
+	describe('with an invalid `color` query parameter', function() {
+		setupRequest('GET', `/__origami/service/image/v2/images/svgtint/${testImageUris.valid}?color=nope`);
+		itRespondsWithStatus(400);
+		itRespondsWithHeader('surrogate-key', /origami-image-service/);
+		it('responds with a descriptive error message', function(done) {
+			this.request.expect(/tint color must be a valid hex code/i).end(done);
+		});
+	});
+
+});

--- a/test/integration/v2/imagesets.test.js
+++ b/test/integration/v2/imagesets.test.js
@@ -147,3 +147,129 @@ onlyRunOnExternalServer('Origami Image Sets via Custom Schemes', function () {
     });
 
 });
+
+onlyRunOnExternalServer('Origami Image Sets via Custom Schemes', function () {
+    describe('ftbrand', function () {
+        for (const name of Object.keys(ftbrand)) {
+            describe(`ftbrand:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftbrand:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+            describe(`ftbrand-v1:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftbrand-v1:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+    });
+    describe('ftflag', function () {
+        for (const name of Object.keys(ftflag)) {
+            describe(`ftflag:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftflag:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+            describe(`ftflag-v1:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftflag-v1:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+    });
+    describe('fticon', function () {
+        for (const name of Object.keys(fticon)) {
+            describe(`fticon:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/fticon:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+        for (const name of Object.keys(fticonV1)) {
+            describe(`fticon-v1:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/fticon-v1:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+    });
+    describe('ftlogo', function () {
+        for (const name of Object.keys(ftlogo)) {
+            describe(`ftlogo:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftlogo:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+            describe(`ftlogo-v1:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftlogo-v1:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+    });
+    describe('ftpodcast', function () {
+        for (const name of Object.keys(ftpodcast)) {
+            describe(`ftpodcast:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftpodcast:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+            describe(`ftpodcast-v1:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftpodcast-v1:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+    });
+    describe('ftsocial', function () {
+        for (const name of Object.keys(ftsocial)) {
+            describe(`ftsocial:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftsocial:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+            describe(`ftsocial-v1:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftsocial-v1:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+        for (const name of Object.keys(ftsocialV2)) {
+            describe(`ftsocial-v2:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/ftsocial-v2:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+    });
+    describe('specialisttitle', function () {
+        for (const name of Object.keys(specialisttitle)) {
+            describe(`specialisttitle:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/specialisttitle:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+            describe(`specialisttitle-v1:${name}`, function () {
+                setupRequest('GET', `/__origami/service/image/v2/images/raw/specialisttitle-v1:${name}?source=origami-image-service`);
+                itRespondsWithStatus(200);
+                itRespondsWithHeader('surrogate-key', /origami-image-service/);
+                itRespondsWithContentType('image/*');
+            });
+        }
+    });
+
+});

--- a/test/integration/v2/imagesetsjson.test.js
+++ b/test/integration/v2/imagesetsjson.test.js
@@ -97,3 +97,96 @@ describe('Origami Image Sets JSON API', function () {
         itRespondsWithHeader('surrogate-key', /origami-image-service/);
     });
 });
+
+describe('Origami Image Sets JSON API', function () {
+    describe('ftbrand', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftbrand?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftbrand-v1', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftbrand-v1?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+        describe('ftflag', function () {
+            setupRequest('GET', '/__origami/service/image/v2/imagesets/ftflag?source=origami-image-service');
+            itRespondsWithStatus(200);
+            itRespondsWithContentType('application/json; charset=utf-8');
+            itRespondsWithHeader('surrogate-key', /origami-image-service/);
+        });
+        describe('ftflag-v1', function () {
+            setupRequest('GET', '/__origami/service/image/v2/imagesets/ftflag-v1?source=origami-image-service');
+            itRespondsWithStatus(200);
+            itRespondsWithContentType('application/json; charset=utf-8');
+            itRespondsWithHeader('surrogate-key', /origami-image-service/);
+        });
+    describe('fticon', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/fticon?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('fticon-v1', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/fticon-v1?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftlogo', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftlogo?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftlogo-v1', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftlogo-v1?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftpodcast', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftpodcast?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftpodcast-v1', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftpodcast-v1?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftsocial', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftsocial?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftsocial-v1', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftsocial-v1?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('ftsocial-v2', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/ftsocial-v2?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('specialisttitle', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/specialisttitle?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+    describe('specialisttitle-v1', function () {
+        setupRequest('GET', '/__origami/service/image/v2/imagesets/specialisttitle-v1?source=origami-image-service');
+        itRespondsWithStatus(200);
+        itRespondsWithContentType('application/json; charset=utf-8');
+        itRespondsWithHeader('surrogate-key', /origami-image-service/);
+    });
+});

--- a/test/unit/lib/image-service.test.js
+++ b/test/unit/lib/image-service.test.js
@@ -587,12 +587,6 @@ describe('lib/image-service', () => {
 			assert.strictEqual(origamiService.mockApp.proxy, httpProxy.mockProxyServer);
 		});
 
-		it('creates and mounts getBasePath middleware', () => {
-			assert.calledOnce(origamiService.middleware.getBasePath);
-			assert.calledWithExactly(origamiService.middleware.getBasePath);
-			assert.calledWith(origamiService.mockApp.use, origamiService.middleware.getBasePath.firstCall.returnValue);
-		});
-
 		it('loads all of the routes', () => {
 			assert.calledOnce(requireAll);
 			assert.isObject(requireAll.firstCall.args[0]);

--- a/test/unit/mock/origami-service.mock.js
+++ b/test/unit/mock/origami-service.mock.js
@@ -25,11 +25,9 @@ const mockApp = module.exports.mockApp = {
 
 const mockServer = module.exports.mockServer = {};
 
-const mockBasePathMiddleware = module.exports.mockBasePathMiddleware = sinon.spy();
 const mockErrorHandlerMiddleware = module.exports.mockErrorHandlerMiddleware = sinon.spy();
 const mockNotFoundMiddleware = module.exports.mockNotFoundMiddleware = sinon.spy();
 origamiService.middleware = {
-	getBasePath: sinon.stub().returns(mockBasePathMiddleware),
 	errorHandler: sinon.stub().returns(mockErrorHandlerMiddleware),
 	notFound: sinon.stub().returns(mockNotFoundMiddleware)
 };

--- a/views/image-sets.html
+++ b/views/image-sets.html
@@ -22,11 +22,11 @@
 	{{#images}}
 	{{#unless deprecated}}
 		<li id="arrow-down" class="image-grid__item">
-			<a href="{{@root.basePath}}v2/images/raw/{{uri}}?source=origami-image-service-website">
-				<img src="{{@root.basePath}}v2/images/raw/{{uri}}?source=origami-image-service&amp;width=200" width=200 height=200 alt="{{name}}" loading=lazy>
+			<a href="/__origami/service/image/v2/images/raw/{{uri}}?source=origami-image-service-website">
+				<img src="/__origami/service/image/v2/images/raw/{{uri}}?source=origami-image-service&amp;width=200" width=200 height=200 alt="{{name}}" loading=lazy>
 			</a>
 			<p class="image-grid__item__title o-layout__unstyled-element">
-				<a href="{{@root.basePath}}v2/docs/url-builder?url={{uri}}&amp;preview=true">{{name}}</a>
+				<a href="/__origami/service/image/v2/docs/url-builder?url={{uri}}&amp;preview=true">{{name}}</a>
 			</p>
 		</li>
 	{{/unless}}

--- a/views/index.html
+++ b/views/index.html
@@ -9,10 +9,10 @@
 </p>
 
 <p>
-	The quickest way to get started is to experiment with the <a href="{{@root.basePath}}v2/docs/url-builder">URL builder</a>, and try
+	The quickest way to get started is to experiment with the <a href="/__origami/service/image/v2/docs/url-builder">URL builder</a>, and try
 	transforming and optimising some of your images.
-	Read the <a href="{{@root.basePath}}v2/docs/api">API documentation</a> for more information on all of the available transforms.
-	If you're migrating from Image Service v1, we maintain a <a href="{{@root.basePath}}v2/docs/migration">migration guide</a> to help you.
+	Read the <a href="/__origami/service/image/v2/docs/api">API documentation</a> for more information on all of the available transforms.
+	If you're migrating from Image Service v1, we maintain a <a href="/__origami/service/image/v2/docs/migration">migration guide</a> to help you.
 </p>
 
 <h2 id="example">Example</h2>
@@ -30,7 +30,7 @@
 				<img src="https://im.ft-static.com/content/images/a60ae24b-b87f-439c-bf1b-6e54946b4cf2.img" alt="Source Image"/>
 			</td>
 			<td>
-				<img src="{{@root.basePath}}v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=docs" alt="Optimised Image"/>
+				<img src="/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=docs" alt="Optimised Image"/>
 			</td>
 		</tr>
 		<tr>
@@ -54,5 +54,5 @@
 	This service is meant for use in applications maintained by The Financial Times.
 	Use by third-parties is not permitted, and non-FT requests may be rate-limited or
 	blocked without notice. More information can be found in the
-	<a href="{{@root.basePath}}v2/docs/api#limitations">Limitations section of the API Documentation</a>
+	<a href="/__origami/service/image/v2/docs/api#limitations">Limitations section of the API Documentation</a>
 </p>

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -30,7 +30,7 @@
 	</style>
 
 	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-layout@^5,o-fonts@^5,o-syntax-highlight@^4,o-forms@^9,o-buttons@^7,o-table@^9,o-footer-services@^4,o-header-services@^5&brand=internal&system_code=origami-image-service-v2" />
-	<link rel="stylesheet" href="{{@root.basePath}}main.css" />
+	<link rel="stylesheet" href="/__origami/service/image/main.css" />
 
 	<script src="https://polyfill.io/v3/polyfill.min.js?features=fetch,default"></script>
 	<script>

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -4,7 +4,7 @@
 			<div class="o-header-services__ftlogo"></div>
 			<div class="o-header-services__title">
 				<h1 class="o-header-services__product-name">
-					<a href="{{@root.basePath}}">Origami Image Service</a>
+					<a href="/__origami/service/image/">Origami Image Service</a>
 				</h1>
 				<span class="o-header-services__product-tagline ">
 					Optimise and resize images easily
@@ -15,7 +15,7 @@
 			<ul class="o-header-services__primary-nav-list">
 				{{#navigation.items}}
 				<li>
-					<a {{#current}}aria-current="true" aria-label="Current page" {{/current}} class="o-header-services__nav-link" href="{{@root.basePath}}{{href}}">
+					<a {{#current}}aria-current="true" aria-label="Current page" {{/current}} class="o-header-services__nav-link" href="{{href}}">
 						{{name}}
 					</a>
 				</li>

--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -6,11 +6,11 @@
 	The form below allows you to experiment with different image transforms, and easily
 	try the service before you start using it in your application.
 	The URL builder does not include all of the available options. See the
-	<a href="{{@root.basePath}}v2/docs/api">API Documentation</a> for more information.
+	<a href="/__origami/service/image/v2/docs/api">API Documentation</a> for more information.
 </p>
 
 <h2 id="url-settings">URL Settings</h2>
-<form class="o-layout__main__full-span" action="{{@root.basePath}}v2/docs/url-builder" method="get">
+<form class="o-layout__main__full-span" action="/__origami/service/image/v2/docs/url-builder" method="get">
 	<div class="flex-container">
 		<div class="form">
 			<label class="o-forms-field">
@@ -102,7 +102,7 @@
 				Fit
 			</span>
 			<span class="o-forms-title__prompt">
-				The way the image should be cropped. See the <a href="{{@root.basePath}}v2/docs/api">API Documentation</a> for more information.
+				The way the image should be cropped. See the <a href="/__origami/service/image/v2/docs/api">API Documentation</a> for more information.
 			</span>
 		</span>
 		<div class="o-forms-input o-forms-input--radio-round o-forms-input--inline">
@@ -134,7 +134,7 @@
 				Gravity
 			</span>
 			<span class="o-forms-title__prompt">
-				Whether image analysis should be used to provide a better crop. See the <a href="{{@root.basePath}}v2/docs/api">API Documentation</a> for more information.
+				Whether image analysis should be used to provide a better crop. See the <a href="/__origami/service/image/v2/docs/api">API Documentation</a> for more information.
 			</span>
 		</span>
 		<div class="o-forms-input o-forms-input--radio-round o-forms-input--inline">


### PR DESCRIPTION
this is because the production origami image service is served under www.ft.com/__origami/service/image/ and having the application server respond to this path will simplify our cdn configuration

By making this change we can remove these parts of the cdn configuration:
https://github.com/Financial-Times/ft.com-cdn/blob/92a50479428e46b35a63485d100a8694e448c327/src/vcl/origami-image-service.vcl#L16
and 
https://github.com/Financial-Times/ft.com-cdn/blob/92a50479428e46b35a63485d100a8694e448c327/src/vcl/origami-image-service.vcl#L67-L76

The reason we have added new routes instead of replacing the existing routes is because when this is deployed it will need to respond to the old routes whilst we make the changes to the CDN to remove the `origami_image_service_miss` and `origami_image_service_pass` subroutines which remove the path prefix /__origami/service/image/ before making the request to our application servers