### PR TITLE
backstage: validate uuid before making requests to internal apis

### DIFF
--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -22,7 +22,6 @@ function getCmsUrl(config) {
 		const cmsId = uriParts.shift();
 		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
     if (!uuidValidate(cmsId)) {
-      // If UUID is not valid, we error
       const error = httpError(400, `Image key ${cmsId} is invalid`);
       error.cacheMaxAge = '5m';
       error.skipSentry = true;

--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -3,6 +3,7 @@
 const httpError = require('http-errors');
 const axios = require('axios').default;
 const createErrorFromAxiosError = require('../create-error-from-axios-error');
+const {validate: uuidValidate} = require('uuid');
 
 module.exports = getCmsUrl;
 
@@ -20,6 +21,13 @@ function getCmsUrl(config) {
 		const uriParts = request.params.imageUrl.split(':').pop().split('?');
 		const cmsId = uriParts.shift();
 		const query = (uriParts.length ? '?' + uriParts.join('?') : '');
+    if (!uuidValidate(cmsId)) {
+      // If UUID is not valid, we error
+      const error = httpError(400, `Image key ${cmsId} is invalid`);
+      error.cacheMaxAge = '5m';
+      error.skipSentry = true;
+      throw error;
+    }
 		const v1Uri = `https://im.ft-static.com/content/images/${cmsId}.img${query}`;
 		const v2Uri = `https://prod-upp-image-read.ft.com/${cmsId}${query}`;
 		const capi = `https://api.ft.com/enrichedcontent/${cmsId}${query}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "statuses": "2.0.0",
         "svg-tint-stream": "1.0.1",
         "throng": "4.0.0",
-        "utf8": "3.0.0"
+        "utf8": "3.0.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "clarify": "^2.1.0",
@@ -3738,6 +3739,16 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
@@ -5893,6 +5904,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/require-all": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/require-all/-/require-all-3.0.0.tgz",
@@ -7114,11 +7134,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -10485,6 +10509,12 @@
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -12193,6 +12223,11 @@
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -13178,9 +13213,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "statuses": "2.0.0",
     "svg-tint-stream": "1.0.1",
     "throng": "4.0.0",
-    "utf8": "3.0.0"
+    "utf8": "3.0.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "clarify": "^2.1.0",

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -3,6 +3,7 @@
 const assert = require('proclaim');
 const axios = require('../helpers/axios');
 const testImageUris = require('../helpers/test-image-uris');
+const {v4: generateUuid} = require('uuid');
 
 const usingExternalServer = Boolean(process.env.HOST);
 const onlyRunOnExternalServer = usingExternalServer ? describe : describe.skip;
@@ -421,7 +422,7 @@ describe('GET /__origami/service/image/v2/images/raw…', function() {
 
 	describe('when a CMS image is not found', function() {
 		it('responds with a 404 status', async function() {
-			const response = await axios.get('/__origami/service/image/v2/images/raw/ftcms:notanid?source=origami-image-service');
+			const response = await axios.get(`/__origami/service/image/v2/images/raw/ftcms:${generateUuid()}?source=origami-image-service`);
 			assert.equal(response.status, 404);
 			assert.equal(response.headers['content-type'], 'text/html; charset=utf-8');
 			assert.match(response.headers['surrogate-key'], /origami-image-service/);

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -2,8 +2,26 @@
 
 const assert = require('proclaim');
 const nock = require('nock');
+const {v4: generateUuid} = require('uuid');
 
-describe('lib/middleware/get-cms-url', () => {
+
+const uuids = {
+  mock1: generateUuid(),
+  mock2: generateUuid(),
+  mock3: generateUuid(),
+  mock4: generateUuid(),
+  mock5: generateUuid(),
+  mock6: generateUuid(),
+  mock7: generateUuid(),
+  mock8: generateUuid(),
+  mock9: generateUuid(),
+  mock10: 'not-a-uuid',
+  mock11: '11-3333-1221213-5553231341',
+  mock12: generateUuid().replace(/^./, '%'),
+  mock13: `${generateUuid}moreText`
+};
+
+describe.only('lib/middleware/get-cms-url', () => {
 	let origamiService;
 	let getCmsUrl;
 	let log;
@@ -39,14 +57,14 @@ describe('lib/middleware/get-cms-url', () => {
 
 		describe('middleware(request, response, next)', () => {
 			let scope;
-			const v2Uri = 'https://prod-upp-image-read.ft.com/mock-id1';
+			const v2Uri = `https://prod-upp-image-read.ft.com/${uuids.mock1}`;
 
 			beforeEach(done => {
-				origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id1';
+				origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock1}`;
 				origamiService.mockRequest.query.source = 'mock-source';
 				origamiService.mockRequest.params.originalImageUrl = 'http://test.example/image.jpg';
 				scope = nock('https://prod-upp-image-read.ft.com').persist();
-				scope.head('/mock-id1').reply(200, 'I am an svg file', {
+				scope.head(`/${uuids.mock1}`).reply(200, 'I am an svg file', {
 					'Content-Type': 'image/svg+xml; charset=utf-8',
 				});
 
@@ -58,26 +76,26 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			it('logs that the CMS ID was found in v2 of the API', () => {
-				assert.isTrue(log.info.calledWithExactly('ftcms-check cmsId=mock-id1 cmsVersionUsed=v2 source=mock-source'));
-				assert.isTrue(log.info.neverCalledWith('ftcms-check cmsId=mock-id1 cmsVersionUsed=v1 source=mock-source'));
-				assert.isTrue(log.info.neverCalledWith('ftcms-check cmsId=mock-id1 cmsVersionUsed=error source=mock-source'));
+				assert.isTrue(log.info.calledWithExactly(`ftcms-check cmsId=${uuids.mock1} cmsVersionUsed=v2 source=mock-source`));
+				assert.isTrue(log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock1} cmsVersionUsed=v1 source=mock-source`));
+				assert.isTrue(log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock1} cmsVersionUsed=error source=mock-source`));
 			});
 
 			describe('when the v2 API cannot find the image', () => {
-				const v1Uri = 'https://im.ft-static.com/content/images/mock-id2.img';
+				const v1Uri = `https://im.ft-static.com/content/images/${uuids.mock2}.img`;
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id2';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock2}`;
 					log.info.resetHistory();
 
 					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
-					nockScopeForV1Images.head('/content/images/mock-id2.img').reply(200, 'I am an svg file', {
+					nockScopeForV1Images.head(`/content/images/${uuids.mock2}.img`).reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
-					nockScopeForV2Images.head('/mock-id2').reply(404, 'I am an svg file', {
+					nockScopeForV2Images.head(`/${uuids.mock2}`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -89,9 +107,9 @@ describe('lib/middleware/get-cms-url', () => {
 				});
 
 				it('logs that the CMS ID was found in v1 of the API', () => {
-					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith('ftcms-check cmsId=mock-id2 cmsVersionUsed=v2 source=mock-source'));
-					assert.isTrue(origamiService.mockApp.ft.log.info.calledWithExactly('ftcms-check cmsId=mock-id2 cmsVersionUsed=v1 source=mock-source'));
-					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith('ftcms-check cmsId=mock-id2 cmsVersionUsed=error source=mock-source'));
+					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock2} cmsVersionUsed=v2 source=mock-source`));
+					assert.isTrue(origamiService.mockApp.ft.log.info.calledWithExactly(`ftcms-check cmsId=${uuids.mock2} cmsVersionUsed=v1 source=mock-source`));
+					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock2} cmsVersionUsed=error source=mock-source`));
 				});
 
 			});
