### PR TITLE
[Update] Pin the file-type package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"dompurify": "^3.1.6",
 				"dotenv": "16.4.5",
 				"fastly-purge": "1.0.1",
-				"file-type": "^16.5.4",
+				"file-type": "16.5.4",
 				"heroku-node-settings": "1.1.0",
 				"http-errors": "1.8.0",
 				"http-proxy": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"dompurify": "^3.1.6",
 		"dotenv": "16.4.5",
 		"fastly-purge": "1.0.1",
-		"file-type": "^16.5.4",
+		"file-type": "16.5.4",
 		"heroku-node-settings": "1.1.0",
 		"http-errors": "1.8.0",
 		"http-proxy": "1.18.1",


### PR DESCRIPTION
Pin the file-type package to v16.5.4 as later versions required ESM module usage, rather than CommonJS