### PR TITLE
[Remove] UUID

### DIFF
--- a/lib/middleware/get-cms-url.js
+++ b/lib/middleware/get-cms-url.js
@@ -1,9 +1,7 @@
-
-
 const httpError = require('http-errors');
 const axios = require('axios').default;
 const createErrorFromAxiosError = require('../create-error-from-axios-error');
-const {validate: uuidValidate} = require('uuid');
+const validate = require('./helpers/validate.js');
 
 module.exports = getCmsUrl;
 
@@ -20,7 +18,7 @@ function getCmsUrl(config) {
 		const uriParts = request.params.imageUrl.split(':').pop().split('?');
 		const cmsId = uriParts.shift();
 		const query = uriParts.length ? '?' + uriParts.join('?') : '';
-		if (!uuidValidate(cmsId)) {
+		if (!validate(cmsId)) {
 			const error = httpError(400, 'Image key is invalid');
 			error.cacheMaxAge = '5m';
 			throw error;

--- a/lib/middleware/helpers/regex.js
+++ b/lib/middleware/helpers/regex.js
@@ -1,0 +1,1 @@
+module.exports = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;

--- a/lib/middleware/helpers/validate.js
+++ b/lib/middleware/helpers/validate.js
@@ -1,0 +1,7 @@
+const REGEX = require('./regex.js');
+
+function validate(uuid) {
+  return typeof uuid === 'string' && REGEX.test(uuid);
+}
+
+module.exports = validate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,7 @@
 				"st": "^3.0.0",
 				"statuses": "2.0.1",
 				"svg-tint-stream": "1.0.1",
-				"utf8": "3.0.0",
-				"uuid": "^10.0.0"
+				"utf8": "3.0.0"
 			},
 			"devDependencies": {
 				"color-contrast": "^1.0.0",
@@ -114,13 +113,13 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
+			"integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.24.7",
+				"@babel/highlight": "^7.25.7",
 				"picocolors": "^1.0.0"
 			},
 			"engines": {
@@ -128,9 +127,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
-			"integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.7.tgz",
+			"integrity": "sha512-9ickoLz+hcXCeh7jrcin+/SLWm+GkxE2kTvoYyp38p4WkdFXfQJxDFGWp/YHjiKLPx06z2A7W8XKuqbReXDzsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -138,22 +137,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
-			"integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
+			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.25.0",
-				"@babel/helper-compilation-targets": "^7.25.2",
-				"@babel/helper-module-transforms": "^7.25.2",
-				"@babel/helpers": "^7.25.0",
-				"@babel/parser": "^7.25.0",
-				"@babel/template": "^7.25.0",
-				"@babel/traverse": "^7.25.2",
-				"@babel/types": "^7.25.2",
+				"@babel/code-frame": "^7.25.7",
+				"@babel/generator": "^7.25.7",
+				"@babel/helper-compilation-targets": "^7.25.7",
+				"@babel/helper-module-transforms": "^7.25.7",
+				"@babel/helpers": "^7.25.7",
+				"@babel/parser": "^7.25.7",
+				"@babel/template": "^7.25.7",
+				"@babel/traverse": "^7.25.7",
+				"@babel/types": "^7.25.7",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -186,31 +185,31 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
-			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
+			"integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.25.6",
+				"@babel/types": "^7.25.7",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"jsesc": "^2.5.1"
+				"jsesc": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
-			"integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
+			"integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.25.2",
-				"@babel/helper-validator-option": "^7.24.8",
-				"browserslist": "^4.23.1",
+				"@babel/compat-data": "^7.25.7",
+				"@babel/helper-validator-option": "^7.25.7",
+				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -229,30 +228,30 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
+			"integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/traverse": "^7.25.7",
+				"@babel/types": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
-			"integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
+			"integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-simple-access": "^7.24.7",
-				"@babel/helper-validator-identifier": "^7.24.7",
-				"@babel/traverse": "^7.25.2"
+				"@babel/helper-module-imports": "^7.25.7",
+				"@babel/helper-simple-access": "^7.25.7",
+				"@babel/helper-validator-identifier": "^7.25.7",
+				"@babel/traverse": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -262,23 +261,23 @@
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
+			"integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/traverse": "^7.25.7",
+				"@babel/types": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
+			"integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -286,9 +285,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
+			"integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -296,9 +295,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-			"integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
+			"integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -306,27 +305,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
-			"integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
+			"integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.25.0",
-				"@babel/types": "^7.25.6"
+				"@babel/template": "^7.25.7",
+				"@babel/types": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
+			"integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.25.7",
 				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.0.0"
@@ -414,13 +413,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
+			"integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.25.6"
+				"@babel/types": "^7.25.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -430,32 +429,32 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
+			"integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.24.7",
-				"@babel/parser": "^7.25.0",
-				"@babel/types": "^7.25.0"
+				"@babel/code-frame": "^7.25.7",
+				"@babel/parser": "^7.25.7",
+				"@babel/types": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
-			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
+			"integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.25.6",
-				"@babel/parser": "^7.25.6",
-				"@babel/template": "^7.25.0",
-				"@babel/types": "^7.25.6",
+				"@babel/code-frame": "^7.25.7",
+				"@babel/generator": "^7.25.7",
+				"@babel/parser": "^7.25.7",
+				"@babel/template": "^7.25.7",
+				"@babel/types": "^7.25.7",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -474,14 +473,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
+			"integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.24.8",
-				"@babel/helper-validator-identifier": "^7.24.7",
+				"@babel/helper-string-parser": "^7.25.7",
+				"@babel/helper-validator-identifier": "^7.25.7",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -518,9 +517,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-			"integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+			"integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -547,6 +546,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
 			"integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -580,6 +580,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.12.0.tgz",
 			"integrity": "sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -599,6 +600,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
 			"integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"levn": "^0.4.1"
 			},
@@ -700,9 +702,9 @@
 			}
 		},
 		"node_modules/@grpc/grpc-js": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.2.tgz",