@@ -102,7 +120,7 @@ describe('lib/middleware/get-cms-url', () => {
 				let nockScopeForFallback;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id3';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock3}`;
 					log.info.resetHistory();
 
 					nockScopeForFallback = nock('http://test.example').persist();
@@ -110,11 +128,11 @@ describe('lib/middleware/get-cms-url', () => {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
-					nockScopeForV1Images.head('/content/images/mock-id3.img').reply(404, 'I am an svg file', {
+					nockScopeForV1Images.head(`/content/images/${uuids.mock3}.img`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
-					nockScopeForV2Images.head('/mock-id3').reply(404, 'I am an svg file', {
+					nockScopeForV2Images.head(`/${uuids.mock3}`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -133,7 +151,7 @@ describe('lib/middleware/get-cms-url', () => {
 				let nockScopeForFallback;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id4';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock4}`;
 					log.info.resetHistory();
 
 					nockScopeForFallback = nock('http://test.example').persist();
@@ -141,11 +159,11 @@ describe('lib/middleware/get-cms-url', () => {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
-					nockScopeForV1Images.head('/content/images/mock-id4.img').reply(404, 'I am an svg file', {
+					nockScopeForV1Images.head(`/content/images/${uuids.mock4}.img`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
-					nockScopeForV2Images.head('/mock-id4').reply(404, 'I am an svg file', {
+					nockScopeForV2Images.head(`/${uuids.mock4}`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -157,27 +175,27 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a 404 error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Unable to get image mock-id4 from Content API v1 or v2');
+					assert.strictEqual(responseError.message, `Unable to get image ${uuids.mock4} from Content API v1 or v2`);
 					assert.strictEqual(responseError.status, 404);
 					assert.strictEqual(responseError.cacheMaxAge, '5m');
 				});
 
 				it('logs that the CMS ID was found in neither API', () => {
-					assert.neverCalledWith(origamiService.mockApp.ft.log.info, 'ftcms-check cmsId=mock-id4 cmsVersionUsed=v2 source=mock-source');
-					assert.neverCalledWith(origamiService.mockApp.ft.log.info, 'ftcms-check cmsId=mock-id4 cmsVersionUsed=v1 source=mock-source');
-					assert.calledWithExactly(origamiService.mockApp.ft.log.info, 'ftcms-check cmsId=mock-id4 cmsVersionUsed=error source=mock-source');
+					assert.neverCalledWith(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${uuids.mock4} cmsVersionUsed=v2 source=mock-source`);
+					assert.neverCalledWith(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${uuids.mock4} cmsVersionUsed=v1 source=mock-source`);
+					assert.calledWithExactly(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${uuids.mock4} cmsVersionUsed=error source=mock-source`);
 				});
 
 			});
 
 			describe('when the ftcms URL has a querystring', () => {
-				const v2Uri = 'https://prod-upp-image-read.ft.com/mock-id5?foo=bar';
+				const v2Uri = `https://prod-upp-image-read.ft.com/${uuids.mock5}?foo=bar`;
 				let scope;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id5?foo=bar';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock5}?foo=bar`;
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head('/mock-id5?foo=bar').reply(200, 'I am an svg file', {
+					scope.head(`/${uuids.mock5}?foo=bar`).reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -208,10 +226,10 @@ describe('lib/middleware/get-cms-url', () => {
 				let scope;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id6';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock6}`;
 
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head('/mock-id6').replyWithError(new Error('mock error'));
+					scope.head(`/${uuids.mock6}`).replyWithError(new Error('mock error'));
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -232,13 +250,13 @@ describe('lib/middleware/get-cms-url', () => {
 				let scope;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id7';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock7}`;
 
 					// V2 errors
 					dnsError = new Error('mock error');
 					dnsError.code = 'ENOTFOUND';
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head('/mock-id7').replyWithError(dnsError);
+					scope.head(`/${uuids.mock7}`).replyWithError(dnsError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -248,7 +266,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'DNS lookup failed for "https://prod-upp-image-read.ft.com/mock-id7"');
+					assert.strictEqual(responseError.message, `DNS lookup failed for "https://prod-upp-image-read.ft.com/${uuids.mock7}"`);
 				});
 
 			});
@@ -260,13 +278,13 @@ describe('lib/middleware/get-cms-url', () => {
 
 				beforeEach(done => {
 					origamiService.mockRequest.url = 'mock-url';
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id8';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock8}`;
 
 					// V2 errors
 					resetError = new Error('mock error');
 					resetError.code = 'ECONNRESET';
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head('/mock-id8').replyWithError(resetError);
+					scope.head(`/${uuids.mock8}`).replyWithError(resetError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -276,7 +294,7 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Connection reset when requesting "https://prod-upp-image-read.ft.com/mock-id8"');
+					assert.strictEqual(responseError.message, `Connection reset when requesting "https://prod-upp-image-read.ft.com/${uuids.mock8}"`);
 				});
 
 			});
@@ -288,13 +306,13 @@ describe('lib/middleware/get-cms-url', () => {
 
 				beforeEach(done => {
 					origamiService.mockRequest.url = 'mock-url';
-					origamiService.mockRequest.params.imageUrl = 'ftcms:mock-id9';
+					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock9}`;
 
 					// V2 errors
 					timeoutError = new Error('mock error');
 					timeoutError.code = 'ETIMEDOUT';
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head('/mock-id9').replyWithError(timeoutError);
+					scope.head(`/${uuids.mock9}`).replyWithError(timeoutError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -304,9 +322,32 @@ describe('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, 'Request timed out when requesting "https://prod-upp-image-read.ft.com/mock-id9"');
+					assert.strictEqual(responseError.message, `Request timed out when requesting "https://prod-upp-image-read.ft.com/${uuids.mock9}"`);
 				});
 			});
+
+      describe('throws an error when UUID', () => {
+        it('is a random string with dashes', () => {
+          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock10}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock10} is invalid`);
+        });
+        it('is a random numbers with dashes', () => {
+          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock11}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock11} is invalid`);
+        
+        });
+        it('is a string with special character in it', () => {
+          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock12}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock12} is invalid`);
+        
+        });
+
+        it('has a random string after valid uuid', () => {
+          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock13}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock13} is invalid`);
+        
+        });
+      });
 		});
 	});
 });

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -4,24 +4,7 @@ const assert = require('proclaim');
 const nock = require('nock');
 const {v4: generateUuid} = require('uuid');
 
-
-const uuids = {
-  mock1: generateUuid(),
-  mock2: generateUuid(),
-  mock3: generateUuid(),
-  mock4: generateUuid(),
-  mock5: generateUuid(),
-  mock6: generateUuid(),
-  mock7: generateUuid(),
-  mock8: generateUuid(),
-  mock9: generateUuid(),
-  mock10: 'not-a-uuid',
-  mock11: '11-3333-1221213-5553231341',
-  mock12: generateUuid().replace(/^./, '%'),
-  mock13: `${generateUuid}moreText`
-};
-
-describe.only('lib/middleware/get-cms-url', () => {
+describe('lib/middleware/get-cms-url', () => {
 	let origamiService;
 	let getCmsUrl;
 	let log;
@@ -56,46 +39,48 @@ describe.only('lib/middleware/get-cms-url', () => {
 		});
 
 		describe('middleware(request, response, next)', () => {
-			let scope;
-			const v2Uri = `https://prod-upp-image-read.ft.com/${uuids.mock1}`;
+      const imageUuid = generateUuid();
+      let scope;
+      const v2Uri = `https://prod-upp-image-read.ft.com/${imageUuid}`;
 
-			beforeEach(done => {
-				origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock1}`;
-				origamiService.mockRequest.query.source = 'mock-source';
-				origamiService.mockRequest.params.originalImageUrl = 'http://test.example/image.jpg';
-				scope = nock('https://prod-upp-image-read.ft.com').persist();
-				scope.head(`/${uuids.mock1}`).reply(200, 'I am an svg file', {
-					'Content-Type': 'image/svg+xml; charset=utf-8',
-				});
+      beforeEach(done => {
+        origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
+        origamiService.mockRequest.query.source = 'mock-source';
+        origamiService.mockRequest.params.originalImageUrl = 'http://test.example/image.jpg';
+        scope = nock('https://prod-upp-image-read.ft.com').persist();
+        scope.head(`/${imageUuid}`).reply(200, 'I am an svg file', {
+          'Content-Type': 'image/svg+xml; charset=utf-8',
+        });
 
-				middleware(origamiService.mockRequest, origamiService.mockResponse, done);
-			});
+        middleware(origamiService.mockRequest, origamiService.mockResponse, done);
+      });
 
-			it('sets the `imageUrl` request param to the v2 API URL corresponding to the CMS ID', () => {
-				assert.strictEqual(origamiService.mockRequest.params.imageUrl, v2Uri);
-			});
+      it('sets the `imageUrl` request param to the v2 API URL corresponding to the CMS ID', () => {
+        assert.strictEqual(origamiService.mockRequest.params.imageUrl, v2Uri);
+      });
 
-			it('logs that the CMS ID was found in v2 of the API', () => {
-				assert.isTrue(log.info.calledWithExactly(`ftcms-check cmsId=${uuids.mock1} cmsVersionUsed=v2 source=mock-source`));
-				assert.isTrue(log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock1} cmsVersionUsed=v1 source=mock-source`));
-				assert.isTrue(log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock1} cmsVersionUsed=error source=mock-source`));
-			});
+      it('logs that the CMS ID was found in v2 of the API', () => {
+        assert.isTrue(log.info.calledWithExactly(`ftcms-check cmsId=${imageUuid} cmsVersionUsed=v2 source=mock-source`));
+        assert.isTrue(log.info.neverCalledWith(`ftcms-check cmsId=${imageUuid} cmsVersionUsed=v1 source=mock-source`));
+        assert.isTrue(log.info.neverCalledWith(`ftcms-check cmsId=${imageUuid} cmsVersionUsed=error source=mock-source`));
+      });
 
 			describe('when the v2 API cannot find the image', () => {
-				const v1Uri = `https://im.ft-static.com/content/images/${uuids.mock2}.img`;
+        const imageUuid = generateUuid();
+				const v1Uri = `https://im.ft-static.com/content/images/${imageUuid}.img`;
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock2}`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
 					log.info.resetHistory();
 
 					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
-					nockScopeForV1Images.head(`/content/images/${uuids.mock2}.img`).reply(200, 'I am an svg file', {
+					nockScopeForV1Images.head(`/content/images/${imageUuid}.img`).reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
-					nockScopeForV2Images.head(`/${uuids.mock2}`).reply(404, 'I am an svg file', {
+					nockScopeForV2Images.head(`/${imageUuid}`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -107,20 +92,21 @@ describe.only('lib/middleware/get-cms-url', () => {
 				});
 
 				it('logs that the CMS ID was found in v1 of the API', () => {
-					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock2} cmsVersionUsed=v2 source=mock-source`));
-					assert.isTrue(origamiService.mockApp.ft.log.info.calledWithExactly(`ftcms-check cmsId=${uuids.mock2} cmsVersionUsed=v1 source=mock-source`));
-					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith(`ftcms-check cmsId=${uuids.mock2} cmsVersionUsed=error source=mock-source`));
+					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith(`ftcms-check cmsId=${imageUuid} cmsVersionUsed=v2 source=mock-source`));
+					assert.isTrue(origamiService.mockApp.ft.log.info.calledWithExactly(`ftcms-check cmsId=${imageUuid} cmsVersionUsed=v1 source=mock-source`));
+					assert.isTrue(origamiService.mockApp.ft.log.info.neverCalledWith(`ftcms-check cmsId=${imageUuid} cmsVersionUsed=error source=mock-source`));
 				});
 
 			});
 
 			describe('when neither the v1 or v2 API can find the image', () => {
+        const imageUuid = generateUuid();
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
 				let nockScopeForFallback;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock3}`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
 					log.info.resetHistory();
 
 					nockScopeForFallback = nock('http://test.example').persist();
@@ -128,11 +114,11 @@ describe.only('lib/middleware/get-cms-url', () => {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
-					nockScopeForV1Images.head(`/content/images/${uuids.mock3}.img`).reply(404, 'I am an svg file', {
+					nockScopeForV1Images.head(`/content/images/${imageUuid}.img`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
-					nockScopeForV2Images.head(`/${uuids.mock3}`).reply(404, 'I am an svg file', {
+					nockScopeForV2Images.head(`/${imageUuid}`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -145,13 +131,14 @@ describe.only('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when neither the v1, v2 API can find the image and the original image url does not exist', () => {
+        const imageUuid = generateUuid();
 				let responseError;
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
 				let nockScopeForFallback;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock4}`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
 					log.info.resetHistory();
 
 					nockScopeForFallback = nock('http://test.example').persist();
@@ -159,11 +146,11 @@ describe.only('lib/middleware/get-cms-url', () => {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV1Images = nock('https://im.ft-static.com').persist();
-					nockScopeForV1Images.head(`/content/images/${uuids.mock4}.img`).reply(404, 'I am an svg file', {
+					nockScopeForV1Images.head(`/content/images/${imageUuid}.img`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 					nockScopeForV2Images = nock('https://prod-upp-image-read.ft.com').persist();
-					nockScopeForV2Images.head(`/${uuids.mock4}`).reply(404, 'I am an svg file', {
+					nockScopeForV2Images.head(`/${imageUuid}`).reply(404, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -175,27 +162,28 @@ describe.only('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a 404 error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, `Unable to get image ${uuids.mock4} from Content API v1 or v2`);
+					assert.strictEqual(responseError.message, `Unable to get image ${imageUuid} from Content API v1 or v2`);
 					assert.strictEqual(responseError.status, 404);
 					assert.strictEqual(responseError.cacheMaxAge, '5m');
 				});
 
 				it('logs that the CMS ID was found in neither API', () => {
-					assert.neverCalledWith(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${uuids.mock4} cmsVersionUsed=v2 source=mock-source`);
-					assert.neverCalledWith(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${uuids.mock4} cmsVersionUsed=v1 source=mock-source`);
-					assert.calledWithExactly(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${uuids.mock4} cmsVersionUsed=error source=mock-source`);
+					assert.neverCalledWith(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${imageUuid} cmsVersionUsed=v2 source=mock-source`);
+					assert.neverCalledWith(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${imageUuid} cmsVersionUsed=v1 source=mock-source`);
+					assert.calledWithExactly(origamiService.mockApp.ft.log.info, `ftcms-check cmsId=${imageUuid} cmsVersionUsed=error source=mock-source`);
 				});
 
 			});
 
 			describe('when the ftcms URL has a querystring', () => {
-				const v2Uri = `https://prod-upp-image-read.ft.com/${uuids.mock5}?foo=bar`;
+        const imageUuid = generateUuid();
+				const v2Uri = `https://prod-upp-image-read.ft.com/${imageUuid}?foo=bar`;
 				let scope;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock5}?foo=bar`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}?foo=bar`;
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head(`/${uuids.mock5}?foo=bar`).reply(200, 'I am an svg file', {
+					scope.head(`/${imageUuid}?foo=bar`).reply(200, 'I am an svg file', {
 						'Content-Type': 'image/svg+xml; charset=utf-8',
 					});
 
@@ -222,14 +210,15 @@ describe.only('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the request errors', () => {
+        const imageUuid = generateUuid();
 				let responseError;
 				let scope;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock6}`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
 
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head(`/${uuids.mock6}`).replyWithError(new Error('mock error'));
+					scope.head(`/${imageUuid}`).replyWithError(new Error('mock error'));
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -245,18 +234,19 @@ describe.only('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the request fails a DNS lookup', () => {
+        const imageUuid = generateUuid();
 				let dnsError;
 				let responseError;
 				let scope;
 
 				beforeEach(done => {
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock7}`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
 
 					// V2 errors
 					dnsError = new Error('mock error');
 					dnsError.code = 'ENOTFOUND';
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head(`/${uuids.mock7}`).replyWithError(dnsError);
+					scope.head(`/${imageUuid}`).replyWithError(dnsError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -266,25 +256,26 @@ describe.only('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, `DNS lookup failed for "https://prod-upp-image-read.ft.com/${uuids.mock7}"`);
+					assert.strictEqual(responseError.message, `DNS lookup failed for "https://prod-upp-image-read.ft.com/${imageUuid}"`);
 				});
 
 			});
 
 			describe('when the request connection resets', () => {
+        const imageUuid = generateUuid();
 				let resetError;
 				let responseError;
 				let scope;
 
 				beforeEach(done => {
 					origamiService.mockRequest.url = 'mock-url';
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock8}`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
 
 					// V2 errors
 					resetError = new Error('mock error');
 					resetError.code = 'ECONNRESET';
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head(`/${uuids.mock8}`).replyWithError(resetError);
+					scope.head(`/${imageUuid}`).replyWithError(resetError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -294,25 +285,26 @@ describe.only('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, `Connection reset when requesting "https://prod-upp-image-read.ft.com/${uuids.mock8}"`);
+					assert.strictEqual(responseError.message, `Connection reset when requesting "https://prod-upp-image-read.ft.com/${imageUuid}"`);
 				});
 
 			});
 
 			describe('when the request times out', () => {
+        const imageUuid = generateUuid();
 				let responseError;
 				let timeoutError;
 				let scope;
 
 				beforeEach(done => {
 					origamiService.mockRequest.url = 'mock-url';
-					origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock9}`;
+					origamiService.mockRequest.params.imageUrl = `ftcms:${imageUuid}`;
 
 					// V2 errors
 					timeoutError = new Error('mock error');
 					timeoutError.code = 'ETIMEDOUT';
 					scope = nock('https://prod-upp-image-read.ft.com').persist();
-					scope.head(`/${uuids.mock9}`).replyWithError(timeoutError);
+					scope.head(`/${imageUuid}`).replyWithError(timeoutError);
 
 					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
 						responseError = error;
@@ -322,30 +314,32 @@ describe.only('lib/middleware/get-cms-url', () => {
 
 				it('calls `next` with a descriptive error', () => {
 					assert.instanceOf(responseError, Error);
-					assert.strictEqual(responseError.message, `Request timed out when requesting "https://prod-upp-image-read.ft.com/${uuids.mock9}"`);
+					assert.strictEqual(responseError.message, `Request timed out when requesting "https://prod-upp-image-read.ft.com/${imageUuid}"`);
 				});
 			});
 
       describe('throws an error when UUID', () => {
         it('is a random string with dashes', () => {
-          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock10}`;
-          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock10} is invalid`);
+          const invalidImageUuid = 'not-a-uuid';
+          origamiService.mockRequest.params.imageUrl = `ftcms:${invalidImageUuid}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${invalidImageUuid} is invalid`);
         });
         it('is a random numbers with dashes', () => {
-          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock11}`;
-          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock11} is invalid`);
+          const invalidImageUuid = '11-3333-1221213-5553231341';
+          origamiService.mockRequest.params.imageUrl = `ftcms:${invalidImageUuid}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${invalidImageUuid} is invalid`);
         
         });
         it('is a string with special character in it', () => {
-          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock12}`;
-          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock12} is invalid`);
-        
+          const invalidImageUuid = generateUuid().replace(/./g, '%');
+          origamiService.mockRequest.params.imageUrl = `ftcms:${invalidImageUuid}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${invalidImageUuid} is invalid`);
         });
 
         it('has a random string after valid uuid', () => {
-          origamiService.mockRequest.params.imageUrl = `ftcms:${uuids.mock13}`;
-          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${uuids.mock13} is invalid`);
-        
+          const invalidImageUuid = `${generateUuid}moreText`;
+          origamiService.mockRequest.params.imageUrl = `ftcms:${invalidImageUuid}`;
+          assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), `Image key ${invalidImageUuid} is invalid`);
         });
       });
 		});


### PR DESCRIPTION
We are using [uuid](https://www.npmjs.com/package/uuid) to validate img uuids passed to the image service. It seems that all our internal APIs use the same structure for generating UUIDs and this library should be enough to validate if img UUIDs are valid or not. 

From manually testing and making a few requests to image service seems to work and we return 400 before we make malicious requests to internal APIs.