### PR TITLE
Update fticon mute

### DIFF
--- a/image-sets/fticon/v1/mute.svg
+++ b/image-sets/fticon/v1/mute.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20735388b3d16c2b5346f6bd09fa2bd57c49089454fb2f0d5c66fe41cc85bffc
-size 394
+oid sha256:0b6bba1844b0f3f1ea3ccf57184cef75c7819c1d42a7d9960d49e6ec9e97a4e6
+size 743


### PR DESCRIPTION
We will also use the mute icon to mean "no audio avaliable", with a clarifying label. We believe the updated icon can convey both meanings more affectively. It also aligns with the mute icon used on IOS, MacOS, and YouTube https://docs.google.com/document/d/1aKhbRfMnCthZ-6D5eT82lpMmBeCcywNl9HzQakBf6lU/edit#heading=h.tv4ot1paadjg