-			"integrity": "sha512-DWp92gDD7/Qkj7r8kus6/HCINeo3yPZWZ3paKgDgsbKbSpoxKg1yvN8xe2Q8uE3zOsPe3bX8FQX2+XValq2yTw==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.1.tgz",
+			"integrity": "sha512-VYrLinJNeW3idIZHTy7BsVL7bsPF9+l89WDYTDV8o1QYJzkf3BSoPXdfaz4c8DyeY12LGSaS8m8BgbT8W66h6Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/proto-loader": "^0.7.13",
@@ -734,13 +736,15 @@
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
 			"integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@hapi/topo": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
 			"integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@hapi/hoek": "^9.0.0"
 			}
@@ -750,6 +754,7 @@
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.0.tgz",
 			"integrity": "sha512-2cbWIHbZVEweE853g8jymffCA+NCMiuqeECeBBLm8dg2oFdjuGJhgN4UAbI+6v0CKbbhvtXA4qV8YR5Ji86nmw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -759,6 +764,7 @@
 			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.5.tgz",
 			"integrity": "sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@humanfs/core": "^0.19.0",
 				"@humanwhocodes/retry": "^0.3.0"
@@ -786,6 +792,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
 			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18"
 			},
@@ -1013,14 +1020,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/auto-instrumentations-node": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.50.0.tgz",
-			"integrity": "sha512-LqoSiWrOM4Cnr395frDHL4R/o5c2fuqqrqW8sZwhxvkasImmVlyL66YMPHllM2O5xVj2nP2ANUKHZSd293meZA==",
+			"version": "0.50.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.50.1.tgz",
+			"integrity": "sha512-R2gXBHixE6eCjjMkapI+uo80Xa7RE+bchVGUUtPvGxjqwoZqbCrCi4OfJBBJpUUcortDSfEo+tIQ1nXAbCVFqw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.53.0",
 				"@opentelemetry/instrumentation-amqplib": "^0.42.0",
-				"@opentelemetry/instrumentation-aws-lambda": "^0.44.0",
+				"@opentelemetry/instrumentation-aws-lambda": "^0.45.0",
 				"@opentelemetry/instrumentation-aws-sdk": "^0.44.0",
 				"@opentelemetry/instrumentation-bunyan": "^0.41.0",
 				"@opentelemetry/instrumentation-cassandra-driver": "^0.41.0",
@@ -1028,8 +1035,8 @@
 				"@opentelemetry/instrumentation-cucumber": "^0.9.0",
 				"@opentelemetry/instrumentation-dataloader": "^0.12.0",
 				"@opentelemetry/instrumentation-dns": "^0.39.0",
-				"@opentelemetry/instrumentation-express": "^0.42.0",
-				"@opentelemetry/instrumentation-fastify": "^0.39.0",
+				"@opentelemetry/instrumentation-express": "^0.43.0",
+				"@opentelemetry/instrumentation-fastify": "^0.40.0",
 				"@opentelemetry/instrumentation-fs": "^0.15.0",
 				"@opentelemetry/instrumentation-generic-pool": "^0.39.0",
 				"@opentelemetry/instrumentation-graphql": "^0.43.0",
@@ -1048,21 +1055,21 @@
 				"@opentelemetry/instrumentation-mysql2": "^0.41.0",
 				"@opentelemetry/instrumentation-nestjs-core": "^0.40.0",
 				"@opentelemetry/instrumentation-net": "^0.39.0",
-				"@opentelemetry/instrumentation-pg": "^0.44.0",
+				"@opentelemetry/instrumentation-pg": "^0.45.0",
 				"@opentelemetry/instrumentation-pino": "^0.42.0",
 				"@opentelemetry/instrumentation-redis": "^0.42.0",
-				"@opentelemetry/instrumentation-redis-4": "^0.42.0",
+				"@opentelemetry/instrumentation-redis-4": "^0.42.1",
 				"@opentelemetry/instrumentation-restify": "^0.41.0",
 				"@opentelemetry/instrumentation-router": "^0.40.0",
 				"@opentelemetry/instrumentation-socket.io": "^0.42.0",
 				"@opentelemetry/instrumentation-tedious": "^0.14.0",
 				"@opentelemetry/instrumentation-undici": "^0.6.0",
 				"@opentelemetry/instrumentation-winston": "^0.40.0",
