### PR TITLE
fix: do not apply avif to gif after initial request

### DIFF
--- a/lib/middleware/process-image-request.js
+++ b/lib/middleware/process-image-request.js
@@ -16,7 +16,8 @@ const FileType = require('file-type');
 module.exports = processImage;
 
 function processImage(config) {
-	const cache = Object.create(null);
+	const imageUploadCache = Object.create(null);
+	const imageMimeTypeCache = Object.create(null);
 
 	cloudinary.config({
 		cloud_name: config.cloudinaryAccountName,
@@ -92,8 +93,8 @@ function processImage(config) {
 		let transformReady = Promise.resolve();
 		// 1. get image from destination
 		const originalImageURI = transform.getUri();
-		if (cache[originalImageURI]) {
-			const imageName = cache[originalImageURI];
+		if (imageUploadCache[originalImageURI]) {
+			const imageName = imageUploadCache[originalImageURI];
 			transform.setName(imageName);
 		} else if (request.params.imageMode === 'placeholder') {
 			transform.setFit('fill');
@@ -106,8 +107,8 @@ function processImage(config) {
 
 			transform.type = 'text';
 
-			if (cache[info]) {
-				transform.setName(cache[info]);
+			if (imageUploadCache[info]) {
+				transform.setName(imageUploadCache[info]);
 			} else {
 				const hash = crypto.createHash('sha256');
 				hash.update(info);
@@ -132,7 +133,7 @@ function processImage(config) {
 					font_weight: 'bold',
 					font_size: 256,
 				}).then(() => {
-					cache[info] = imageName;
+					imageUploadCache[info] = imageName;
 				});
 			}
 		} else {
@@ -217,7 +218,10 @@ function processImage(config) {
 
 							const imageName = hash.digest('hex');
 							transform.setName(imageName);
-							cache[originalImageURI] = imageName;
+							imageUploadCache[originalImageURI] = imageName;
+							if(type && type.mime) {
+								imageMimeTypeCache[originalImageURI] = type.mime;
+							}
 
 							// 3. upload the image to cloudinary - this will not error if the image has already been uploaded to cloudinary
 							try {
@@ -260,6 +264,13 @@ function processImage(config) {
 			});
 		}
 
+
+		// Remove avif if mime type is gif
+		const mimeType = imageMimeTypeCache[originalImageURI];
+		if (mimeType && mimeType.startsWith('image/gif')) {
+			transform.setFormat('auto');
+		}
+		
 		transformReady
 			.then(() => {
 				// Create a Cloudinary transform


### PR DESCRIPTION
If we have an image in in memory cache:
https://github.com/Financial-Times/origami-image-service/blob/5254832481ef794909eca717d5f27e75147eebed/lib/middleware/process-image-request.js#L95
Then we don't check if the image is a gif to remove the avif transform:
https://github.com/Financial-Times/origami-image-service/blob/5254832481ef794909eca717d5f27e75147eebed/lib/middleware/process-image-request.js#L175

This is a bit not nice, and could use a refactor, but should
stop the production issue without removing avif support.