### PR TITLE
fix: remove better-lookup

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -1,12 +1,5 @@
 'use strict';
 
-const http = require('http');
-const https = require('https');
-const { install } = require('better-lookup');
-
-install(http.globalAgent);
-install(https.globalAgent);
-
 const CloudinaryMetrics = require('./cloudinary-metrics');
 const healthChecks = require('./health-checks');
 const httpError = require('http-errors');

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@sentry/node": "^5.30.0",
         "axios": "^0.26.1",
         "base-64": "0.1.0",
-        "better-lookup": "^1.1.3",
         "cloudinary": "1.22.0",
         "colornames": "1.1.1",
         "date-fns": "2.15.0",
@@ -541,26 +540,6 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
-    },
-    "node_modules/@hyurl/utils": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@hyurl/utils/-/utils-0.2.23.tgz",
-      "integrity": "sha512-2UNFEycsDhBweDJQ6KkKkqxddhRdzSCkXb0z9t8SM6XCv3pu7mrd8Ujf2BGpk28iD/COI41b7+HmqhfiiZABuw==",
-      "dependencies": {
-        "check-iterable": "^1.0.2",
-        "could-be-class": "^0.2.0",
-        "is-like": "^0.1.9",
-        "tslib": "^2.3.1",
-        "utf8-length": "0.0.1"
-      },
-      "engines": {
-        "node": ">=8.3"
-      }
-    },
-    "node_modules/@hyurl/utils/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1172,17 +1151,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/better-lookup": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/better-lookup/-/better-lookup-1.1.3.tgz",
-      "integrity": "sha512-wCqS8pmdytxjOXjOoK6X3Ot2eXG+NOeCAqsIaAubZ39HS/Ys9TrN605gU+SlwA+606PvVMV/ZIjneYxJbIl8oA==",
-      "dependencies": {
-        "@hyurl/utils": "^0.2.8"
-      },
-      "engines": {
-        "node": ">=8.3"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -1460,11 +1428,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/check-iterable": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/check-iterable/-/check-iterable-1.0.5.tgz",
-      "integrity": "sha512-7mbGn9yS/Kz4v+a4qz4cc4IkgJSrxzkiWeMlHav/jrywg48S5Eo2WfH10Pq84wAPYBY8cjFr9yBoub8tCJKMZw=="
     },
     "node_modules/check-more-types": {
       "version": "2.24.0",
@@ -1768,11 +1731,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "node_modules/could-be-class": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/could-be-class/-/could-be-class-0.2.1.tgz",
-      "integrity": "sha512-QcY2rm26FdrmQWOi0gp9TZDwty95nsfLVOUjLqujue1uyKb4VksYKaLb0FlcyLEMNx2e1KNdvRkDlqtCJRQIag=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3564,11 +3522,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-like": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/is-like/-/is-like-0.1.9.tgz",
-      "integrity": "sha512-yJCXCxUvWQtHnkf2UQIWiScmWd0/ON6YVVLdr4LpcxzO9e/xxHrVtfuf3HNyAV/cBL77prop7pUGZvfRW/ahfQ=="
     },
     "node_modules/is-npm": {
       "version": "4.0.0",
@@ -7108,11 +7061,6 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
-    "node_modules/utf8-length": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
-      "integrity": "sha1-0xXEvtUpyXfxjdNcc9cmKDJ9mto="
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7972,25 +7920,6 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
-    "@hyurl/utils": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@hyurl/utils/-/utils-0.2.23.tgz",
-      "integrity": "sha512-2UNFEycsDhBweDJQ6KkKkqxddhRdzSCkXb0z9t8SM6XCv3pu7mrd8Ujf2BGpk28iD/COI41b7+HmqhfiiZABuw==",
-      "requires": {
-        "check-iterable": "^1.0.2",
-        "could-be-class": "^0.2.0",
-        "is-like": "^0.1.9",
-        "tslib": "^2.3.1",
-        "utf8-length": "0.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
-      }
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -8512,14 +8441,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "better-lookup": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/better-lookup/-/better-lookup-1.1.3.tgz",
-      "integrity": "sha512-wCqS8pmdytxjOXjOoK6X3Ot2eXG+NOeCAqsIaAubZ39HS/Ys9TrN605gU+SlwA+606PvVMV/ZIjneYxJbIl8oA==",
-      "requires": {
-        "@hyurl/utils": "^0.2.8"
-      }
-    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -8741,11 +8662,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
-    "check-iterable": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/check-iterable/-/check-iterable-1.0.5.tgz",
-      "integrity": "sha512-7mbGn9yS/Kz4v+a4qz4cc4IkgJSrxzkiWeMlHav/jrywg48S5Eo2WfH10Pq84wAPYBY8cjFr9yBoub8tCJKMZw=="
     },
     "check-more-types": {
       "version": "2.24.0",
@@ -9000,11 +8916,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "could-be-class": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/could-be-class/-/could-be-class-0.2.1.tgz",
-      "integrity": "sha512-QcY2rm26FdrmQWOi0gp9TZDwty95nsfLVOUjLqujue1uyKb4VksYKaLb0FlcyLEMNx2e1KNdvRkDlqtCJRQIag=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -10397,11 +10308,6 @@
         "global-dirs": "^2.0.1",
         "is-path-inside": "^3.0.1"
       }
-    },
-    "is-like": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/is-like/-/is-like-0.1.9.tgz",
-      "integrity": "sha512-yJCXCxUvWQtHnkf2UQIWiScmWd0/ON6YVVLdr4LpcxzO9e/xxHrVtfuf3HNyAV/cBL77prop7pUGZvfRW/ahfQ=="
     },
     "is-npm": {
       "version": "4.0.0",
@@ -13215,11 +13121,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-    },
-    "utf8-length": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
-      "integrity": "sha1-0xXEvtUpyXfxjdNcc9cmKDJ9mto="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@sentry/node": "^5.30.0",
     "axios": "^0.26.1",
     "base-64": "0.1.0",
-    "better-lookup": "^1.1.3",
     "cloudinary": "1.22.0",
     "colornames": "1.1.1",
     "date-fns": "2.15.0",


### PR DESCRIPTION
We have seen many `ENETUNREACH` errors since Apr 6, when this was released. I'm not sure why. Let's see if removing better-lookup will help.