-				"@opentelemetry/resource-detector-alibaba-cloud": "^0.29.1",
-				"@opentelemetry/resource-detector-aws": "^1.6.1",
+				"@opentelemetry/resource-detector-alibaba-cloud": "^0.29.2",
+				"@opentelemetry/resource-detector-aws": "^1.6.2",
 				"@opentelemetry/resource-detector-azure": "^0.2.11",
-				"@opentelemetry/resource-detector-container": "^0.4.1",
-				"@opentelemetry/resource-detector-gcp": "^0.29.11",
+				"@opentelemetry/resource-detector-container": "^0.4.2",
+				"@opentelemetry/resource-detector-gcp": "^0.29.12",
 				"@opentelemetry/resources": "^1.24.0",
 				"@opentelemetry/sdk-node": "^0.53.0"
 			},
@@ -1278,6 +1285,7 @@
 			"version": "0.35.4",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.4.tgz",
 			"integrity": "sha512-3nPElbfYZ2oKNoMw2CkXkHxQryebqACcSgMbbKcn+GnGKp+h7MeOHyg21NmmTt9xgCvRHYiHNkWGkB4laP0oUw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/sdk-metrics": "^1.8.0",
 				"systeminformation": "5.22.9"
@@ -1327,9 +1335,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-aws-lambda": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.44.0.tgz",
-			"integrity": "sha512-6vmr7FJIuopZzsQjEQTp4xWtF6kBp7DhD7pPIN8FN0dKUKyuVraABIpgWjMfelaUPy4rTYUGkYqPluhG0wx8Dw==",
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.45.0.tgz",
+			"integrity": "sha512-22ZnmYftKjFoiqC1k3tu2AVKiXSZv+ohuHWk4V4MdJpPuNkadY624aDkv5BmwDeavDxVFgqE9nGgDM9s3Q94mg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.53.0",
@@ -1462,9 +1470,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-express": {
-			"version": "0.42.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.42.0.tgz",
-			"integrity": "sha512-YNcy7ZfGnLsVEqGXQPT+S0G1AE46N21ORY7i7yUQyfhGAL4RBjnZUqefMI0NwqIl6nGbr1IpF0rZGoN8Q7x12Q==",
+			"version": "0.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.43.0.tgz",
+			"integrity": "sha512-bxTIlzn9qPXJgrhz8/Do5Q3jIlqfpoJrSUtVGqH+90eM1v2PkPHc+SdE+zSqe4q9Y1UQJosmZ4N4bm7Zj/++MA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^1.8.0",
@@ -1479,9 +1487,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-fastify": {
-			"version": "0.39.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.39.0.tgz",
-			"integrity": "sha512-SS9uSlKcsWZabhBp2szErkeuuBDgxOUlllwkS92dVaWRnMmwysPhcEgHKB8rUe3BHg/GnZC1eo1hbTZv4YhfoA==",
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.40.0.tgz",
+			"integrity": "sha512-74qj4nG3zPtU7g2x4sm2T4R3/pBMyrYstTsqSZwdlhQk1SD4l8OSY9sPRX1qkhfxOuW3U4KZQAV/Cymb3fB6hg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^1.8.0",
@@ -1791,9 +1799,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-pg": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.44.0.tgz",
-			"integrity": "sha512-oTWVyzKqXud1BYEGX1loo2o4k4vaU1elr3vPO8NZolrBtFvQ34nx4HgUaexUDuEog00qQt+MLR5gws/p+JXMLQ==",
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.45.0.tgz",
+			"integrity": "sha512-IuIZa9u4lnJhSs2WaSGv/lWcTtWUdv2xYtWRHEDr9njn9PBKzCzz709+9IvxNibbSjCASdLS1Stuq1LVRCYbXg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.53.0",
@@ -1844,9 +1852,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-redis-4": {
-			"version": "0.42.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.42.0.tgz",
-			"integrity": "sha512-NaD+t2JNcOzX/Qa7kMy68JbmoVIV37fT/fJYzLKu2Wwd+0NCxt+K2OOsOakA8GVg8lSpFdbx4V/suzZZ2Pvdjg==",
+			"version": "0.42.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.42.1.tgz",
+			"integrity": "sha512-xm17LJhDfQzQo4wkM/zFwh6wk3SNN/FBFGkscI9Kj4efrb/o5p8Z3yE6ldBPNdIZ6RAwg2p3DL7fvE3DuUDJWA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.53.0",
@@ -2095,12 +2103,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-			"version": "0.29.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.29.1.tgz",
-			"integrity": "sha512-Qshebw6azBuKUqGkVgambZlLS6Xh+LCoLXep1oqW1RSzSOHQxGYDsPs99v8NzO65eJHHOu8wc2yKsWZQAgYsSw==",
+			"version": "0.29.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.29.2.tgz",
+			"integrity": "sha512-EZ4V4NU+ZFAWqgQJB5V1G/f5Kf9i8ARmfh3iKE+H/UNxZUfElF4k4TqUBwQTanstggCOz4aZ3pc85x7SKcm7SA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/resources": "^1.0.0",
+				"@opentelemetry/resources": "^1.10.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2111,9 +2119,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-aws": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.6.1.tgz",
-			"integrity": "sha512-A/3lqx9xoew7sFi+AVUUVr6VgB7UJ5qqddkKR3gQk9hWLm1R7HUXVJG09cLcZ7DMNpX13DohPRGmHE/vp1vafw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.6.2.tgz",
+			"integrity": "sha512-xxT6PVmcBTtCo0rf4Bv/mnDMpVRITVt13bDX8mOqKVb0kr5EwIMabZS5EGJhXjP4nljrOIA7ZlOJgSX0Kehfkw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^1.0.0",
@@ -2145,9 +2153,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-container": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.4.1.tgz",
-			"integrity": "sha512-v0bvO6RxYtbxvY/HwqrPQnZ4UtP4nBq4AOyS30iqV2vEtiLTY1gNTbNvTF1lwN/gg/g5CY1tRSrHcYODDOv0vw==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.4.2.tgz",
+			"integrity": "sha512-CNBEJD/SqWvzli/BhVe4ohUkUJYl0tJRZgrzDLHHyKid7A/3WqosASSfsGMr2rqAF/9zcKUXCLfIKnau2AioYA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/resources": "^1.10.0",
@@ -2161,13 +2169,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-gcp": {
-			"version": "0.29.11",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.11.tgz",
-			"integrity": "sha512-07wJx4nyxD/c2z3n70OQOg8fmoO/baTsq8uU+f7tZaehRNQx76MPkRbV2L902N40Z21SPIG8biUZ30OXE9tOIg==",
+			"version": "0.29.12",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.12.tgz",
+			"integrity": "sha512-liFG9XTaFVyY9YdFy4r2qVNa4a+Mg3k+XoWzzq2F+/xR0hFLfL0H4k7CsMW+T4Vl+1Cvc9W9WEVt5VCF4u/SYw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^1.0.0",
-				"@opentelemetry/resources": "^1.0.0",
+				"@opentelemetry/resources": "^1.10.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
 				"gcp-metadata": "^6.0.0"
 			},
