### PR TITLE
fix: scripts/delete-old-images-from-cloudinary.js [OR-298]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/node": "^5.30.0",
         "axios": "^0.26.1",
         "base-64": "0.1.0",
-        "cloudinary": "1.22.0",
+        "cloudinary": "1.40.0",
         "colornames": "1.1.1",
         "date-fns": "2.15.0",
         "dompurify": "2.2.2",
@@ -1573,16 +1573,25 @@
       }
     },
     "node_modules/cloudinary": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.22.0.tgz",
-      "integrity": "sha512-qQhSVqGyOWtGbPc3JrwyUXJEZpdqsEzBFSf5+gTo7gbKbXdzEysLagigoSlp6JYI7YW2oEbz4aeZlgN2ucOkzQ==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.40.0.tgz",
+      "integrity": "sha512-Fifkl8NRw/M+Enw4cKCXc6e0Or28c5y6RVGYS3OCLzT1W8EfBt416FURhLuuL/S4BCVv8bSilmnM746kCtth3g==",
       "dependencies": {
-        "core-js": "^3.6.5",
-        "lodash": "^4.17.11",
+        "cloudinary-core": "^2.13.0",
+        "core-js": "^3.30.1",
+        "lodash": "^4.17.21",
         "q": "^1.5.1"
       },
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/cloudinary-core": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/cloudinary-core/-/cloudinary-core-2.13.0.tgz",
+      "integrity": "sha512-Nt0Q5I2FtenmJghtC4YZ3MZZbGg1wLm84SsxcuVwZ83OyJqG9CNIGp86CiI6iDv3QobaqBUpOT7vg+HqY5HxEA==",
+      "peerDependencies": {
+        "lodash": ">=4.0"
       }
     },
     "node_modules/color-contrast": {
@@ -1724,9 +1733,14 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
+      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -8780,14 +8794,21 @@
       }
     },
     "cloudinary": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.22.0.tgz",
-      "integrity": "sha512-qQhSVqGyOWtGbPc3JrwyUXJEZpdqsEzBFSf5+gTo7gbKbXdzEysLagigoSlp6JYI7YW2oEbz4aeZlgN2ucOkzQ==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.40.0.tgz",
+      "integrity": "sha512-Fifkl8NRw/M+Enw4cKCXc6e0Or28c5y6RVGYS3OCLzT1W8EfBt416FURhLuuL/S4BCVv8bSilmnM746kCtth3g==",
       "requires": {
-        "core-js": "^3.6.5",
-        "lodash": "^4.17.11",
+        "cloudinary-core": "^2.13.0",
+        "core-js": "^3.30.1",
+        "lodash": "^4.17.21",
         "q": "^1.5.1"
       }
+    },
+    "cloudinary-core": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/cloudinary-core/-/cloudinary-core-2.13.0.tgz",
+      "integrity": "sha512-Nt0Q5I2FtenmJghtC4YZ3MZZbGg1wLm84SsxcuVwZ83OyJqG9CNIGp86CiI6iDv3QobaqBUpOT7vg+HqY5HxEA==",
+      "requires": {}
     },
     "color-contrast": {
       "version": "1.0.0",
@@ -8909,9 +8930,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
+      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@sentry/node": "^5.30.0",
     "axios": "^0.26.1",
     "base-64": "0.1.0",
-    "cloudinary": "1.22.0",
+    "cloudinary": "1.40.0",
     "colornames": "1.1.1",
     "date-fns": "2.15.0",
     "dompurify": "2.2.2",


### PR DESCRIPTION
To reduce Cloudinary costs we want to delete old images. We have a script to do this, which is run every day via a "Heroku scheduler" on origami-image-service-eu. However this script errors due to api limits, it's stuck trying to delete the same images on loop.

- Pass `next_cursor` to Cloudinary search, so the next results are returned correctly.
- Set `keep_original` when deleting images. This will delete only derived images – transforms – not the originals. We don't promise to keep originals and expect the source images to remain available, but I don't want to have to explain that to any angry product teams right now.
- Update logs to help us monitor the script. If it deletes many images and then fails before the script exits, we want to know.

We probably don't want to run this updated script every day as it will have to process every image we have stored, that is older than a month, everyday. This is because it no longer deletes the originals. Let's run this inititally to clear the backlog of old transforms, monitor the duration of future runs, and consider changing the search expression to process a limited range of images such as those uploaded between the last 3-6 months `.expression('uploaded_at:[24w TO 12w]')`.