### PR TITLE
feat: transform images with Cloudinary's 'pad' option

### DIFF
--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -376,7 +376,7 @@ module.exports = class ImageTransform {
 		if (value === 'transparent') {
 			return ImageTransform.colors.white;
 		}
-		if (!/^#?[0-9a-f]{3,8}$/i.test(value)) {
+		if (!/^#?[0-9a-f]{3,6}$/i.test(value)) {
 			value = colornames(value);
 		}
 		if (!value) {

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -639,7 +639,8 @@ module.exports = class ImageTransform {
 			'contain',
 			'cover',
 			'fill',
-			'scale-down'
+			'scale-down',
+			'pad'
 		];
 	}
 

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -29,7 +29,7 @@ module.exports = class ImageTransform {
 	 * @param {(String|Number)} [properties.width] - The width of the transformed image in pixels.
 	 * @param {(String|Number)} [properties.height] - The height of the transformed image in pixels.
 	 * @param {(String|Number)} [properties.dpr=1] - The device-pixel ratio of the transformed image.
-	 * @param {String} [properties.fit=cover] - The cropping strategy of the transformed image. One of contain, cover, fill, or scale-down.
+	 * @param {String} [properties.fit=cover] - The cropping strategy of the transformed image. One of contain, cover, fill, scale-down, or pad.
 	 * @param {String} [properties.quality=medium] - The compression quality of the transformed image. One of lowest, low, medium, high, highest, lossless.
 	 * @param {String} [properties.format=auto] - The file format of the transformed image. One of auto, jpg, png, svg.
 	 * @param {String} [properties.bgcolor] - A background color to apply to the transformed image (if transparent). Hex code or named color.

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -376,7 +376,7 @@ module.exports = class ImageTransform {
 		if (value === 'transparent') {
 			return ImageTransform.colors.white;
 		}
-		if (!/^#?[0-9a-f]{3,6}$/i.test(value)) {
+		if (!/^#?[0-9a-f]{3,8}$/i.test(value)) {
 			value = colornames(value);
 		}
 		if (!value) {

--- a/lib/routes/v2/docs/url-builder.js
+++ b/lib/routes/v2/docs/url-builder.js
@@ -29,7 +29,8 @@ module.exports = app => {
 				isCover: !request.query.fit,
 				isContain: (request.query.fit === 'contain'),
 				isFill: (request.query.fit === 'fill'),
-				isScaleDown: (request.query.fit === 'scale-down')
+				isScaleDown: (request.query.fit === 'scale-down'),
+				isPad: (request.query.fit === 'pad')
 			},
 			gravity: {
 				value: request.query.gravity,

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -14,7 +14,7 @@ function cloudinaryTransform(transform, options = {}) {
 		api_key: options.cloudinaryApiKey,
 		api_secret: options.cloudinaryApiSecret
 	});
-	return cloudinary.url(transform.getName()||encodeURI(transform.getUri()), buildCloudinaryTransforms(transform));
+	return cloudinary.url(transform.getName() || encodeURI(transform.getUri()), buildCloudinaryTransforms(transform));
 }
 
 function buildCloudinaryTransforms(transform) {
@@ -62,7 +62,8 @@ function getCloudinaryCropStrategy(cropStrategy) {
 		contain: 'fit',
 		cover: 'fill',
 		fill: 'scale',
-		'scale-down': 'limit'
+		'scale-down': 'limit',
+		pad: 'pad'
 	};
 	return cropStrategyMap[cropStrategy];
 }

--- a/test/unit/lib/image-transform.test.js
+++ b/test/unit/lib/image-transform.test.js
@@ -1318,7 +1318,8 @@ describe('lib/image-transform', () => {
 			'contain',
 			'cover',
 			'fill',
-			'scale-down'
+			'scale-down',
+			'pad'
 		]);
 	});
 

--- a/views/api.html
+++ b/views/api.html
@@ -121,6 +121,8 @@
 					<dd>The image width and height are set to the exact dimensions given in the <code>width</code> and <code>height</code> parameters, potentially stretching the image.</dd>
 					<dt>scale-down</dt>
 					<dd>Similarly to <code>contain</code>, the image dimensions are scaled down to be less than or equal to the corresponding dimensions of the frame, but the image is never enlarged.</dd>
+					<dt>pad</dt>
+					<dd>The image should be scaled to fill the specified width and height whilst preserving the original aspect ratio. Any empty space after transforming will be filled with the colour set in <code>bgcolor</code>.</code></dd>
 				</dl>
 			</td>
 		</tr>

--- a/views/url-builder.html
+++ b/views/url-builder.html
@@ -127,6 +127,10 @@
 				<input type="radio" name="fit" value="scale-down"{{#if form.format.isScaleDown}}checked{{/if}}/>
 				<span class="o-forms-input__label">scale-down</span>
 			</label>
+			<label>
+				<input type="radio" name="fit" value="pad"{{#if form.format.isScaleDown}}checked{{/if}}/>
+				<span class="o-forms-input__label">pad</span>
+			</label>
 		</div>
 	</div>
 


### PR DESCRIPTION
Enables requests to the API with `fit` set to `pad`. This will allow images to be scaled whilst maintaining the original aspect ratio. Any white space that occurs after the transform will bet set with a colour from `bgcolor`.

Partially completes OR-240. FTEdit would like the background to also be transparent, but this doesn't appear to work without further changes. Releasing this as an increment will allow them to test if this feature meets their requirements whilst we work on the transparency issue.