@@ -2383,41 +2391,41 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sentry-internal/tracing": {
-			"version": "7.119.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.0.tgz",
-			"integrity": "sha512-oKdFJnn+56f0DHUADlL8o9l8jTib3VDLbWQBVkjD9EprxfaCwt2m8L5ACRBdQ8hmpxCEo4I8/6traZ7qAdBUqA==",
+			"version": "7.119.1",
+			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.1.tgz",
+			"integrity": "sha512-cI0YraPd6qBwvUA3wQdPGTy8PzAoK0NZiaTN1LM3IczdPegehWOaEG5GVTnpGnTsmBAzn1xnBXNBhgiU4dgcrQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "7.119.0",
-				"@sentry/types": "7.119.0",
-				"@sentry/utils": "7.119.0"
+				"@sentry/core": "7.119.1",
+				"@sentry/types": "7.119.1",
+				"@sentry/utils": "7.119.1"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/core": {
-			"version": "7.119.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.0.tgz",
-			"integrity": "sha512-CS2kUv9rAJJEjiRat6wle3JATHypB0SyD7pt4cpX5y0dN5dZ1JrF57oLHRMnga9fxRivydHz7tMTuBhSSwhzjw==",
+			"version": "7.119.1",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.1.tgz",
+			"integrity": "sha512-YUNnH7O7paVd+UmpArWCPH4Phlb5LwrkWVqzFWqL3xPyCcTSof2RL8UmvpkTjgYJjJ+NDfq5mPFkqv3aOEn5Sw==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/types": "7.119.0",
-				"@sentry/utils": "7.119.0"
+				"@sentry/types": "7.119.1",
+				"@sentry/utils": "7.119.1"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/integrations": {
-			"version": "7.119.0",
-			"resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.0.tgz",
-			"integrity": "sha512-OHShvtsRW0A+ZL/ZbMnMqDEtJddPasndjq+1aQXw40mN+zeP7At/V1yPZyFaURy86iX7Ucxw5BtmzuNy7hLyTA==",
+			"version": "7.119.1",
+			"resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.1.tgz",
+			"integrity": "sha512-CGmLEPnaBqbUleVqrmGYjRjf5/OwjUXo57I9t0KKWViq81mWnYhaUhRZWFNoCNQHns+3+GPCOMvl0zlawt+evw==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "7.119.0",
-				"@sentry/types": "7.119.0",
-				"@sentry/utils": "7.119.0",
+				"@sentry/core": "7.119.1",
+				"@sentry/types": "7.119.1",
+				"@sentry/utils": "7.119.1",
 				"localforage": "^1.8.1"
 			},
 			"engines": {
@@ -2425,37 +2433,37 @@
 			}
 		},
 		"node_modules/@sentry/node": {
-			"version": "7.119.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.0.tgz",
-			"integrity": "sha512-9PFzN8xS6U0oZCflpVxS2SSIsHkCaj7qYBlsvHj4CTGWfao9ImwrU6+smy4qoG6oxwPfoVb5pOOMb4WpWOvXcQ==",
+			"version": "7.119.1",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.1.tgz",
+			"integrity": "sha512-rpnoQCMxWh/ccjOe+qsmvXAdlTxQHXEWdaltSxnwj7QY+kOGKGP18WTQFLq/gdOBRw9aa6PEQGwhnLfhBXXaYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry-internal/tracing": "7.119.0",
-				"@sentry/core": "7.119.0",
-				"@sentry/integrations": "7.119.0",
-				"@sentry/types": "7.119.0",
-				"@sentry/utils": "7.119.0"
+				"@sentry-internal/tracing": "7.119.1",
+				"@sentry/core": "7.119.1",
+				"@sentry/integrations": "7.119.1",
+				"@sentry/types": "7.119.1",
+				"@sentry/utils": "7.119.1"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/types": {
-			"version": "7.119.0",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.0.tgz",
-			"integrity": "sha512-27qQbutDBPKGbuJHROxhIWc1i0HJaGLA90tjMu11wt0E4UNxXRX+UQl4Twu68v4EV3CPvQcEpQfgsViYcXmq+w==",
+			"version": "7.119.1",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.1.tgz",
+			"integrity": "sha512-4G2mcZNnYzK3pa2PuTq+M2GcwBRY/yy1rF+HfZU+LAPZr98nzq2X3+mJHNJoobeHRkvVh7YZMPi4ogXiIS5VNQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/utils": {
-			"version": "7.119.0",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.0.tgz",
-			"integrity": "sha512-ZwyXexWn2ZIe2bBoYnXJVPc2esCSbKpdc6+0WJa8eutXfHq3FRKg4ohkfCBpfxljQGEfP1+kfin945lA21Ka+A==",
+			"version": "7.119.1",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.1.tgz",
+			"integrity": "sha512-ju/Cvyeu/vkfC5/XBV30UNet5kLEicZmXSyuLwZu95hEbL+foPdxN+re7pCI/eNqfe3B2vz7lvz5afLVOlQ2Hg==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/types": "7.119.0"
+				"@sentry/types": "7.119.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2466,6 +2474,7 @@
 			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
 			"integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@hapi/hoek": "^9.0.0"
 			}
@@ -2474,19 +2483,22 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
 			"integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sideway/pinpoint": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
 			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"type-detect": "4.0.8"
 			}
