### PR TITLE
backstage: log 4.x.x errors when downloading an image from its source

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -33,6 +33,7 @@ function processImage(config) {
 	);
 
 	return (request, response, next) => {
+		const log = request.app.ft.log;
 		let transform;
 		// Add the URI from the path to the query so we can
 		// pass it into the transform as one object
@@ -157,6 +158,7 @@ function processImage(config) {
 				const file = response.data;
 
 				if (response.status >= 400) {
+					log.info(`Failed to download image from destination (${response.status}) ${imageURI}`);
 					const error = httpError(response.status);
 					error.cacheMaxAge = '5m';
 					error.skipSentry = true;

--- a/test/unit/lib/middleware/process-image-request.test.js
+++ b/test/unit/lib/middleware/process-image-request.test.js
@@ -11,8 +11,11 @@ describe('lib/middleware/process-image-request', () => {
 	let cloudinary;
 	let ImageTransform;
 	let processImageRequest;
+	let origamiService;
 
 	beforeEach(() => {
+		origamiService = require('../../mock/origami-service.mock');
+
 		ImageTransform = sinon.stub();
 		mockery.registerMock('../image-transform', ImageTransform);
 
@@ -68,6 +71,7 @@ describe('lib/middleware/process-image-request', () => {
 
 			beforeEach((done) => {
 				request = httpMock.createRequest();
+				request.app = origamiService.mockApp;
 				response = httpMock.createResponse();
 				next = sinon.stub();
 				mockImageTransform = {
@@ -118,6 +122,7 @@ describe('lib/middleware/process-image-request', () => {
 
 			beforeEach((done) => {
 				request = httpMock.createRequest();
+				request.app = origamiService.mockApp;
 				response = httpMock.createResponse();
 				next = sinon.stub();
 				mockImageTransform = {


### PR DESCRIPTION
This is to help debug the app-badge imageset. The images [404 in prod](https://origami-image-service-eu.herokuapp.com/__origami/service/image/v2/images/raw/app-badge-v1:apple?source=origami-image-service-website)
but work locally, in [dev](https://origami-image-service-dev.herokuapp.com/__origami/service/image/v2/images/raw/app-badge-v1:apple?source=origami-image-service-website), and [qa](https://origami-image-service-qa.herokuapp.com/__origami/service/image/v2/images/raw/app-badge-v1:apple?source=origami-image-service-website).

Relates to: https://github.com/Financial-Times/origami-image-service/pull/799

<img width="1416" alt="Screenshot 2022-04-28 at 17 03 31" src="https://user-images.githubusercontent.com/10405691/165798986-69958ca5-1940-4732-b9e5-6c75163cdbe3.png">

