### PR TITLE
fix: Allow SVG filters

### DIFF
--- a/lib/middleware/handle-svg.js
+++ b/lib/middleware/handle-svg.js
@@ -1,5 +1,3 @@
-
-
 const createDOMPurify = require('dompurify');
 const httpError = require('http-errors');
 const axios = require('axios').default;
@@ -97,12 +95,15 @@ function handleSvg(config = {}) {
 							if (isTrustedDestination) {
 								response.send(entireSvg);
 							} else {
-								response.send(DOMPurify.sanitize(entireSvg,{
-									FORBID_TAGS: ['a'],
-									USE_PROFILES: {
-										svg: true
-									}
-								}));
+								response.send(
+									DOMPurify.sanitize(entireSvg, {
+										FORBID_TAGS: ['a'],
+										USE_PROFILES: {
+											svg: true,
+											svgFilters: true,
+										},
+									})
+								);
 							}
 						}
 					});


### PR DESCRIPTION
To prevent anchor tags in untrusted SVG we made sanitisation more strict.
https://github.com/Financial-Times/origami-image-service/pull/974

This broke some legit SVGs by stripping filters