@@ -2496,6 +2508,7 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
 			"integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1"
 			}
@@ -2505,6 +2518,7 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
 			"integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1",
 				"lodash.get": "^4.4.2",
@@ -2516,6 +2530,7 @@
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
 			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -2524,7 +2539,8 @@
 			"version": "0.7.3",
 			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
 			"integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
-			"dev": true
+			"dev": true,
+			"license": "(Unlicense OR Apache-2.0)"
 		},
 		"node_modules/@tokenizer/token": {
 			"version": "0.3.0",
@@ -2537,19 +2553,6 @@
 			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.143.tgz",
 			"integrity": "sha512-u5vzlcR14ge/4pMTTMDQr3MF0wEe38B2F9o84uC4F43vN5DGTy63npRrB6jQhyt+C0lGv4ZfiRcRkqJoZuPnmg==",
 			"license": "MIT"
-		},
-		"node_modules/@types/body-parser": {
-			"version": "1.19.5",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-			"integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/connect": "*",
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/bunyan": {
 			"version": "1.8.9",
@@ -2573,52 +2576,15 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-			"dev": true
-		},
-		"node_modules/@types/express": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-			"integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/body-parser": "*",
-				"@types/express-serve-static-core": "^4.17.33",
-				"@types/qs": "*",
-				"@types/serve-static": "*"
-			}
-		},
-		"node_modules/@types/express-serve-static-core": {
-			"version": "4.19.5",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
-			"integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/qs": "*",
-				"@types/range-parser": "*",
-				"@types/send": "*"
-			}
-		},
-		"node_modules/@types/http-errors": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-			"integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/memcached": {
 			"version": "2.2.10",
@@ -2628,15 +2594,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/mime": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-			"integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/@types/mysql": {
 			"version": "2.15.26",
@@ -2648,9 +2605,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "22.5.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-			"integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+			"version": "22.7.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+			"integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.19.2"
@@ -2674,51 +2631,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/pg": "*"
-			}
-		},
-		"node_modules/@types/qs": {
-			"version": "6.9.15",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-			"integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@types/range-parser": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@types/send": {
-			"version": "0.17.4",
-			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-			"integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/mime": "^1",
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/serve-static": {
-			"version": "1.15.7",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-			"integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/http-errors": "*",
-				"@types/node": "*",
-				"@types/send": "*"
 			}
 		},
 		"node_modules/@types/shimmer": {
@@ -3161,21 +3073,6 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
 		},
