### PR TITLE
fix: three-barrelled-name

### DIFF
--- a/lib/middleware/get-headshot-url.js
+++ b/lib/middleware/get-headshot-url.js
@@ -45,7 +45,8 @@ function getHeadshotUrl(config) {
 		// In error scenarios, the name is being output into the html
 		// We first check the name is not an XSS vector.
 		// If we think it is potentially an XSS vector, we return an error.
-		if (!/^\p{Letter}+(-\p{Letter}+)$/u.test(name)) {
+		//this regex fix the three or more -barrelled-name
+		if (!/^\p{Letter}+(-\p{Letter}+)+$/u.test(name)){
 			const error = httpError(404, 'Refusing to get image for the provided name - The image name was an unexpected format. If this name should work, please contact someone from the Origami team.');
 			error.cacheMaxAge = '1d';
 			error.skipSentry = true;


### PR DESCRIPTION
In our newsletter in Spark, if an author has a three or more part name, their photo breaks. 
I changed the regex to include three or more barrelled names getting accepted.
