### PR TITLE
fix: let the OTel SDK set the service instance ID

### DIFF
--- a/opentelemetry.js
+++ b/opentelemetry.js
@@ -21,7 +21,6 @@ const {
 const {
 	SEMRESATTRS_CLOUD_PROVIDER,
 	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
-	SEMRESATTRS_SERVICE_INSTANCE_ID,
 	SEMRESATTRS_SERVICE_VERSION,
 } = require('@opentelemetry/semantic-conventions');
 
@@ -32,7 +31,6 @@ const resource = new Resource({
 	['heroku.release.creation_timestamp']: process.env.HEROKU_RELEASE_CREATED_AT,
 	[SEMRESATTRS_CLOUD_PROVIDER]: 'heroku',
 	[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: process.env.NODE_ENV,
-	[SEMRESATTRS_SERVICE_INSTANCE_ID]: process.env.HEROKU_DYNO_ID,
 	[SEMRESATTRS_SERVICE_VERSION]: process.env.HEROKU_RELEASE_VERSION,
 });
 


### PR DESCRIPTION
This should mean each process will send metrics with a unique service instance ID.

> For applications running behind an application server (like unicorn), we do not recommend using one identifier for all processes participating in the application. Instead, it’s recommended each division (e.g. a worker thread in unicorn) to have its own instance.id.

From https://opentelemetry.io/docs/specs/semconv/resource/#service-experimental.

### References

* https://github.com/Financial-Times/origami-image-service/pull/863