-		"node_modules/body-parser/node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/body-parser/node_modules/toidentifier": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3222,9 +3119,9 @@
 			"license": "ISC"
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-			"integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+			"integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
 			"dev": true,
 			"funding": [
 				{
@@ -3242,8 +3139,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001646",
-				"electron-to-chromium": "^1.5.4",
+				"caniuse-lite": "^1.0.30001663",
+				"electron-to-chromium": "^1.5.28",
 				"node-releases": "^2.0.18",
 				"update-browserslist-db": "^1.1.0"
 			},
@@ -3343,9 +3240,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001660",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-			"integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+			"version": "1.0.30001667",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
+			"integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3477,6 +3374,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.5.0.tgz",
 			"integrity": "sha512-gPkyylFpyBAXiErAnMgZBlpwztHuZoik/OTLQM9oswjlzYHLMtQGoh0oisPBQvVHQxHmBUjcgwsAi393HDedqQ==",
+			"license": "MIT",
 			"dependencies": {
 				"lodash": "^4.17.21",
 				"q": "^1.5.1"
@@ -3586,9 +3484,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -3678,6 +3576,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
 			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/kossnocorp"
@@ -3827,7 +3726,8 @@
 		"node_modules/dompurify": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-			"integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
+			"integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+			"license": "(MPL-2.0 OR Apache-2.0)"
 		},
 		"node_modules/duplexer": {
 			"version": "0.1.2",
@@ -3853,9 +3753,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.19",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.19.tgz",
-			"integrity": "sha512-kpLJJi3zxTR1U828P+LIUDZ5ohixyo68/IcYOHLqnbTPr/wdgn4i1ECvmALN9E16JPA6cvCG5UG79gVwVdEK5w==",
+			"version": "1.5.33",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.33.tgz",
+			"integrity": "sha512-+cYTcFB1QqD4j4LegwLfpCNxifb6dDFUAwk6RsLusCwIaZI6or2f+q8rs5tTB2YC53HhOlIbEaqHMAAC8IOIwA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3945,6 +3845,7 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.12.0.tgz",
 			"integrity": "sha512-UVIOlTEWxwIopRL1wgSQYdnVDcEvs2wyaO6DGo5mXqe3r16IoCNWkR29iHhyaP4cICWjbgbmFUGAhh0GJRuGZw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.11.0",
@@ -4005,6 +3906,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.1.0.tgz",
 			"integrity": "sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -4021,6 +3923,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
 			"integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -4033,6 +3936,7 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
 			"integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"acorn": "^8.12.0",
 				"acorn-jsx": "^5.3.2",
@@ -4077,6 +3981,7 @@
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -4160,9 +4065,9 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.20.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
-			"integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
+			"version": "4.21.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+			"integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -4170,14 +4075,14 @@
 				"body-parser": "1.20.3",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.6.0",
+				"cookie": "0.7.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.2.0",
+				"finalhandler": "1.3.1",
 				"fresh": "0.5.2",
 				"http-errors": "2.0.0",
 				"merge-descriptors": "1.0.3",
@@ -4186,11 +4091,11 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "0.1.10",
 				"proxy-addr": "~2.0.7",
-				"qs": "6.11.0",
+				"qs": "6.13.0",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "0.19.0",
-				"serve-static": "1.16.0",
+				"serve-static": "1.16.2",
 				"setprototypeof": "1.2.0",
 				"statuses": "2.0.1",
 				"type-is": "~1.6.18",
@@ -4354,13 +4259,13 @@
 			}
 		},
 		"node_modules/finalhandler": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+			"integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"on-finished": "2.4.1",
 				"parseurl": "~1.3.3",
@@ -4378,15 +4283,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
-			}
-		},
-		"node_modules/finalhandler/node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/finalhandler/node_modules/ms": {
@@ -4499,17 +4395,33 @@
 			"license": "MIT"
 		},
 		"node_modules/foreground-child": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
-				"signal-exit": "^3.0.2"
+				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/forever-agent": {
@@ -4636,19 +4548,6 @@
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/gaxios/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/gcp-metadata": {
@@ -5094,6 +4993,7 @@
 			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
 			"integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"husky": "bin.js"
 			},
@@ -5177,9 +5077,9 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz",
-			"integrity": "sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==",
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.11.2.tgz",
+			"integrity": "sha512-gK6Rr6EykBcc6cVWRSBR5TWf8nn6hZMYSRYqCcHa0l0d1fPK7JSYo6+Mlmck76jIX9aL/IZ71c06U2VpFwl1zA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"acorn": "^8.8.2",
@@ -5526,6 +5426,7 @@
 			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
 			"integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@hapi/hoek": "^9.3.0",
 				"@hapi/topo": "^5.1.0",
@@ -5564,6 +5465,7 @@
 			"version": "25.0.1",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
 			"integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+			"license": "MIT",
 			"dependencies": {
 				"cssstyle": "^4.1.0",
 				"data-urls": "^5.0.0",
@@ -5600,16 +5502,16 @@
 			}
 		},
 		"node_modules/jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=6"
 			}
 		},
 		"node_modules/json-bigint": {
@@ -5692,7 +5594,8 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
 			"integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -5785,7 +5688,8 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -6494,6 +6398,7 @@
 			"resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
 			"integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1",
 				"@sinonjs/fake-timers": "^13.0.1",
@@ -6503,10 +6408,11 @@
 			}
 		},
 		"node_modules/nise/node_modules/path-to-regexp": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-			"integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+			"integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=16"
 			}
