### PR TITLE
chore: Remove polyfill.io use

### DIFF
--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -32,7 +32,6 @@
 	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-layout@^5,o-fonts@^5,o-syntax-highlight@^4,o-forms@^9,o-buttons@^7,o-table@^9,o-footer-services@^4,o-header-services@^5&brand=internal&system_code=origami-image-service-v2" />
 	<link rel="stylesheet" href="/__origami/service/image/main.css" />
 
-	<script src="https://polyfill.io/v3/polyfill.min.js?features=fetch,default"></script>
 	<script>
 		(function(src) {
 			if (window.cutsTheMustard) {


### PR DESCRIPTION
Polyfill has not been FT owned for awhile, and has recently been sold. We are able to meet our browser support policy without it.