### PR TITLE
feat: overlay images.

### DIFF
--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -177,7 +177,7 @@ function createProxy(errorHandler) {
 		const encodeKeys = (key = '') => base64.encode(utf8.encode(key));
 
 		if (request.query?.overlay){
-			proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} overlay-${encodeKeys(normaliseKeys(keyForImageType))} ${encodeKeys(normaliseKeys(keyForScheme))} ${encodeKeys(request.params.schemeUrl)}`;
+			proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} ${encodeKeys(normaliseKeys(keyForImageType))} ${encodeKeys(normaliseKeys(keyForScheme))} ${encodeKeys(request.params.schemeUrl)} ${encodeKeys('overlay-'+request.query.overlay)}`;
 		} else {
 			proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} ${encodeKeys(normaliseKeys(keyForImageType))} ${encodeKeys(normaliseKeys(keyForScheme))} ${encodeKeys(request.params.schemeUrl)}`;
 		}

--- a/lib/image-service.js
+++ b/lib/image-service.js
@@ -176,7 +176,11 @@ function createProxy(errorHandler) {
 		const normaliseKeys = (key = '') => key.toLowerCase();
 		const encodeKeys = (key = '') => base64.encode(utf8.encode(key));
 
-		proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} ${encodeKeys(normaliseKeys(keyForImageType))} ${encodeKeys(normaliseKeys(keyForScheme))} ${encodeKeys(request.params.schemeUrl)}`;
+		if (request.query?.overlay){
+			proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} overlay-${encodeKeys(normaliseKeys(keyForImageType))} ${encodeKeys(normaliseKeys(keyForScheme))} ${encodeKeys(request.params.schemeUrl)}`;
+		} else {
+			proxyResponse.headers['Surrogate-Key'] = `${keyForAllImages} ${encodeKeys(normaliseKeys(keyForImageType))} ${encodeKeys(normaliseKeys(keyForScheme))} ${encodeKeys(request.params.schemeUrl)}`;
+		}
 
 		if (request.transform && request.transform.getDpr()) {
 			proxyResponse.headers['Content-Dpr'] = request.transform.getDpr();

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -63,6 +63,7 @@ module.exports = class ImageTransform {
 			this.setOverlayX(properties.overlay_x);
 			this.setOverlayY(properties.overlay_y);
 			this.setOverlayGravity(properties.overlay_gravity);
+			this.setOverlayCrop(properties.overlay_crop);
 		}
 	}
 
@@ -184,7 +185,26 @@ module.exports = class ImageTransform {
 	 */
 
 	setOverlayGravity(value) {
-		this.overlay_gravity = value ? value : 'south_east';
+		const errorMessage = `Overlay gravity must be one of ${ImageTransform.validOverlayGravities.join(', ')}`;
+		this.overlay_gravity = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validOverlayGravities, errorMessage);
+	}
+
+	/**
+	 * Get the overlay crop.
+	 * @return {String}
+	 */
+	getOverlayCrop() {
+		return this.overlay_crop;
+	}
+
+	/**
+	 * Set the overlay crop
+	 * @param {String} value
+	 */
+
+	setOverlayCrop(value) {
+		const errorMessage = `Overlay crop must be one of ${ImageTransform.validOverlayCrops.join(', ')}`;
+		this.overlay_crop = ImageTransform.sanitizeEnumerableValue(value, ImageTransform.validOverlayCrops, errorMessage);
 	}
 
 
@@ -771,6 +791,37 @@ module.exports = class ImageTransform {
 		return [
 			'faces',
 			'poi'
+		];
+	}
+
+	/**
+	 * @private
+	 */
+	static get validOverlayGravities() {
+		return [
+			'south_east',
+			'north_west',
+			'south_west',
+			'north_east'
+		];
+	}
+
+	static get validOverlayCrops() {
+		return [
+			'scale',
+			'fill',
+			'crop',
+			'fill_pad',
+			'fit',
+			'imagga_crop',
+			'imagga_scale',
+			'lfill',
+			'limit',
+			'lpad',
+			'mfit',
+			'mpad',
+			'pad',
+			'thumb'
 		];
 	}
 

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -34,13 +34,11 @@ module.exports = class ImageTransform {
 	 * @param {String} [properties.format=auto] - The file format of the transformed image. One of auto, jpg, png, svg.
 	 * @param {String} [properties.bgcolor] - A background color to apply to the transformed image (if transparent). Hex code or named color.
 	 * @param {String} [properties.overlay] - THE URI of an overlay image.
-	 * @param {String} [properties.overlay_position] - Position o the overlay image. Defaults to 'relative'.
 	 * @param {String} [properties.overlay_width] - Width of the overlay image. Defaults to an empty string.
 	 * @param {String} [properties.overlay_height] - Height of the overlay image. Defaults to an empty string.
 	 * @param {String} [properties.overlay_x] - X position of the overlay image. Defaults to 0.
 	 * @param {String} [properties.overlay_y] - Y position of the overlay image. Defaults to 0.
 	 * @param {String} [properties.overlay_gravity] - Gravity of the overlay image. Defaults to 'south_east'.
-	 * @param {String} [properties.overlay_crop] - Crop of the overlay image. Defaults to 'scale';
 	 */
 	constructor(properties) {
 		if (properties.uri) {
@@ -57,16 +55,14 @@ module.exports = class ImageTransform {
 		this.setFormat(properties.format);
 		this.setBgcolor(properties.bgcolor);
 		this.setTint(properties.tint);
-		
+
 		if (properties.overlay) {
 			this.setOverlay(properties.overlay);
-			this.setOverlayPosition(properties.overlay_position);
 			this.setOverlayWidth(properties.overlay_width);
 			this.setOverlayHeight(properties.overlay_height);
 			this.setOverlayX(properties.overlay_x);
 			this.setOverlayY(properties.overlay_y);
 			this.setOverlayGravity(properties.overlay_gravity);
-			this.setOverlayCrop(properties.overlay_crop);
 		}
 	}
 
@@ -87,50 +83,34 @@ module.exports = class ImageTransform {
 		this.uri = ImageTransform.sanitizeUriValue(value, errorMessage);
 	}
 
-		/**
-	 * Get the overlay.
-	 * @return {String}
-	 */
-		getOverlay() {
-			return this.overlay;
-		}
-	
-		/**
-		 * Set the overlay
-		 * @param {String} value - The URI.
-		 */
-		setOverlay(value) {
-			this.overlay = value ? value : false;
-		}
-
-
-		/**
-	 * Get the overlay position.
-	 * @return {String}
-	 */
-	getOverlayPosition() {
-		return this.overlay_position;
+	/**
+ * Get the overlay.
+ * @return {String}
+ */
+	getOverlay() {
+		return this.overlay;
 	}
 
 	/**
-	 * Set the overlay position
+	 * Set the overlay
 	 * @param {String} value - The URI.
 	 */
-	setOverlayPosition(value) {
-		this.overlay_position = value ? value : 'relative';
+	setOverlay(value) {
+		this.overlay = value ? value : false;
 	}
 
+
 	/**
-		 * Get the overlay width.
-		 * @return {String}
-		 */
+	 * Get the overlay width.
+	 * @return {String | Number}
+	 */
 	getOverlayWidth() {
 		return this.overlay_width;
 	}
 
 	/**
 	 * Set the overlay width
-	 * @param {String} value 
+	 * @param {String | Number} value 
 	 */
 
 	setOverlayWidth(value) {
@@ -139,16 +119,16 @@ module.exports = class ImageTransform {
 	}
 
 	/**
-		 * Get the overlay height.
-		 * @return {String}
-		 */
+	 * Get the overlay height.
+	 * @return {String | Number}
+	 */
 	getOverlayHeight() {
 		return this.overlay_height;
 	}
 
 	/**
 	 * Set the overlay height
-	 * @param {String} value 
+	 * @param {String | Number} value 
 	 */
 
 	setOverlayHeight(value) {
@@ -158,16 +138,16 @@ module.exports = class ImageTransform {
 
 
 	/**
-		 * Get the overlay x.
-		 * @return {String}
-		 */
+	 * Get the overlay x.
+	 * @return {String | Number}
+	 */
 	getOverlayX() {
 		return this.overlay_x;
 	}
 
 	/**
 	 * Set the overlay x
-	 * @param {String} value 
+	 * @param {String | Number} value 
 	 */
 
 	setOverlayX(value) {
@@ -176,16 +156,16 @@ module.exports = class ImageTransform {
 	}
 
 	/**
-		 * Get the overlay y.
-		 * @return {String}
-		 */
+	 * Get the overlay y.
+	 * @return {String | Number}
+	 */
 	getOverlayY() {
 		return this.overlay_y;
 	}
 
 	/**
 	 * Set the overlay y
-	 * @param {String} value 
+	 * @param {String | Number} value 
 	 */
 
 	setOverlayY(value) {
@@ -193,22 +173,6 @@ module.exports = class ImageTransform {
 		this.overlay_y = value ? value : 0;
 	}
 
-	/**
-	 * Get the overlay crop.
-	 * @return {String}
-	 */
-	getOverlayCrop() {
-		return this.overlay_crop;
-	}
-
-	/**
-	 * Set the overlay crop
-	 * @param {String} value
-	 */
-
-	setOverlayCrop(value) {
-		this.overlay_crop = value ? value : 'scale';
-	}
 
 	/**
 	 * Get the overlay gravity.

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -33,6 +33,14 @@ module.exports = class ImageTransform {
 	 * @param {String} [properties.quality=medium] - The compression quality of the transformed image. One of lowest, low, medium, high, highest, lossless.
 	 * @param {String} [properties.format=auto] - The file format of the transformed image. One of auto, jpg, png, svg.
 	 * @param {String} [properties.bgcolor] - A background color to apply to the transformed image (if transparent). Hex code or named color.
+	 * @param {String} [properties.overlay] - THE URI of an overlay image.
+	 * @param {String} [properties.overlay_position] - Position o the overlay image. Defaults to 'relative'.
+	 * @param {String} [properties.overlay_width] - Width of the overlay image. Defaults to an empty string.
+	 * @param {String} [properties.overlay_height] - Height of the overlay image. Defaults to an empty string.
+	 * @param {String} [properties.overlay_x] - X position of the overlay image. Defaults to 0.
+	 * @param {String} [properties.overlay_y] - Y position of the overlay image. Defaults to 0.
+	 * @param {String} [properties.overlay_gravity] - Gravity of the overlay image. Defaults to 'south_east'.
+	 * @param {String} [properties.overlay_crop] - Crop of the overlay image. Defaults to 'scale';
 	 */
 	constructor(properties) {
 		if (properties.uri) {
@@ -49,15 +57,17 @@ module.exports = class ImageTransform {
 		this.setFormat(properties.format);
 		this.setBgcolor(properties.bgcolor);
 		this.setTint(properties.tint);
-		this.setOverlay(properties.overlay);
-		this.setOverlayPosition(properties.overlay_position);
-		this.setOverlayWidth(properties.overlay_width);
-		this.setOverlayHeight(properties.overlay_height);
-		this.setOverlayX(properties.overlay_x);
-		this.setOverlayY(properties.overlay_y);
-		this.setOverlayGravity(properties.overlay_gravity);
-		this.setOverlayCrop(properties.overlay_crop);
 		
+		if (properties.overlay) {
+			this.setOverlay(properties.overlay);
+			this.setOverlayPosition(properties.overlay_position);
+			this.setOverlayWidth(properties.overlay_width);
+			this.setOverlayHeight(properties.overlay_height);
+			this.setOverlayX(properties.overlay_x);
+			this.setOverlayY(properties.overlay_y);
+			this.setOverlayGravity(properties.overlay_gravity);
+			this.setOverlayCrop(properties.overlay_crop);
+		}
 	}
 
 	/**
@@ -197,8 +207,7 @@ module.exports = class ImageTransform {
 	 */
 
 	setOverlayCrop(value) {
-		// the cloudinary api will ignore an empty string
-		this.overlay_crop = value ? value : '';
+		this.overlay_crop = value ? value : 'scale';
 	}
 
 	/**

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -809,19 +809,7 @@ module.exports = class ImageTransform {
 	static get validOverlayCrops() {
 		return [
 			'scale',
-			'fill',
-			'crop',
-			'fill_pad',
-			'fit',
-			'imagga_crop',
-			'imagga_scale',
-			'lfill',
-			'limit',
-			'lpad',
-			'mfit',
-			'mpad',
-			'pad',
-			'thumb'
+			'crop'
 		];
 	}
 

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -114,8 +114,7 @@ module.exports = class ImageTransform {
 	 */
 
 	setOverlayWidth(value) {
-		// the cloudinary api will ignore an empty string
-		this.overlay_width = value ? value : '';
+		this.overlay_width = value;
 	}
 
 	/**
@@ -132,8 +131,7 @@ module.exports = class ImageTransform {
 	 */
 
 	setOverlayHeight(value) {
-		// the cloudinary api will ignore an empty string
-		this.overlay_height = value ? value : '';
+		this.overlay_height = value;
 	}
 
 
@@ -151,8 +149,7 @@ module.exports = class ImageTransform {
 	 */
 
 	setOverlayX(value) {
-		// the cloudinary api will ignore an empty string
-		this.overlay_x = value ? value : 0;
+		this.overlay_x = value;
 	}
 
 	/**
@@ -169,8 +166,7 @@ module.exports = class ImageTransform {
 	 */
 
 	setOverlayY(value) {
-		// the cloudinary api will ignore an empty string
-		this.overlay_y = value ? value : 0;
+		this.overlay_y = value;
 	}
 
 
@@ -190,7 +186,7 @@ module.exports = class ImageTransform {
 	setOverlayGravity(value) {
 		this.overlay_gravity = value ? value : 'south_east';
 	}
-	
+
 
 	/**
 	 * Get the width of the transformed image in pixels.

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -49,6 +49,8 @@ module.exports = class ImageTransform {
 		this.setFormat(properties.format);
 		this.setBgcolor(properties.bgcolor);
 		this.setTint(properties.tint);
+		this.setOverlay(properties.overlay);
+
 	}
 
 	/**
@@ -67,6 +69,22 @@ module.exports = class ImageTransform {
 		const errorMessage = 'Image URI must be a string with a valid scheme';
 		this.uri = ImageTransform.sanitizeUriValue(value, errorMessage);
 	}
+
+		/**
+	 * Get the overlay.
+	 * @return {String}
+	 */
+		getOverlay() {
+			return this.overlay;
+		}
+	
+		/**
+		 * Set the overlay
+		 * @param {String} value - The URI.
+		 */
+		setOverlay(value) {
+			this.overlay = value ? value : false;
+		}
 
 	/**
 	 * Get the width of the transformed image in pixels.

--- a/lib/image-transform.js
+++ b/lib/image-transform.js
@@ -50,7 +50,14 @@ module.exports = class ImageTransform {
 		this.setBgcolor(properties.bgcolor);
 		this.setTint(properties.tint);
 		this.setOverlay(properties.overlay);
-
+		this.setOverlayPosition(properties.overlay_position);
+		this.setOverlayWidth(properties.overlay_width);
+		this.setOverlayHeight(properties.overlay_height);
+		this.setOverlayX(properties.overlay_x);
+		this.setOverlayY(properties.overlay_y);
+		this.setOverlayGravity(properties.overlay_gravity);
+		this.setOverlayCrop(properties.overlay_crop);
+		
 	}
 
 	/**
@@ -85,6 +92,132 @@ module.exports = class ImageTransform {
 		setOverlay(value) {
 			this.overlay = value ? value : false;
 		}
+
+
+		/**
+	 * Get the overlay position.
+	 * @return {String}
+	 */
+	getOverlayPosition() {
+		return this.overlay_position;
+	}
+
+	/**
+	 * Set the overlay position
+	 * @param {String} value - The URI.
+	 */
+	setOverlayPosition(value) {
+		this.overlay_position = value ? value : 'relative';
+	}
+
+	/**
+		 * Get the overlay width.
+		 * @return {String}
+		 */
+	getOverlayWidth() {
+		return this.overlay_width;
+	}
+
+	/**
+	 * Set the overlay width
+	 * @param {String} value 
+	 */
+
+	setOverlayWidth(value) {
+		// the cloudinary api will ignore an empty string
+		this.overlay_width = value ? value : '';
+	}
+
+	/**
+		 * Get the overlay height.
+		 * @return {String}
+		 */
+	getOverlayHeight() {
+		return this.overlay_height;
+	}
+
+	/**
+	 * Set the overlay height
+	 * @param {String} value 
+	 */
+
+	setOverlayHeight(value) {
+		// the cloudinary api will ignore an empty string
+		this.overlay_height = value ? value : '';
+	}
+
+
+	/**
+		 * Get the overlay x.
+		 * @return {String}
+		 */
+	getOverlayX() {
+		return this.overlay_x;
+	}
+
+	/**
+	 * Set the overlay x
+	 * @param {String} value 
+	 */
+
+	setOverlayX(value) {
+		// the cloudinary api will ignore an empty string
+		this.overlay_x = value ? value : 0;
+	}
+
+	/**
+		 * Get the overlay y.
+		 * @return {String}
+		 */
+	getOverlayY() {
+		return this.overlay_y;
+	}
+
+	/**
+	 * Set the overlay y
+	 * @param {String} value 
+	 */
+
+	setOverlayY(value) {
+		// the cloudinary api will ignore an empty string
+		this.overlay_y = value ? value : 0;
+	}
+
+	/**
+	 * Get the overlay crop.
+	 * @return {String}
+	 */
+	getOverlayCrop() {
+		return this.overlay_crop;
+	}
+
+	/**
+	 * Set the overlay crop
+	 * @param {String} value
+	 */
+
+	setOverlayCrop(value) {
+		// the cloudinary api will ignore an empty string
+		this.overlay_crop = value ? value : '';
+	}
+
+	/**
+	 * Get the overlay gravity.
+	 * @return {String}
+	 */
+	getOverlayGravity() {
+		return this.overlay_gravity;
+	}
+
+	/**
+	 * Set the overlay gravity
+	 * @param {String} value
+	 */
+
+	setOverlayGravity(value) {
+		this.overlay_gravity = value ? value : 'south_east';
+	}
+	
 
 	/**
 	 * Get the width of the transformed image in pixels.

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -50,11 +50,30 @@ function buildCloudinaryTransforms(transform) {
 		cloudinaryTransforms.effect = `tint:100:${tint.join(':')}`;
 	}
 
+	const overlay = transform.getOverlay();
+
 	const immutable = transform.getImmutable();
 	if (immutable) {
 		cloudinaryTransforms.flags.push('immutable_cache');
 	}
-	return cloudinaryTransforms;
+
+	if (overlay) {
+
+		let overlayTransform = [];
+
+		overlayTransform.push(
+			{ overlay: { 'url': overlay } },
+			{ flags: "relative", height: "0.10", crop: "scale" },
+			{ flags: ["layer_apply", "no_overflow"],
+			gravity: "south_east", x: 0, y: 30 }
+		)
+
+		return {transformation: [cloudinaryTransforms, overlayTransform]}
+	} else {
+		return cloudinaryTransforms;
+	}
+
+
 }
 
 function getCloudinaryCropStrategy(cropStrategy) {

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -61,20 +61,18 @@ function buildCloudinaryTransforms(transform) {
 
 	if (overlay) {
 
-		const overlayPosition = transform.getOverlayPosition();
 		const overlayHeight = transform.getOverlayHeight();
 		const overlayWidth = transform.getOverlayWidth();
 		const overlayX = transform.getOverlayX();
 		const overlayY = transform.getOverlayY();
 		const overlayGravity = transform.getOverlayGravity();
-		const overlayCrop = transform.getOverlayCrop();
 
 		const overlayTransform = [];
 
 		overlayTransform.push(
 			{ overlay: { 'url': overlay } },
 			// relative flag as it's sized relative to the parent image
-			{ flags: overlayPosition, height: overlayHeight, width: overlayWidth, crop: overlayCrop },
+			{ flags: 'relative', height: overlayHeight, width: overlayWidth, crop: 'scale' },
 			// these are here to make sure the overlay never flows over the original image
 			{ flags: ['layer_apply', 'no_overflow'],
 			gravity: overlayGravity, x: overlayX, y: overlayY }

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -50,22 +50,34 @@ function buildCloudinaryTransforms(transform) {
 		cloudinaryTransforms.effect = `tint:100:${tint.join(':')}`;
 	}
 
-	const overlay = transform.getOverlay();
 
 	const immutable = transform.getImmutable();
 	if (immutable) {
 		cloudinaryTransforms.flags.push('immutable_cache');
 	}
 
+	const overlay = transform.getOverlay();
+
+
 	if (overlay) {
+
+		const overlayPosition = transform.getOverlayPosition();
+		const overlayHeight = transform.getOverlayWidth();
+		const overlayWidth = transform.getOverlayHeight();
+		const overlayX = transform.getOverlayX();
+		const overlayY = transform.getOverlayY();
+		const overlayGravity = transform.getOverlayGravity();
+		const overlayCrop = transform.getOverlayCrop();
 
 		const overlayTransform = [];
 
 		overlayTransform.push(
 			{ overlay: { 'url': overlay } },
-			{ flags: 'relative', height: '0.10', crop: 'scale' },
+			// relative flag as it's sized relative to the parent image
+			{ flags: overlayPosition, height: overlayHeight, width: overlayWidth, crop: overlayCrop },
+			// these are here to make sure the overlay never flows over the original image
 			{ flags: ['layer_apply', 'no_overflow'],
-			gravity: 'south_east', x: 0, y: 30 }
+			gravity: overlayGravity, x: overlayX, y: overlayY }
 		);
 
 		return {transformation: [cloudinaryTransforms, overlayTransform]};

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -66,13 +66,14 @@ function buildCloudinaryTransforms(transform) {
 		const overlayX = transform.getOverlayX() ? transform.getOverlayX() : 0;
 		const overlayY = transform.getOverlayY() ? transform.getOverlayY() : 0;
 		const overlayGravity = transform.getOverlayGravity();
+		const overlayCrop = transform.getOverlayCrop();
 		const overlayTransform = [];
 
 
 		overlayTransform.push(
 			{ overlay: { 'url': overlay } },
 			// relative flag as it's sized relative to the parent image
-			{ flags: 'relative', height: overlayHeight, width: overlayWidth, crop: 'scale' },
+			{ flags: 'relative', height: overlayHeight, width: overlayWidth, crop: overlayCrop },
 			// these are here to make sure the overlay never flows over the original image
 			{ flags: ['layer_apply', 'no_overflow'],
 			gravity: overlayGravity, x: overlayX, y: overlayY }

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -61,13 +61,13 @@ function buildCloudinaryTransforms(transform) {
 
 	if (overlay) {
 
-		const overlayHeight = transform.getOverlayHeight();
-		const overlayWidth = transform.getOverlayWidth();
-		const overlayX = transform.getOverlayX();
-		const overlayY = transform.getOverlayY();
+		const overlayHeight = transform.getOverlayHeight() ? transform.getOverlayHeight() : '';
+		const overlayWidth = transform.getOverlayWidth() ? transform.getOverlayWidth() : '';
+		const overlayX = transform.getOverlayX() ? transform.getOverlayX() : 0;
+		const overlayY = transform.getOverlayY() ? transform.getOverlayY() : 0;
 		const overlayGravity = transform.getOverlayGravity();
-
 		const overlayTransform = [];
+
 
 		overlayTransform.push(
 			{ overlay: { 'url': overlay } },

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -59,16 +59,16 @@ function buildCloudinaryTransforms(transform) {
 
 	if (overlay) {
 
-		let overlayTransform = [];
+		const overlayTransform = [];
 
 		overlayTransform.push(
 			{ overlay: { 'url': overlay } },
-			{ flags: "relative", height: "0.10", crop: "scale" },
-			{ flags: ["layer_apply", "no_overflow"],
-			gravity: "south_east", x: 0, y: 30 }
-		)
+			{ flags: 'relative', height: '0.10', crop: 'scale' },
+			{ flags: ['layer_apply', 'no_overflow'],
+			gravity: 'south_east', x: 0, y: 30 }
+		);
 
-		return {transformation: [cloudinaryTransforms, overlayTransform]}
+		return {transformation: [cloudinaryTransforms, overlayTransform]};
 	} else {
 		return cloudinaryTransforms;
 	}

--- a/lib/transformers/cloudinary.js
+++ b/lib/transformers/cloudinary.js
@@ -62,8 +62,8 @@ function buildCloudinaryTransforms(transform) {
 	if (overlay) {
 
 		const overlayPosition = transform.getOverlayPosition();
-		const overlayHeight = transform.getOverlayWidth();
-		const overlayWidth = transform.getOverlayHeight();
+		const overlayHeight = transform.getOverlayHeight();
+		const overlayWidth = transform.getOverlayWidth();
 		const overlayX = transform.getOverlayX();
 		const overlayY = transform.getOverlayY();
 		const overlayGravity = transform.getOverlayGravity();

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -259,7 +259,7 @@ describe('lib/transformers/cloudinary', () => {
 			};
 			const cloudinaryUrl = cloudinaryTransform(transform, options);
 
-			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_scale,fl_relative/fl_layer_apply.no_overflow/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_scale,fl_relative/fl_layer_apply.no_overflow,x_0,y_0/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
 
 		});
 

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -259,7 +259,7 @@ describe('lib/transformers/cloudinary', () => {
 			};
 			const cloudinaryUrl = cloudinaryTransform(transform, options);
 
-			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/fl_layer_apply.no_overflow/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_scale,fl_relative/fl_layer_apply.no_overflow/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
 
 		});
 
@@ -271,10 +271,8 @@ describe('lib/transformers/cloudinary', () => {
 			transform.setOverlayX('30');
 			transform.setOverlayY('40');
 			transform.setOverlayGravity('north_west');
-			transform.setOverlayCrop('crop');
 			transform.setOverlayWidth('150');
 			transform.setOverlayHeight('50');
-			transform.setOverlayPosition('relative');
 
 			const options = {
 				cloudinaryAccountName: 'testaccount',
@@ -283,7 +281,7 @@ describe('lib/transformers/cloudinary', () => {
 			};
 			const cloudinaryUrl = cloudinaryTransform(transform, options);
 
-			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_crop,fl_relative,h_50,w_150/fl_layer_apply.no_overflow,g_north_west,x_30,y_40/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_scale,fl_relative,h_50,w_150/fl_layer_apply.no_overflow,g_north_west,x_30,y_40/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
 
 		});
 

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -11,44 +11,6 @@ describe('lib/transformers/cloudinary', () => {
 		cloudinaryTransform = require('../../../../lib/transformers/cloudinary');
 	});
 
-	describe('Overlay functionality', () => {
-		beforeEach(() => {
-			ImageTransform = require('../../../../lib/image-transform');
-			cloudinaryTransform = require('../../../../lib/transformers/cloudinary');
-		});
-		it('should handle overlays correctly', () => {
-
-			let transform = new ImageTransform({ uri: 'http://example.com' });
-
-			transform.setOverlay('http://overlay.com/')
-			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52')
-			const options = {
-				cloudinaryAccountName: 'testaccount',
-				cloudinaryApiKey: 'api-key',
-				cloudinaryApiSecret: 'api-secret'
-			};
-			const cloudinaryUrl = cloudinaryTransform(transform, options);
-
-			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/fl_layer_apply.no_overflow/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
-
-		});
-
-		it('should not include overlay transforms if overlay is not set', () => {
-			let transform = new ImageTransform({});
-			transform.setOverlay(null)
-			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52')
-			const options = {
-				cloudinaryAccountName: 'testaccount',
-				cloudinaryApiKey: 'api-key',
-				cloudinaryApiSecret: 'api-secret'
-			};
-			const cloudinaryUrl = cloudinaryTransform(transform, options);
-
-			assert.equal(cloudinaryUrl, 'https://res.cloudinary.com/testaccount/image/upload/s--9OIPtX6Y--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
-
-		});
-	});
-
 	it('exports a function', () => {
 		assert.isFunction(cloudinaryTransform);
 	});
@@ -276,6 +238,70 @@ describe('lib/transformers/cloudinary', () => {
 			});
 
 		});
+
+
+
+	describe('Overlay functionality', () => {
+		beforeEach(() => {
+			ImageTransform = require('../../../../lib/image-transform');
+			cloudinaryTransform = require('../../../../lib/transformers/cloudinary');
+		});
+		it('should handle overlay correctly', () => {
+
+			const transform = new ImageTransform({ uri: 'http://example.com' });
+
+			transform.setOverlay('http://overlay.com/');
+			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			const options = {
+				cloudinaryAccountName: 'testaccount',
+				cloudinaryApiKey: 'api-key',
+				cloudinaryApiSecret: 'api-secret'
+			};
+			const cloudinaryUrl = cloudinaryTransform(transform, options);
+
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/fl_layer_apply.no_overflow/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+
+		});
+
+		it('should handle all overlay properties correctly', () => {
+
+			const transform = new ImageTransform({ uri: 'http://example.com' });
+			transform.setOverlay('http://overlay.com/');
+			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			transform.setOverlayX('30');
+			transform.setOverlayY('40');
+			transform.setOverlayGravity('north_west');
+			transform.setOverlayCrop('crop');
+			transform.setOverlayWidth('150');
+			transform.setOverlayHeight('50');
+			transform.setOverlayPosition('relative');
+
+			const options = {
+				cloudinaryAccountName: 'testaccount',
+				cloudinaryApiKey: 'api-key',
+				cloudinaryApiSecret: 'api-secret'
+			};
+			const cloudinaryUrl = cloudinaryTransform(transform, options);
+
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_crop,fl_relative,h_150,w_50/fl_layer_apply.no_overflow,g_north_west,x_30,y_40/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+
+		});
+
+		it('should not include overlay transforms if overlay is not set', () => {
+			const transform = new ImageTransform({});
+			transform.setOverlay(null);
+			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			const options = {
+				cloudinaryAccountName: 'testaccount',
+				cloudinaryApiKey: 'api-key',
+				cloudinaryApiSecret: 'api-secret'
+			};
+			const cloudinaryUrl = cloudinaryTransform(transform, options);
+
+			assert.equal(cloudinaryUrl, 'https://res.cloudinary.com/testaccount/image/upload/s--9OIPtX6Y--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+
+		});
+	});
 
 	});
 

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -250,6 +250,7 @@ describe('lib/transformers/cloudinary', () => {
 
 			const transform = new ImageTransform({ uri: 'http://example.com' });
 
+			transform.setOverlayCrop('scale');
 			transform.setOverlay('http://overlay.com/');
 			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
 			const options = {
@@ -273,6 +274,7 @@ describe('lib/transformers/cloudinary', () => {
 			transform.setOverlayGravity('north_west');
 			transform.setOverlayWidth('150');
 			transform.setOverlayHeight('50');
+			transform.setOverlayCrop('crop');
 
 			const options = {
 				cloudinaryAccountName: 'testaccount',
@@ -281,7 +283,7 @@ describe('lib/transformers/cloudinary', () => {
 			};
 			const cloudinaryUrl = cloudinaryTransform(transform, options);
 
-			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_scale,fl_relative,h_50,w_150/fl_layer_apply.no_overflow,g_north_west,x_30,y_40/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_crop,fl_relative,h_50,w_150/fl_layer_apply.no_overflow,g_north_west,x_30,y_40/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
 
 		});
 

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -283,7 +283,7 @@ describe('lib/transformers/cloudinary', () => {
 			};
 			const cloudinaryUrl = cloudinaryTransform(transform, options);
 
-			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_crop,fl_relative,h_150,w_50/fl_layer_apply.no_overflow,g_north_west,x_30,y_40/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/c_crop,fl_relative,h_50,w_150/fl_layer_apply.no_overflow,g_north_west,x_30,y_40/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
 
 		});
 

--- a/test/unit/lib/transformers/cloudinary.test.js
+++ b/test/unit/lib/transformers/cloudinary.test.js
@@ -11,6 +11,44 @@ describe('lib/transformers/cloudinary', () => {
 		cloudinaryTransform = require('../../../../lib/transformers/cloudinary');
 	});
 
+	describe('Overlay functionality', () => {
+		beforeEach(() => {
+			ImageTransform = require('../../../../lib/image-transform');
+			cloudinaryTransform = require('../../../../lib/transformers/cloudinary');
+		});
+		it('should handle overlays correctly', () => {
+
+			let transform = new ImageTransform({ uri: 'http://example.com' });
+
+			transform.setOverlay('http://overlay.com/')
+			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52')
+			const options = {
+				cloudinaryAccountName: 'testaccount',
+				cloudinaryApiKey: 'api-key',
+				cloudinaryApiSecret: 'api-secret'
+			};
+			const cloudinaryUrl = cloudinaryTransform(transform, options);
+
+			assert.equal(cloudinaryUrl, 'http://res.cloudinary.com/testaccount/image/upload/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/l_fetch:aHR0cDovL292ZXJsYXkuY29tLw/fl_layer_apply.no_overflow/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+
+		});
+
+		it('should not include overlay transforms if overlay is not set', () => {
+			let transform = new ImageTransform({});
+			transform.setOverlay(null)
+			transform.setName('5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52')
+			const options = {
+				cloudinaryAccountName: 'testaccount',
+				cloudinaryApiKey: 'api-key',
+				cloudinaryApiSecret: 'api-secret'
+			};
+			const cloudinaryUrl = cloudinaryTransform(transform, options);
+
+			assert.equal(cloudinaryUrl, 'https://res.cloudinary.com/testaccount/image/upload/s--9OIPtX6Y--/c_fill,f_auto,fl_lossy.any_format.force_strip.progressive,q_72/5032c0754b4756b34aabc2383dbf5eef5e8d73ab5d10b74c9ee067b1879efd52');
+
+		});
+	});
+
 	it('exports a function', () => {
 		assert.isFunction(cloudinaryTransform);
 	});

--- a/views/api.html
+++ b/views/api.html
@@ -213,19 +213,8 @@
 			<th scope="row"><code>overlay_X</code></td>
 			<td>
 				<p>Crop of the overlay. May be set to:
-					<code>fill</code>
+					<code>scale</code>
 					<code>crop</code>
-					<code>fill_pad</code>
-					<code>fit</code>
-					<code>imagga_crop</code>
-					<code>imagga_scale</code>
-					<code>lfill</code>
-					<code>limit</code>
-					<code>lpad</code>
-					<code>mfit</code>
-					<code>mpad</code>
-					<code>pad</code>
-					<code>thum</code>.
 				</p>
 			</td>
 		</tr>

--- a/views/api.html
+++ b/views/api.html
@@ -185,6 +185,42 @@
 				<p>Name of the application making the request, used for audit purposes. This should be a valid FT System Code which relates to the application making the request.</p>
 			</td>
 		</tr>
+		<tr id="overlay">
+			<th scope="row"><code>overlay</code></td>
+			<td>
+				<p>URL of an image overlay</p>
+			</td>
+		</tr>
+		<tr id="overlay_x">
+			<th scope="row"><code>overlay_X</code></td>
+			<td>
+				<p>X position of overlay</p>
+			</td>
+		</tr>
+		<tr id="overlay_y">
+			<th scope="row"><code>overlay_X</code></td>
+			<td>
+				<p>Y position of overlay</p>
+			</td>
+		</tr>
+		<tr id="overlay_gravity">
+			<th scope="row"><code>overlay_X</code></td>
+			<td>
+				<p>Direction of the position of overlay. E.g north_east, south_west etc</p>
+			</td>
+		</tr>
+		<tr id="overlay_width">
+			<th scope="row"><code>overlay_width</code></td>
+			<td>
+				<p>Width of the overlay</p>
+			</td>
+		</tr>
+		<tr id="overlay_height">
+			<th scope="row"><code>overlay_height</code></td>
+			<td>
+				<p>Height of the overlay</p>
+			</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/views/api.html
+++ b/views/api.html
@@ -206,7 +206,27 @@
 		<tr id="overlay_gravity">
 			<th scope="row"><code>overlay_X</code></td>
 			<td>
-				<p>Direction of the position of overlay. E.g north_east, south_west etc</p>
+				<p>Direction of the position of overlay. May be set to <code>south_west</code>,<code>south_east</code>,<code>north_west</code>,<code>north_east</code></p>.
+			</td>
+		</tr>
+		<tr id="overlay_crop">
+			<th scope="row"><code>overlay_X</code></td>
+			<td>
+				<p>Crop of the overlay. May be set to:
+					<code>fill</code>
+					<code>crop</code>
+					<code>fill_pad</code>
+					<code>fit</code>
+					<code>imagga_crop</code>
+					<code>imagga_scale</code>
+					<code>lfill</code>
+					<code>limit</code>
+					<code>lpad</code>
+					<code>mfit</code>
+					<code>mpad</code>
+					<code>pad</code>
+					<code>thum</code>.
+				</p>
 			</td>
 		</tr>
 		<tr id="overlay_width">


### PR DESCRIPTION



Run locally and hit with: 
http://localhost:8080/__origami/service/image/v2/images/raw/https%3A%2F%2Fd1e00ek4ebabms.cloudfront.net%2Fproduction%2Fa88c2b59-ac2d-4f70-a68a-57b8499bd70f.jpg?source=next-article&fit=scale-down&quality=highest&width=700&dpr=1&overlay=https://ft-next-assets-prod.s3.eu-west-1.amazonaws.com/assets/ft-banner.png&overlay_height=0.5&overlay_y=30

You should see: 

<img width="652" alt="Screenshot 2023-10-26 at 10 01 37" src="https://github.com/Financial-Times/origami-image-service/assets/5636341/63a661fe-d4f4-4356-a0f8-99f081881304">