@@ -6573,6 +6479,7 @@
 			"resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.16.1.tgz",
 			"integrity": "sha512-Q2m5bmIE1KFeeKI6OsSn+c4XDara5NWnUJgzqnIkhiCNukYX+fqu0ADSeKOlpWtbCwgRnJ69F+7RUiQltzTKXA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"accepts": "^1.3.7",
 				"content-disposition": "^0.5.3",
@@ -6636,6 +6543,7 @@
 			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
 			"integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^3.5.2",
 				"debug": "^4",
@@ -6706,9 +6614,9 @@
 			}
 		},
 		"node_modules/nwsapi": {
-			"version": "2.2.12",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
-			"integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
+			"version": "2.2.13",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
+			"integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==",
 			"license": "MIT"
 		},
 		"node_modules/nyc": {
@@ -6716,6 +6624,7 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
 			"integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@istanbuljs/load-nyc-config": "^1.0.0",
 				"@istanbuljs/schema": "^0.1.2",
@@ -6776,34 +6685,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/foreground-child": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/nyc/node_modules/foreground-child/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/nyc/node_modules/locate-path": {
@@ -7218,9 +7099,9 @@
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
-			"integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+			"integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==",
 			"license": "MIT"
 		},
 		"node_modules/pg-types": {
@@ -7561,12 +7442,12 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.4"
+				"side-channel": "^1.0.6"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -7970,6 +7851,7 @@
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
 			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
@@ -8147,91 +8029,18 @@
 			}
 		},
 		"node_modules/serve-static": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
-			"integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+			"integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
 			"license": "MIT",
 			"dependencies": {
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.18.0"
+				"send": "0.19.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/serve-static/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/serve-static/node_modules/debug/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"license": "MIT"
-		},
-		"node_modules/serve-static/node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/serve-static/node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-			"license": "MIT",
-			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/serve-static/node_modules/send": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
-				"mime": "1.6.0",
-				"ms": "2.1.3",
-				"on-finished": "2.4.1",
-				"range-parser": "~1.2.1",
-				"statuses": "2.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/serve-static/node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6"
 			}
 		},
 		"node_modules/set-blocking": {
@@ -8336,6 +8145,7 @@
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
 			"integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1",
 				"@sinonjs/fake-timers": "^13.0.2",
@@ -8354,6 +8164,7 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
 			"integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -8400,6 +8211,20 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/spawn-wrap/node_modules/foreground-child": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/split": {
@@ -8491,6 +8316,7 @@
 			"resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.8.tgz",
 			"integrity": "sha512-v2fV6NV2F7tL1ocwfI4Wpait+IKjRbT5l3ZZ+ZikXdMLmxYsS8ynGAsCQAUVXkVyGyS+UibsRnvgHkMvJIvCsw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"arg": "^5.0.2",
 				"bluebird": "3.7.2",
@@ -8818,20 +8644,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "6.1.47",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.47.tgz",
-			"integrity": "sha512-R/K2tZ5MiY+mVrnSkNJkwqYT2vUv1lcT6wJvd2emGaMJ7PHUGRY4e3tUsdFCXgqxi2QgbHjL3yJgXCo40v9Hxw==",
+			"version": "6.1.50",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.50.tgz",
+			"integrity": "sha512-q9GOap6q3KCsLMdOjXhWU5jVZ8/1dIib898JBRLsN+tBhENpBDcAVQbE0epADOjw11FhQQy9AcbqKGBQPUfTQA==",
+			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.47"
+				"tldts-core": "^6.1.50"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.47",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.47.tgz",
-			"integrity": "sha512-6SWyFMnlst1fEt7GQVAAu16EGgFK0cLouH/2Mk6Ftlwhv3Ol40L0dlpGMcnnNiiOMyD2EV/aF3S+U2nKvvLvrA=="
+			"version": "6.1.50",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.50.tgz",
+			"integrity": "sha512-na2EcZqmdA2iV9zHV7OHQDxxdciEpxrjbkp+aHmZgnZKHzoElLajP59np5/4+sare9fQBfixgvXKx8ev1d7ytw==",
+			"license": "MIT"
 		},
 		"node_modules/to-fast-properties": {
 			"version": "2.0.0",
@@ -8896,6 +8724,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
 			"integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tldts": "^6.1.32"
 			},
