### PR TITLE
[OR-140] Fix Cloudinary SSL Handshake Error, revert back to https

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -48,7 +48,8 @@ function createProxy(errorHandler) {
 	const proxy = httpProxy.createProxyServer({
 		ignorePath: true,
 		proxyTimeout: 25000, // 25 seconds
-		secure: false
+		secure: false,
+		changeOrigin: true
 	});
 	proxy.on('proxyReq', proxyRequestHandler);
 	proxy.on('proxyRes', proxyResponseHandler);

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -20,10 +20,8 @@ function cloudinaryTransform(transform, options = {}) {
 function buildCloudinaryTransforms(transform) {
 	const cloudinaryTransforms = {
 		type: transform.type || 'upload',
-		// Never use the secure API.
-		// Due to an unknown issue which causes an openssl error intermittently.
-		// https://response.ftops.tech/incident/2032/
-		secure: false,
+		// Always use the secure API
+		secure: true,
 
 		// Sign image URLs
 		sign_url: true,

--- a/test/integration/v2/images-debug.test.js
+++ b/test/integration/v2/images-debug.test.js
@@ -25,7 +25,7 @@ describe('GET /v2/images/debug…', function () {
 						immutable: true,
 						name: '15a8ed456065fe9f8193405a81d4ee3d1531876634177efe359a662496d62793'
 					});
-					assert.match(response.body.appliedTransform, new RegExp('^http://res.cloudinary.com/financial-times/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/15a8ed456065fe9f8193405a81d4ee3d1531876634177efe359a662496d62793$'));
+					assert.match(response.body.appliedTransform, new RegExp('^https://res.cloudinary.com/financial-times/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive.immutable_cache,h_456,q_72,w_123/15a8ed456065fe9f8193405a81d4ee3d1531876634177efe359a662496d62793$'));
 				}).end(done);
 			});
 		});

--- a/test/unit/lib/image-service.test.js
+++ b/test/unit/lib/image-service.test.js
@@ -162,7 +162,8 @@ describe('lib/image-service', () => {
 			assert.calledWithExactly(httpProxy.createProxyServer, {
 				ignorePath: true,
 				proxyTimeout: 25000,
-				secure: false
+				secure: false,
+				changeOrigin: true
 			});
 		});
 

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -33,7 +33,7 @@ describe('lib/transformers/cloudinary', () => {
 		});
 
 		it('returns a Cloudinary upload URL', () => {
-			assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+			assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 		});
 
 		describe('when `transform` has a `width` property', () => {
@@ -44,7 +44,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72,w_123/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72,w_123/http://example.com/$'));
 			});
 
 		});
@@ -57,7 +57,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,h_123,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,h_123,q_72/http://example.com/$'));
 			});
 
 		});
@@ -70,7 +70,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,dpr_2,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,dpr_2,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -83,7 +83,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fit,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fit,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -96,7 +96,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -109,7 +109,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_scale,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_scale,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -122,7 +122,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_limit,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_limit,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -135,7 +135,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,g_auto:faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,g_auto:faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -148,7 +148,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,g_auto:no_faces,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,g_auto:no_faces,q_72/http://example.com/$'));
 			});
 
 		});
@@ -161,7 +161,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_png,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_png,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -174,7 +174,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_30/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_30/http://example.com/$'));
 			});
 
 		});
@@ -187,7 +187,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/b_rgb:ff0000,c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -200,7 +200,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,e_tint:100:ff0000,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -213,7 +213,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,e_tint:100:ff0000:00ff00,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/http://example.com/$'));
 			});
 
 		});
@@ -226,7 +226,7 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 			it('returns the expected Cloudinary upload URL', () => {
-				assert.match(cloudinaryUrl, new RegExp('^http://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
+				assert.match(cloudinaryUrl, new RegExp('^https://res.cloudinary.com/testaccount/image/upload/s--[^/]+--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive.immutable_cache,q_72/http://example.com/$'));
 			});
 
 		});


### PR DESCRIPTION
Origami Image Service errored intermittently, in waves. We were getting around ~10,000 errors a day. We mitigated by switching to http requests.

We've found Cloudinary are backed by 3 cdns:
resa.cloudinary.com (akamai)
resf.cloudinary.com (fastly)
resc.cloudinary.com (cloudfront)

When we proxy image requests to resc.cloudinary.com (cloudfront) we got errors. We got no errors when proxying image service requests via Cloudinary's other two cdn providers. Alex pointed out this could explain the intermittent, wave-like nature of the errors we're seeing as dns cache expires.

We were able to output the full openssl log using:
```
proxyRequest.socket.enableTrace();
```
https://github.com/Financial-Times/origami-image-service/pull/823/files#diff-ba85e65e5381efabd2a2e48851c18adee2030e7d64e82265f3a041ebea630a7c

Cloudinary helped us identify:
"It is related to the SNI value, it appear that you've set SNI (server name) to origami-image-service-dev.herokuapp.com - that breaks TLS handshake. [...]
Because of how we have Fastly services set up the SNI doesn't matter. So periodically you were hitting Cloud Flare and running into validation issues."

I think the way we were setting the hostname via the proxy is the issue. Looks like setting `http-proxy`'s `changeOrigin` setting solves the issue, which tells htt-proxy to set the host header. https://github.com/http-party/node-http-proxy/blob/9b96cd725127a024dabebec6c7ea8c807272223d/lib/http-proxy/common.js#L100