@@ -8919,7 +8748,8 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
 			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-			"dev": true
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
@@ -8967,6 +8797,7 @@
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -9053,9 +8884,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
 			"dev": true,
 			"funding": [
 				{
@@ -9073,8 +8904,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"escalade": "^3.1.2",
-				"picocolors": "^1.0.1"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.0"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -9139,9 +8970,9 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -9200,6 +9031,7 @@
 			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.1.tgz",
 			"integrity": "sha512-1wWQOyR2LVVtaqrcIL2+OM+x7bkpmzVROa0Nf6FryXkS+er5Sa1kzFGjzZRqLnHa3n1rACFLeTwUqE1ETL9Mig==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.7.7",
 				"joi": "^17.13.3",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
 		"st": "^3.0.0",
 		"statuses": "2.0.1",
 		"svg-tint-stream": "1.0.1",
-		"utf8": "3.0.0",
-		"uuid": "^10.0.0"
+		"utf8": "3.0.0"
 	},
 	"devDependencies": {
 		"color-contrast": "^1.0.0",

--- a/test/integration/v2/images-raw.test.js
+++ b/test/integration/v2/images-raw.test.js
@@ -3,7 +3,7 @@
 const assert = require('proclaim');
 const axios = require('../helpers/axios');
 const testImageUris = require('../helpers/test-image-uris');
-const {v4: generateUuid} = require('uuid');
+const { randomUUID } = require('crypto');
 
 const usingExternalServer = Boolean(process.env.HOST);
 const onlyRunOnExternalServer = usingExternalServer ? describe : describe.skip;
@@ -569,7 +569,7 @@ describe('GET /__origami/service/image/v2/images/raw…', function () {
 	describe('when a CMS image is not found', function () {
 		it('responds with a 404 status', async function () {
 			const response = await axios.get(
-				`/__origami/service/image/v2/images/raw/ftcms:${generateUuid()}?source=origami-image-service`
+				`/__origami/service/image/v2/images/raw/ftcms:${randomUUID()}?source=origami-image-service`
 			);
 			assert.equal(response.status, 404);
 			assert.equal(

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('proclaim');
 const nock = require('nock');
-const {v4: generateUuid} = require('uuid');
+const { randomUUID } = require('crypto');
 
 describe('lib/middleware/get-cms-url', () => {
 	let origamiService;
@@ -39,7 +39,7 @@ describe('lib/middleware/get-cms-url', () => {
 		});
 
 		describe('middleware(request, response, next)', () => {
-      const imageUuid = generateUuid();
+      const imageUuid = randomUUID();
       let scope;
       const v2Uri = `https://prod-upp-image-read.ft.com/${imageUuid}`;
 
@@ -66,7 +66,7 @@ describe('lib/middleware/get-cms-url', () => {
       });
 
 			describe('when the v2 API cannot find the image', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				const v1Uri = `https://im.ft-static.com/content/images/${imageUuid}.img`;
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
@@ -100,7 +100,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when neither the v1 or v2 API can find the image', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
 				let nockScopeForFallback;
@@ -131,7 +131,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when neither the v1, v2 API can find the image and the original image url does not exist', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				let responseError;
 				let nockScopeForV1Images;
 				let nockScopeForV2Images;
@@ -176,7 +176,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the ftcms URL has a querystring', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				const v2Uri = `https://prod-upp-image-read.ft.com/${imageUuid}?foo=bar`;
 				let scope;
 
@@ -210,7 +210,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the request errors', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				let responseError;
 				let scope;
 
@@ -234,7 +234,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the request fails a DNS lookup', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				let dnsError;
 				let responseError;
 				let scope;
@@ -262,7 +262,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the request connection resets', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				let resetError;
 				let responseError;
 				let scope;
@@ -291,7 +291,7 @@ describe('lib/middleware/get-cms-url', () => {
 			});
 
 			describe('when the request times out', () => {
-        const imageUuid = generateUuid();
+        const imageUuid = randomUUID();
 				let responseError;
 				let timeoutError;
 				let scope;
@@ -331,13 +331,13 @@ describe('lib/middleware/get-cms-url', () => {
         
         });
         it('is a string with special character in it', () => {
-          const invalidImageUuid = generateUuid().replace(/./g, '%');
+          const invalidImageUuid = randomUUID().replace(/./g, '%');
           origamiService.mockRequest.params.imageUrl = `ftcms:${invalidImageUuid}`;
           assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), 'Image key is invalid');
         });
 
         it('has a random string after valid uuid', () => {
-          const invalidImageUuid = `${generateUuid}moreText`;
+          const invalidImageUuid = `${randomUUID}moreText`;
           origamiService.mockRequest.params.imageUrl = `ftcms:${invalidImageUuid}`;
           assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), 'Image key is invalid');
         });

--- a/test/unit/lib/middleware/get-cms-url.test.js
+++ b/test/unit/lib/middleware/get-cms-url.test.js
@@ -337,7 +337,7 @@ describe('lib/middleware/get-cms-url', () => {
         });
 
         it('has a random string after valid uuid', () => {
-          const invalidImageUuid = `${randomUUID}moreText`;
+          const invalidImageUuid = `${randomUUID()}moreText`;
           origamiService.mockRequest.params.imageUrl = `ftcms:${invalidImageUuid}`;
           assert.throws(() => middleware(origamiService.mockRequest, origamiService.mockResponse), 'Image key is invalid');
         });


### PR DESCRIPTION
**What**
- Remove `uuid` and adopt the native `crypto.randomUUID` functionality.

`How`
- Replace the validation functionality of uuid with the exact replica of it using regex.
- Use `crypto.randomUUID` to generate uuid for Test.
- Remove uuid packages.